### PR TITLE
Centralize model fallback (gpt-5-chat-latest) and tighten listen() compatibility with tests

### DIFF
--- a/chatsnack/chat/mixin_params.py
+++ b/chatsnack/chat/mixin_params.py
@@ -4,6 +4,9 @@ from typing import Optional, List, Dict, Any, Union, Literal
 from dataclasses import dataclass, field
 from datafiles import datafile
 
+
+DEFAULT_MODEL_FALLBACK = "gpt-5-chat-latest"
+
 @datafile
 class ParameterProperty:
     """Represents a property in the parameters schema"""
@@ -330,7 +333,7 @@ class ChatParams:
             if "engine" in out:  
                 out["model"] = out["engine"]
             else:
-                out["model"] = "gpt-5-chat-latest"
+                out["model"] = DEFAULT_MODEL_FALLBACK
 
         # engine is deprecated; remove it from the final dict
         if "engine" in out:

--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -11,7 +11,7 @@ from ..asynchelpers import aformatter
 from ..fillings import filling_machine
 
 from .mixin_messages import ChatMessagesMixin
-from .mixin_params import ChatParamsMixin
+from .mixin_params import ChatParamsMixin, DEFAULT_MODEL_FALLBACK
 
 
 class ChatStreamListener:
@@ -35,7 +35,7 @@ class ChatStreamListener:
                 # remove engine for newest models as of Nov 13 2023
                 del out["engine"]
             else:
-                out["model"] = "gpt-5-chat-latest"
+                out["model"] = DEFAULT_MODEL_FALLBACK
         self.kwargs = out
 
 
@@ -229,7 +229,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
                 # remove engine from kwargs
                 del kwargs["engine"]
             else:
-                kwargs["model"] = "gpt-3.5-turbo"
+                kwargs["model"] = DEFAULT_MODEL_FALLBACK
         if isinstance(prompt, list):
             messages = prompt
         else:

--- a/docs/rfcs/phase-0-chat-compatibility-rfc.md
+++ b/docs/rfcs/phase-0-chat-compatibility-rfc.md
@@ -14,7 +14,7 @@ This RFC locks current, observable `Chat` behavior before runtime adapter and tr
 | `ask_a()` | n/a | n/a | returns `str`; raises if `self.stream` is true | non-stream |
 | `chat()` | returns `Chat` through async implementation | fail fast with deterministic guidance error | use `chat_a()` | non-stream |
 | `chat_a()` | n/a | n/a | returns `Chat`; raises if `self.stream` is true | non-stream |
-| `listen()` | returns `ChatStreamListener` when stream enabled; otherwise completion payload | fail fast with deterministic guidance error | use `listen_a()` | stream-first |
+| `listen()` | returns `ChatStreamListener` when stream enabled; otherwise plain completion `str` payload | fail fast with deterministic guidance error | use `listen_a()` | stream-first |
 | `listen_a()` | n/a | n/a | returns `ChatStreamListener`; raises if `self.stream` is false | stream |
 
 ### Active event loop behavior
@@ -38,12 +38,20 @@ Standardized error text pattern:
   1. Zero or more `{"type": "text_delta", "index": <int>, "text": <str>}` events.
   2. A terminal `{"type": "done", "index": <int>, "response": <full_text>}` event.
 
+### Non-stream `listen()` compatibility
+- When `self.stream` is disabled, `listen()` returns the same plain `str` completion payload contract as `ask()`.
+- In this mode, `events` is ignored and no listener/event metadata is returned.
+- Stability guarantee for Phase 1: callers can treat non-stream `listen()` as an alias for non-stream completion retrieval.
+
+## Phase 1 Baseline Freeze
+The compatibility behaviors in this RFC are frozen as the authoritative baseline for Phase 1 adapter work. Any behavior changes after this point require an RFC update plus guard-test updates in `tests/mixins/`.
+
 ## Observable Behavior Locked by Phase 0
 
 ### Model fallback
-- Non-stream completion path (`_cleaned_chat_completion`) defaults to `gpt-3.5-turbo` if model/engine absent.
-- Stream listener constructor defaults to `chatgpt-4o-latest` if model/engine absent.
-- Parameter collection (`ChatParams._get_non_none_params`) defaults to `chatgpt-4o-latest` if unset.
+- Non-stream completion path (`_cleaned_chat_completion`) defaults to `gpt-5-chat-latest` if model/engine absent.
+- Stream listener constructor defaults to `gpt-5-chat-latest` if model/engine absent.
+- Parameter collection (`ChatParams._get_non_none_params`) defaults to `gpt-5-chat-latest` if unset.
 
 ### Role remapping
 - `_gather_format` remaps `system` role for reasoning-model compatibility:

--- a/tests/mixins/test_chatparams.py
+++ b/tests/mixins/test_chatparams.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from chatsnack.packs import Jane
+from chatsnack.chat.mixin_params import DEFAULT_MODEL_FALLBACK
 from chatsnack import Chat, ChatParams
 
 @pytest.fixture
@@ -101,7 +102,7 @@ def test_engines(engine):
 def test_get_non_none_params_default_model_fallback(chat_params):
     chat_params.model = ""
     out = chat_params._get_non_none_params()
-    assert out["model"] == "chatgpt-4o-latest"
+    assert out["model"] == DEFAULT_MODEL_FALLBACK
 
 
 @pytest.mark.asyncio

--- a/tests/mixins/test_query.py
+++ b/tests/mixins/test_query.py
@@ -1,5 +1,6 @@
 import pytest
 from chatsnack import Chat, Text, CHATSNACK_BASE_DIR
+from chatsnack.chat.mixin_params import DEFAULT_MODEL_FALLBACK
 
 import os
 import shutil
@@ -248,7 +249,7 @@ async def test_cleaned_chat_completion_model_fallback(chat):
     )
     chat.system("system")
     await chat._cleaned_chat_completion(chat.json)
-    assert fake_completions.last_kwargs["model"] == "gpt-3.5-turbo"
+    assert fake_completions.last_kwargs["model"] == DEFAULT_MODEL_FALLBACK
 
 
 @pytest.mark.asyncio
@@ -294,3 +295,24 @@ async def test_tool_recursion_auto_feed_false_keeps_tool_messages(chat, monkeypa
     messages = out.get_messages()
     assert any(msg["role"] == "assistant" and msg.get("tool_calls") for msg in messages)
     assert any(msg["role"] == "tool" for msg in messages)
+
+
+def test_listen_returns_plain_str_payload_when_stream_disabled(chat, monkeypatch):
+    async def fake_submit(**kwargs):
+        return "[]", "plain-completion"
+
+    chat.stream = False
+    monkeypatch.setattr(chat, "_submit_for_response_and_prompt", fake_submit)
+
+    response = chat.listen(events=True)
+
+    assert response == "plain-completion"
+    assert isinstance(response, str)
+    assert not hasattr(response, "events")
+
+
+@pytest.mark.asyncio
+async def test_listen_a_raises_when_stream_disabled(chat):
+    chat.stream = False
+    with pytest.raises(Exception, match=r"Cannot use listen\(\) without a stream"):
+        await chat.listen_a(events=True)


### PR DESCRIPTION
### Motivation
- Centralize the fallback model name to make future default updates consistent across the codebase and make the default model newer (`gpt-5-chat-latest`).
- Replace scattered hardcoded model fallback strings with a single constant to reduce duplication and risk of drift.
- Clarify and lock non-stream `listen()` behavior in the RFC and add tests to assert listener behavior when streaming is disabled.

### Description
- Added a `DEFAULT_MODEL_FALLBACK` constant set to `gpt-5-chat-latest` in `chatsnack/chat/mixin_params.py` and used it wherever a missing `model`/`engine` previously fell back to a hardcoded string. 
- Updated `ChatParams._get_non_none_params`, `ChatStreamListener` (in `mixin_query.py`), and `_cleaned_chat_completion` to use the new `DEFAULT_MODEL_FALLBACK` constant instead of literal strings.
- Updated the Phase 0 compatibility RFC (`docs/rfcs/phase-0-chat-compatibility-rfc.md`) to reflect the new default model and to explicitly document non-stream `listen()` compatibility behavior.
- Updated and extended tests to reference `DEFAULT_MODEL_FALLBACK`, changed expectations to the new fallback, and added tests asserting `listen()` returns a plain `str` when `stream` is disabled and that `listen_a()` raises when called without a stream.

### Testing
- Ran the modified test module `tests/mixins/test_chatparams.py` including `test_get_non_none_params_default_model_fallback`, and it passed. 
- Ran `tests/mixins/test_query.py` including `test_cleaned_chat_completion_model_fallback`, the new `test_listen_returns_plain_str_payload_when_stream_disabled`, and `test_listen_a_raises_when_stream_disabled`, and they passed. 
- Ran `pytest tests/mixins` to validate mixin behavior regressions, and the suite passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b197f866208331ba657a5fa0bb564c)