### PR TITLE
Phase 0: Codify Chat compatibility contract, add evented listener + migration-guard tests

### DIFF
--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -48,6 +48,7 @@ class ChatStreamListener:
         return self
 
     async def _get_responses_a(self):
+        done_event = None
         try:
             async for respo in self._response_gen:
                 # TODO: Sweet summer child, it's no longer just content that we need to check for
@@ -70,15 +71,17 @@ class ChatStreamListener:
                         else:
                             yield content if content is not None else ""
                         self._chunk_index += 1
-        finally:
-            self.is_complete = True
-            self.response = self.current_content
             if self.events:
-                yield {
+                done_event = {
                     "type": "done",
                     "index": self._chunk_index,
                     "response": self.current_content,
                 }
+        finally:
+            self.is_complete = True
+            self.response = self.current_content
+        if done_event is not None:
+            yield done_event
 
     def __aiter__(self):
         return self._get_responses_a()
@@ -92,6 +95,7 @@ class ChatStreamListener:
 
     # non-async method that returns a generator that yields the responses
     def _get_responses(self):
+        done_event = None
         try:
             for respo in self._response_gen:
                 # TODO: Sweet summer child, it's no longer just content that we need to check for
@@ -114,15 +118,17 @@ class ChatStreamListener:
                         else:
                             yield content if content is not None else ""
                         self._chunk_index += 1
-        finally:
-            self.is_complete = True
-            self.response = self.current_content
             if self.events:
-                yield {
+                done_event = {
                     "type": "done",
                     "index": self._chunk_index,
                     "response": self.current_content,
                 }
+        finally:
+            self.is_complete = True
+            self.response = self.current_content
+        if done_event is not None:
+            yield done_event
 
     # non-async
     def __iter__(self):

--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -15,7 +15,7 @@ from .mixin_params import ChatParamsMixin
 
 
 class ChatStreamListener:
-    def __init__(self, ai, prompt, **kwargs):
+    def __init__(self, ai, prompt, events=False, **kwargs):
         if isinstance(prompt, list):
             self.prompt = prompt
         else:
@@ -25,6 +25,8 @@ class ChatStreamListener:
         self.current_content = ""
         self.response = ""
         self.ai = ai
+        self.events = events
+        self._chunk_index = 0
         out = kwargs.copy()
         if "model" not in out or len(out["model"]) < 2:
             # if engine is set, use that
@@ -59,10 +61,24 @@ class ChatStreamListener:
                         content = resp['choices'][0]['delta']['content']
                         if content is not None:
                             self.current_content += content
-                        yield content if content is not None else ""
+                        if self.events:
+                            yield {
+                                "type": "text_delta",
+                                "index": self._chunk_index,
+                                "text": content if content is not None else "",
+                            }
+                        else:
+                            yield content if content is not None else ""
+                        self._chunk_index += 1
         finally:
             self.is_complete = True
             self.response = self.current_content
+            if self.events:
+                yield {
+                    "type": "done",
+                    "index": self._chunk_index,
+                    "response": self.current_content,
+                }
 
     def __aiter__(self):
         return self._get_responses_a()
@@ -89,10 +105,24 @@ class ChatStreamListener:
                         content = resp['choices'][0]['delta']['content']
                         if content is not None:
                             self.current_content += content
-                        yield content if content is not None else ""
+                        if self.events:
+                            yield {
+                                "type": "text_delta",
+                                "index": self._chunk_index,
+                                "text": content if content is not None else "",
+                            }
+                        else:
+                            yield content if content is not None else ""
+                        self._chunk_index += 1
         finally:
             self.is_complete = True
             self.response = self.current_content
+            if self.events:
+                yield {
+                    "type": "done",
+                    "index": self._chunk_index,
+                    "response": self.current_content,
+                }
 
     # non-async
     def __iter__(self):
@@ -101,6 +131,17 @@ class ChatStreamListener:
 
 
 class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
+    def _run_sync(self, coro, method_name: str):
+        try:
+            return asyncio.run(coro)
+        except RuntimeError as exc:
+            if "asyncio.run() cannot be called from a running event loop" in str(exc):
+                raise RuntimeError(
+                    f"Cannot call sync {method_name}() from an active event loop. "
+                    f"Use {method_name}_a() instead."
+                ) from None
+            raise
+
     # async method that gathers will execute an async format method on every message in the chat prompt and gather the results into a final json string
     async def _gather_format(self, format_coro, **kwargs) -> str:
         new_messages = self.get_messages()
@@ -259,7 +300,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         """
         if usermsg is not None:
             additional_vars["__user"] = usermsg
-        return asyncio.run(self.ask_a(**additional_vars))
+        return self._run_sync(self.ask_a(**additional_vars), "ask")
     async def ask_a(self, usermsg=None, **additional_vars) -> str:
         """ Executes the query as-is, async version of ask()"""
         if self.stream:
@@ -270,19 +311,20 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         # filter the response if we have a pattern
         response = self.filter_by_pattern(response)
         return response
-    def listen(self, usermsg=None, **additional_vars) -> ChatStreamListener:
+    def listen(self, usermsg=None, events=False, **additional_vars) -> ChatStreamListener:
         """
         Executes the internal chat query as-is and returns a listener object that can be iterated on for the text.
         If usermsg is passed in, it will be added as a user message to the chat before executing the query. ⭐
         """
         if usermsg is not None:
             additional_vars["__user"] = usermsg
-        _, response = asyncio.run(self._submit_for_response_and_prompt(**additional_vars))
+        _, response = self._run_sync(self._submit_for_response_and_prompt(**additional_vars), "listen")
         if self.params.stream:
             # response is a ChatStreamListener so lets start it
+            response.events = events
             response.start()
         return response
-    async def listen_a(self, usermsg=None, async_listen=True, **additional_vars) -> ChatStreamListener:
+    async def listen_a(self, usermsg=None, async_listen=True, events=False, **additional_vars) -> ChatStreamListener:
         """ Executes the query as-is, async version of listen()"""
         if not self.stream:
             raise Exception("Cannot use listen() without a stream")
@@ -291,6 +333,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         _, response = await self._submit_for_response_and_prompt(**additional_vars)
         if self.params.stream:
             # response is a ChatStreamListener so lets start it
+            response.events = events
             await response.start_a()
         return response
     def chat(self, usermsg=None, **additional_vars) -> object:
@@ -300,7 +343,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         """
         if usermsg is not None:
             additional_vars["__user"] = usermsg
-        return asyncio.run(self.chat_a(**additional_vars))
+        return self._run_sync(self.chat_a(**additional_vars), "chat")
         
     async def chat_a(self, usermsg=None, **additional_vars) -> object:
         """Executes the query as-is, and returns a ChatPrompt object that contains the response. Async version of chat()"""

--- a/docs/rfcs/phase-0-chat-compatibility-rfc.md
+++ b/docs/rfcs/phase-0-chat-compatibility-rfc.md
@@ -1,0 +1,73 @@
+# Chatsnack Phase 0 Compatibility RFC: `Chat` Public Contract
+
+## Status
+Accepted for Phase 0 guardrails.
+
+## Scope
+This RFC locks current, observable `Chat` behavior before runtime adapter and transport migration work.
+
+## Public Sync/Async Matrix
+
+| Method | Sync script usage | Sync active-loop usage | Async usage in loop | Streaming contract |
+| --- | --- | --- | --- | --- |
+| `ask()` | returns `str` through async implementation | fail fast with deterministic guidance error | use `ask_a()` | non-stream |
+| `ask_a()` | n/a | n/a | returns `str`; raises if `self.stream` is true | non-stream |
+| `chat()` | returns `Chat` through async implementation | fail fast with deterministic guidance error | use `chat_a()` | non-stream |
+| `chat_a()` | n/a | n/a | returns `Chat`; raises if `self.stream` is true | non-stream |
+| `listen()` | returns `ChatStreamListener` when stream enabled; otherwise completion payload | fail fast with deterministic guidance error | use `listen_a()` | stream-first |
+| `listen_a()` | n/a | n/a | returns `ChatStreamListener`; raises if `self.stream` is false | stream |
+
+### Active event loop behavior
+Sync wrappers (`ask`, `chat`, `listen`) are script-oriented and fail fast if called from an active event loop.
+
+Standardized error text pattern:
+- `Cannot call sync ask() from an active event loop. Use ask_a() instead.`
+- `Cannot call sync chat() from an active event loop. Use chat_a() instead.`
+- `Cannot call sync listen() from an active event loop. Use listen_a() instead.`
+
+## Listener Compatibility Contract
+
+### Legacy default mode
+- `listen()` / `listen_a()` default `events=False`.
+- Iteration yields `str` chunks.
+- `''.join(listener)` remains valid compatibility behavior.
+
+### Opt-in events mode
+- `listen(events=True)` and `listen_a(events=True)` yield structured event dictionaries.
+- Stable event ordering:
+  1. Zero or more `{"type": "text_delta", "index": <int>, "text": <str>}` events.
+  2. A terminal `{"type": "done", "index": <int>, "response": <full_text>}` event.
+
+## Observable Behavior Locked by Phase 0
+
+### Model fallback
+- Non-stream completion path (`_cleaned_chat_completion`) defaults to `gpt-3.5-turbo` if model/engine absent.
+- Stream listener constructor defaults to `chatgpt-4o-latest` if model/engine absent.
+- Parameter collection (`ChatParams._get_non_none_params`) defaults to `chatgpt-4o-latest` if unset.
+
+### Role remapping
+- `_gather_format` remaps `system` role for reasoning-model compatibility:
+  - `system -> developer` for models without system but with developer messages (e.g. `o1`).
+  - `system -> user` for models without system/developer support (`o1-preview`, `o1-mini`).
+
+### Tool recursion
+- `auto_execute=None` behaves as enabled.
+- Max recursion depth is `5`.
+- `auto_feed=None` behaves as enabled, feeding tool output back for follow-up completion.
+- `auto_feed=False` records assistant/tool interactions and stops recursion.
+- Tool-call metadata and tool messages are preserved in returned chat history.
+
+### Return shape
+- `_cleaned_chat_completion()` returns `str` when no tool calls are present.
+- `_cleaned_chat_completion()` returns a message object when tool calls are present.
+- `chat_a()` branches on this shape and preserves downstream tool-call data.
+
+## Guard Test Coverage
+Phase 0 adds migration-guard tests in `tests/mixins/` to lock:
+- sync wrapper fail-fast loop semantics,
+- async method behavior in active loops,
+- fallback model defaults,
+- role remapping behavior,
+- tool recursion `auto_execute`/`auto_feed` behavior,
+- return-shape branching,
+- listener legacy text iteration and events-mode iteration.

--- a/tests/mixins/test_chatparams.py
+++ b/tests/mixins/test_chatparams.py
@@ -96,3 +96,29 @@ def test_engines(engine):
     assert output is not None
     assert len(output) > 0
     print(output)
+
+
+def test_get_non_none_params_default_model_fallback(chat_params):
+    chat_params.model = ""
+    out = chat_params._get_non_none_params()
+    assert out["model"] == "chatgpt-4o-latest"
+
+
+@pytest.mark.asyncio
+async def test_reasoning_model_role_remap_to_developer(chat_params_mixin):
+    chat_params_mixin.model = "o1"
+    chat_params_mixin.system("You are system")
+    prompt = await chat_params_mixin._build_final_prompt()
+    import json
+    messages = json.loads(prompt)
+    assert messages[0]["role"] == "developer"
+
+
+@pytest.mark.asyncio
+async def test_o1_preview_role_remap_to_user(chat_params_mixin):
+    chat_params_mixin.model = "o1-preview"
+    chat_params_mixin.system("You are system")
+    prompt = await chat_params_mixin._build_final_prompt()
+    import json
+    messages = json.loads(prompt)
+    assert messages[0]["role"] == "user"

--- a/tests/mixins/test_query.py
+++ b/tests/mixins/test_query.py
@@ -157,3 +157,140 @@ def test_copy_chatprompt_generated_name_length():
 
 
 
+
+import asyncio
+from types import SimpleNamespace
+
+
+class _FakeMessage:
+    def __init__(self, content="hello", tool_calls=None):
+        self.content = content
+        self.tool_calls = tool_calls
+
+    def model_dump(self):
+        return {
+            "role": "assistant",
+            "content": self.content,
+            "tool_calls": self.tool_calls,
+        }
+
+
+class _FakeChoice:
+    def __init__(self, message):
+        self.message = message
+
+
+class _FakeResponse:
+    def __init__(self, message):
+        self.choices = [_FakeChoice(message)]
+
+
+class _FakeAsyncCompletions:
+    def __init__(self):
+        self.last_kwargs = None
+
+    async def create(self, messages, **kwargs):
+        self.last_kwargs = kwargs
+        return _FakeResponse(_FakeMessage(content="ok", tool_calls=None))
+
+
+@pytest.mark.asyncio
+async def test_sync_methods_fail_fast_in_active_loop(chat, monkeypatch):
+    def raise_active_loop(coro):
+        coro.close()
+        raise RuntimeError("asyncio.run() cannot be called from a running event loop")
+
+    monkeypatch.setattr("chatsnack.chat.mixin_query.asyncio.run", raise_active_loop)
+
+    with pytest.raises(RuntimeError, match=r"Cannot call sync ask\(\)"):
+        chat.ask()
+    with pytest.raises(RuntimeError, match=r"Cannot call sync chat\(\)"):
+        chat.chat()
+    with pytest.raises(RuntimeError, match=r"Cannot call sync listen\(\)"):
+        chat.listen()
+
+
+@pytest.mark.asyncio
+async def test_async_methods_work_in_active_loop(chat, monkeypatch):
+    async def fake_submit(**kwargs):
+        return "[]", "async-output"
+
+    async def fake_chat_a(self, usermsg=None, **additional_vars):
+        return Chat(name="async-chat")
+
+    monkeypatch.setattr(chat, "_submit_for_response_and_prompt", fake_submit)
+
+    assert await chat.ask_a() == "async-output"
+
+    async def fake_submit_listener(**kwargs):
+        return "[]", SimpleNamespace(start_a=lambda: asyncio.sleep(0), events=False)
+
+    chat.stream = True
+    monkeypatch.setattr(chat, "_submit_for_response_and_prompt", fake_submit_listener)
+    listener = await chat.listen_a(events=True)
+    assert listener.events is True
+
+
+@pytest.mark.asyncio
+async def test_ask_a_and_chat_a_raise_when_stream_enabled(chat):
+    chat.stream = True
+    with pytest.raises(Exception, match=r"Cannot use ask\(\) with a stream"):
+        await chat.ask_a()
+    with pytest.raises(Exception, match=r"Cannot use chat\(\) with a stream"):
+        await chat.chat_a()
+
+
+@pytest.mark.asyncio
+async def test_cleaned_chat_completion_model_fallback(chat):
+    fake_completions = _FakeAsyncCompletions()
+    chat.ai.aclient = SimpleNamespace(
+        chat=SimpleNamespace(completions=fake_completions)
+    )
+    chat.system("system")
+    await chat._cleaned_chat_completion(chat.json)
+    assert fake_completions.last_kwargs["model"] == "gpt-3.5-turbo"
+
+
+@pytest.mark.asyncio
+async def test_cleaned_chat_completion_returns_message_object_for_tool_calls(chat):
+    class ToolCompletions:
+        async def create(self, messages, **kwargs):
+            tool_calls = [SimpleNamespace(id="1", function=SimpleNamespace(name="x", arguments="{}"))]
+            return _FakeResponse(_FakeMessage(content=None, tool_calls=tool_calls))
+
+    chat.ai.aclient = SimpleNamespace(chat=SimpleNamespace(completions=ToolCompletions()))
+    response = await chat._cleaned_chat_completion("[]")
+    assert hasattr(response, "tool_calls")
+    assert response.tool_calls
+
+
+@pytest.mark.asyncio
+async def test_tool_recursion_auto_feed_false_keeps_tool_messages(chat, monkeypatch):
+    class _ToolCall:
+        def __init__(self):
+            self.id = "call_1"
+            self.function = SimpleNamespace(name="echo", arguments='{"x":1}')
+
+        def as_dict(self):
+            return {"id": self.id, "type": "function", "function": {"name": self.function.name, "arguments": self.function.arguments}}
+
+    tool_call = _ToolCall()
+
+    class _ToolMessage(_FakeMessage):
+        def model_dump(self):
+            return {"role": "assistant", "content": None, "tool_calls": [tool_call.as_dict()]}
+
+    first_response = _ToolMessage(content=None, tool_calls=[tool_call])
+
+    async def fake_submit(**kwargs):
+        return "[]", first_response
+
+    monkeypatch.setattr(chat, "_submit_for_response_and_prompt", fake_submit)
+    monkeypatch.setattr(chat, "execute_tool_call", lambda tc: {"ok": True})
+
+    chat.auto_execute = True
+    chat.auto_feed = False
+    out = await chat.chat_a()
+    messages = out.get_messages()
+    assert any(msg["role"] == "assistant" and msg.get("tool_calls") for msg in messages)
+    assert any(msg["role"] == "tool" for msg in messages)

--- a/tests/mixins/test_query_listen.py
+++ b/tests/mixins/test_query_listen.py
@@ -185,6 +185,53 @@ def test_listener_events_mode_sync():
     assert events[-1]["response"] == "AB"
 
 
+
+
+def test_listener_events_mode_sync_stops_cleanly_on_early_break():
+    ai = SimpleNamespace(
+        client=SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=lambda **kwargs: _sync_stream())
+            )
+        )
+    )
+    listener = ChatStreamListener(ai, "[]", events=True)
+    listener.start()
+
+    collected = []
+    for event in listener:
+        collected.append(event)
+        break
+
+    assert collected == [{"type": "text_delta", "index": 0, "text": "A"}]
+    assert listener.response == "A"
+    assert listener.is_complete
+
+
+@pytest.mark.asyncio
+async def test_listener_events_mode_async_stops_cleanly_on_early_break():
+    async def create(**kwargs):
+        return _async_stream()
+
+    ai = SimpleNamespace(
+        aclient=SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=create)
+            )
+        )
+    )
+    listener = ChatStreamListener(ai, "[]", events=True)
+    await listener.start_a()
+
+    collected = []
+    async for event in listener:
+        collected.append(event)
+        break
+
+    assert collected == [{"type": "text_delta", "index": 0, "text": "A"}]
+    assert listener.response == "A"
+    assert listener.is_complete
+
 @pytest.mark.asyncio
 async def test_listener_events_mode_async():
     async def create(**kwargs):

--- a/tests/mixins/test_query_listen.py
+++ b/tests/mixins/test_query_listen.py
@@ -120,3 +120,87 @@ async def test_listen_a():
 
     # assert that the output of listen is the same as the output of ask
     assert output == ask_output
+
+from types import SimpleNamespace
+
+
+class _FakeStreamChunk:
+    def __init__(self, content=None, finish_reason=None):
+        self._content = content
+        self._finish_reason = finish_reason
+
+    def model_dump(self):
+        return {
+            "choices": [
+                {
+                    "finish_reason": self._finish_reason,
+                    "delta": {"content": self._content},
+                }
+            ]
+        }
+
+
+def _sync_stream():
+    yield _FakeStreamChunk("A")
+    yield _FakeStreamChunk("B")
+    yield _FakeStreamChunk(None, finish_reason="stop")
+
+
+async def _async_stream():
+    yield _FakeStreamChunk("A")
+    yield _FakeStreamChunk("B")
+    yield _FakeStreamChunk(None, finish_reason="stop")
+
+
+def test_listener_default_legacy_text_mode():
+    ai = SimpleNamespace(
+        client=SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=lambda **kwargs: _sync_stream())
+            )
+        )
+    )
+    listener = ChatStreamListener(ai, "[]")
+    listener.start()
+    chunks = list(listener)
+    assert chunks == ["A", "B", ""]
+    assert "".join(chunks) == "AB"
+
+
+def test_listener_events_mode_sync():
+    ai = SimpleNamespace(
+        client=SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=lambda **kwargs: _sync_stream())
+            )
+        )
+    )
+    listener = ChatStreamListener(ai, "[]", events=True)
+    listener.start()
+    events = list(listener)
+    assert events[0]["type"] == "text_delta"
+    assert events[0]["text"] == "A"
+    assert events[1]["text"] == "B"
+    assert events[-1]["type"] == "done"
+    assert events[-1]["response"] == "AB"
+
+
+@pytest.mark.asyncio
+async def test_listener_events_mode_async():
+    async def create(**kwargs):
+        return _async_stream()
+
+    ai = SimpleNamespace(
+        aclient=SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=create)
+            )
+        )
+    )
+    listener = ChatStreamListener(ai, "[]", events=True)
+    await listener.start_a()
+    events = []
+    async for event in listener:
+        events.append(event)
+    assert [e["type"] for e in events] == ["text_delta", "text_delta", "text_delta", "done"]
+    assert events[-1]["response"] == "AB"


### PR DESCRIPTION
### Motivation
- Lock down the current public `Chat` contract and observable quirks before introducing a `RuntimeAdapter` or changing transports. 
- Provide deterministic behavior for sync wrappers when called from active event loops and preserve legacy listener iteration semantics while offering an opt-in structured event mode.

### Description
- Add Phase 0 compatibility RFC at `docs/rfcs/phase-0-chat-compatibility-rfc.md` documenting sync/async matrix, listener contract, model fallback, role remapping, tool recursion, and return-shape guarantees. 
- Extend `ChatStreamListener` in `chatsnack/chat/mixin_query.py` with an `events` flag and chunk `index` tracking, yielding either legacy `str` deltas or structured events of shape `{"type":"text_delta","index":<int>,"text":<str>}` and a terminal `{"type":"done","index":<int>,"response":<full_text>}`. 
- Introduce `_run_sync()` in `ChatQueryMixin` to wrap `asyncio.run(...)` and convert active-loop `asyncio.run()` errors into deterministic guidance errors like `Cannot call sync ask() from an active event loop. Use ask_a() instead.`. 
- Update sync wrappers (`ask`, `chat`, `listen`) to use `_run_sync()` and add `events` argument to `listen`/`listen_a()` to opt into event-mode. 
- Add migration-guard tests under `tests/mixins/` to lock behaviors: sync/async wrapper semantics, listener legacy/event iteration (sync + async), model fallback, role remapping, tool-call return-shape, and tool recursion with `auto_feed=False`.

### Testing
- Ran focused mixin tests for sync/async and tool behavior with `PYTHONPATH=. pytest -q tests/mixins/test_query.py -k 'sync_methods_fail_fast_in_active_loop or async_methods_work_in_active_loop or ask_a_and_chat_a_raise_when_stream_enabled or cleaned_chat_completion_model_fallback or cleaned_chat_completion_returns_message_object_for_tool_calls or tool_recursion_auto_feed_false_keeps_tool_messages'` which completed `6 passed, 13 deselected`.
- Ran listener tests with `PYTHONPATH=. pytest -q tests/mixins/test_query_listen.py -k 'listener_default_legacy_text_mode or listener_events_mode_sync or listener_events_mode_async'` which completed `3 passed, 4 deselected`.
- Ran chat-params tests with `PYTHONPATH=. pytest -q tests/mixins/test_chatparams.py -k 'get_non_none_params_default_model_fallback or reasoning_model_role_remap_to_developer or o1_preview_role_remap_to_user'` which completed `3 passed, 22 deselected`.
- Verified byte-compile of modified files with `python -m py_compile chatsnack/chat/mixin_query.py tests/mixins/test_query.py tests/mixins/test_query_listen.py tests/mixins/test_chatparams.py` which succeeded.
- Note: an initial broad test run encountered environment/network-related failures when tests triggered real API calls; tests were then scoped/mocked so the new guard tests run deterministically and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0b193118483318eab61b41f0ecf4b)