### PR TITLE
Introduce runtime adapter boundary with ChatCompletionsAdapter and v1 stream events

### DIFF
--- a/chatsnack/chat/__init__.py
+++ b/chatsnack/chat/__init__.py
@@ -8,6 +8,7 @@ from datafiles import datafile
 
 from ..aiclient import AiClient
 from ..defaults import CHATSNACK_BASE_DIR
+from ..runtime import ChatCompletionsAdapter
 from .mixin_query import ChatQueryMixin
 from .mixin_params import ChatParams, ChatParamsMixin
 from .mixin_serialization import DatafileMixin, ChatSerializationMixin
@@ -142,6 +143,7 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
         self._initial_registry = getattr(self, '_local_registry', None)
 
         self.ai = AiClient()
+        self.runtime = ChatCompletionsAdapter(self.ai)
 
 
    

--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -9,13 +9,14 @@ from datafiles import datafile
 
 from ..asynchelpers import aformatter
 from ..fillings import filling_machine
+from ..runtime import EVENT_SCHEMA_VERSION
 
 from .mixin_messages import ChatMessagesMixin
 from .mixin_params import ChatParamsMixin, DEFAULT_MODEL_FALLBACK
 
 
 class ChatStreamListener:
-    def __init__(self, ai, prompt, events=False, **kwargs):
+    def __init__(self, ai, prompt, events=False, event_schema="legacy", runtime=None, **kwargs):
         if isinstance(prompt, list):
             self.prompt = prompt
         else:
@@ -25,36 +26,108 @@ class ChatStreamListener:
         self.current_content = ""
         self.response = ""
         self.ai = ai
+        self.runtime = runtime
         self.events = events
+        self.event_schema = event_schema
         self._chunk_index = 0
         out = kwargs.copy()
         if "model" not in out or len(out["model"]) < 2:
-            # if engine is set, use that
             if "engine" in out:
                 out["model"] = out["engine"]
-                # remove engine for newest models as of Nov 13 2023
                 del out["engine"]
             else:
                 out["model"] = DEFAULT_MODEL_FALLBACK
         self.kwargs = out
 
+    def _event_from_runtime(self, event):
+        if self.events:
+            if self.event_schema == "v1":
+                return {
+                    "schema_version": event.schema_version,
+                    "type": event.type,
+                    "index": event.index,
+                    "data": event.data,
+                }
+
+            if event.type == "text_delta":
+                return {
+                    "type": "text_delta",
+                    "index": event.index,
+                    "text": event.data.get("text", ""),
+                }
+            if event.type == "completed":
+                terminal = event.data.get("terminal", {})
+                return {
+                    "type": "done",
+                    "index": event.index,
+                    "response": terminal.get("response_text", self.current_content),
+                }
+            if event.type == "error":
+                return {
+                    "type": "error",
+                    "index": event.index,
+                    "error": event.data.get("error", {}),
+                }
+            return None
+        if event.type == "text_delta":
+            return event.data.get("text", "")
+        return None
+
+    def _format_text_event(self, text: str):
+        if self.event_schema == "v1":
+            return {
+                "schema_version": EVENT_SCHEMA_VERSION,
+                "type": "text_delta",
+                "index": self._chunk_index,
+                "data": {"text": text},
+            }
+        return {
+            "type": "text_delta",
+            "index": self._chunk_index,
+            "text": text,
+        }
+
+    def _format_done_event(self):
+        if self.event_schema == "v1":
+            return {
+                "schema_version": EVENT_SCHEMA_VERSION,
+                "type": "completed",
+                "index": self._chunk_index,
+                "data": {"terminal": {"response_text": self.current_content}},
+            }
+        return {
+            "type": "done",
+            "index": self._chunk_index,
+            "response": self.current_content,
+        }
 
     async def start_a(self):
-        # if stream=True isn't in the kwargs, add it
+        if self.runtime is not None:
+            self._response_gen = self.runtime.stream_completion_a(self.prompt, **self.kwargs)
+            return self
         if not self.kwargs.get('stream', False):
             self.kwargs['stream'] = True
-        #self._response_gen = await _chatcompletion(self.prompt,  **self.kwargs)
         self._response_gen = await self.ai.aclient.chat.completions.create(messages=self.prompt,**self.kwargs)
         return self
 
     async def _get_responses_a(self):
-        done_event = None
         try:
-            async for respo in self._response_gen:
-                # TODO: Sweet summer child, it's no longer just content that we need to check for
-                #       but also slowly filling function call arguments for tool_calls. 
-                #       See: https://community.openai.com/t/functions-calling-with-streaming/305742
-                resp = respo.model_dump()
+            async for event in self._response_gen:
+                if self.runtime is not None:
+                    if event.type == "text_delta":
+                        self.current_content += event.data.get("text", "")
+                    elif event.type == "completed":
+                        terminal = event.data.get("terminal", {})
+                        self.current_content = terminal.get("response_text", self.current_content)
+                        self.is_complete = True
+                    elif event.type == "error":
+                        self.is_complete = True
+                    rendered = self._event_from_runtime(event)
+                    if rendered is not None:
+                        yield rendered
+                    continue
+
+                resp = event.model_dump()
                 if "choices" in resp:
                     if resp['choices'][0]['finish_reason'] is not None:
                         self.is_complete = True
@@ -63,45 +136,46 @@ class ChatStreamListener:
                         if content is not None:
                             self.current_content += content
                         if self.events:
-                            yield {
-                                "type": "text_delta",
-                                "index": self._chunk_index,
-                                "text": content if content is not None else "",
-                            }
+                            yield self._format_text_event(content if content is not None else "")
                         else:
                             yield content if content is not None else ""
                         self._chunk_index += 1
-            if self.events:
-                done_event = {
-                    "type": "done",
-                    "index": self._chunk_index,
-                    "response": self.current_content,
-                }
+            if self.events and self.runtime is None:
+                yield self._format_done_event()
         finally:
             self.is_complete = True
             self.response = self.current_content
-        if done_event is not None:
-            yield done_event
 
     def __aiter__(self):
         return self._get_responses_a()
 
     def start(self):
-        # if stream=True isn't in the kwargs, add it
+        if self.runtime is not None:
+            self._response_gen = self.runtime.stream_completion(self.prompt, **self.kwargs)
+            return self
         if not self.kwargs.get('stream', False):
-            self.kwargs['stream'] = True        
+            self.kwargs['stream'] = True
         self._response_gen = self.ai.client.chat.completions.create(messages=self.prompt,**self.kwargs)
         return self
 
-    # non-async method that returns a generator that yields the responses
     def _get_responses(self):
-        done_event = None
         try:
-            for respo in self._response_gen:
-                # TODO: Sweet summer child, it's no longer just content that we need to check for
-                #       but also slowly filling function call arguments for tool_calls. 
-                #       See: https://community.openai.com/t/functions-calling-with-streaming/305742
-                resp = respo.model_dump()
+            for event in self._response_gen:
+                if self.runtime is not None:
+                    if event.type == "text_delta":
+                        self.current_content += event.data.get("text", "")
+                    elif event.type == "completed":
+                        terminal = event.data.get("terminal", {})
+                        self.current_content = terminal.get("response_text", self.current_content)
+                        self.is_complete = True
+                    elif event.type == "error":
+                        self.is_complete = True
+                    rendered = self._event_from_runtime(event)
+                    if rendered is not None:
+                        yield rendered
+                    continue
+
+                resp = event.model_dump()
                 if "choices" in resp:
                     if resp['choices'][0]['finish_reason'] is not None:
                         self.is_complete = True
@@ -110,30 +184,18 @@ class ChatStreamListener:
                         if content is not None:
                             self.current_content += content
                         if self.events:
-                            yield {
-                                "type": "text_delta",
-                                "index": self._chunk_index,
-                                "text": content if content is not None else "",
-                            }
+                            yield self._format_text_event(content if content is not None else "")
                         else:
                             yield content if content is not None else ""
                         self._chunk_index += 1
-            if self.events:
-                done_event = {
-                    "type": "done",
-                    "index": self._chunk_index,
-                    "response": self.current_content,
-                }
+            if self.events and self.runtime is None:
+                yield self._format_done_event()
         finally:
             self.is_complete = True
             self.response = self.current_content
-        if done_event is not None:
-            yield done_event
 
-    # non-async
     def __iter__(self):
         return self._get_responses()
-
 
 
 class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
@@ -215,7 +277,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         
         if hasattr(self, 'params') and self.params and self.params.stream:
             # we're streaming so we need to use the wrapper object
-            listener = ChatStreamListener(self.ai, prompt, **kwargs)
+            listener = ChatStreamListener(self.ai, prompt, runtime=getattr(self, "runtime", None), **kwargs)
             return prompt, listener
         else:
             return prompt, await self._cleaned_chat_completion(prompt, **kwargs)
@@ -235,43 +297,45 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         else:
             messages = json.loads(prompt)            
 
-        response = await self.ai.aclient.chat.completions.create(
-            messages=messages,
-            **kwargs
-        )
+        adapter = getattr(self, "runtime", None)
+        if adapter is not None:
+            normalized = await adapter.create_completion_a(messages=messages, **kwargs)
+            response = normalized
+        else:
+            response = await self.ai.aclient.chat.completions.create(
+                messages=messages,
+                **kwargs
+            )
         # trace log for the messages and the kwargs
         logger.trace("Messages: {messages}", messages=messages)
         logger.trace("Kwargs: {kwargs}", kwargs=
                      {k: v for k, v in kwargs.items() if k != 'stream'})
 
+        if adapter is not None:
+            message = response.message
+            logger.trace("Response content: {content}", content=message.content)
+            has_tool_calls = bool(message.tool_calls)
+            if has_tool_calls:
+                logger.debug("Tool calls detected in response: {num_calls}", num_calls=len(message.tool_calls))
+                return message
+            return message.content
+
         # trace log of the message content, if it exists
         if hasattr(response, "choices") and len(response.choices) > 0:
             if hasattr(response.choices[0], "message") and hasattr(response.choices[0].message, "content"):
-                # format string clarifying what this is
                 logger.trace("Response content: {content}", content=response.choices[0].message.content)
-                # log the entire base response object in pprint
                 import pprint
                 logger.trace(pprint.pformat(response))
-                
             else:
-                # mention there was no message for the prompt var (first 15 chars)
-                logger.warning("No response content for prompt: {prompt}", prompt=prompt[:15]) 
+                logger.warning("No response content for prompt: {prompt}", prompt=prompt[:15])
         else:
-            # mention there was no response for the prompt var
             logger.warning("Response content: No response for prompt: {prompt}", prompt=prompt[:15])
 
-        # Check if we have tool calls and record them for later use
-        has_tool_calls = (hasattr(response.choices[0].message, "tool_calls") and 
-                          response.choices[0].message.tool_calls)
-        
-        # Return the full message object if it contains tool calls
-        # This preserves the tool_calls field for proper handling in chat_a
+        has_tool_calls = (hasattr(response.choices[0].message, "tool_calls") and response.choices[0].message.tool_calls)
         if has_tool_calls:
-            logger.debug("Tool calls detected in response: {num_calls}", 
-                        num_calls=len(response.choices[0].message.tool_calls))
+            logger.debug("Tool calls detected in response: {num_calls}", num_calls=len(response.choices[0].message.tool_calls))
             return response.choices[0].message
-        
-        # Otherwise just return the content as before
+
         return response.choices[0].message.content
 
     @property
@@ -317,7 +381,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         # filter the response if we have a pattern
         response = self.filter_by_pattern(response)
         return response
-    def listen(self, usermsg=None, events=False, **additional_vars) -> ChatStreamListener:
+    def listen(self, usermsg=None, events=False, event_schema="legacy", **additional_vars) -> ChatStreamListener:
         """
         Executes the internal chat query as-is and returns a listener object that can be iterated on for the text.
         If usermsg is passed in, it will be added as a user message to the chat before executing the query. ⭐
@@ -328,9 +392,10 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         if self.params.stream:
             # response is a ChatStreamListener so lets start it
             response.events = events
+            response.event_schema = event_schema
             response.start()
         return response
-    async def listen_a(self, usermsg=None, async_listen=True, events=False, **additional_vars) -> ChatStreamListener:
+    async def listen_a(self, usermsg=None, async_listen=True, events=False, event_schema="legacy", **additional_vars) -> ChatStreamListener:
         """ Executes the query as-is, async version of listen()"""
         if not self.stream:
             raise Exception("Cannot use listen() without a stream")
@@ -340,6 +405,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         if self.params.stream:
             # response is a ChatStreamListener so lets start it
             response.events = events
+            response.event_schema = event_schema
             await response.start_a()
         return response
     def chat(self, usermsg=None, **additional_vars) -> object:
@@ -394,7 +460,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
                              num_calls=len(response.tool_calls))
                 
             # Add the assistant response with tool calls
-            msg = response.model_dump()
+            msg = response.model_dump() if hasattr(response, "model_dump") else {"role": "assistant", "content": response.content, "tool_calls": [{"id": tc.id, "type": tc.type, "function": {"name": tc.function.name if tc.function else "", "arguments": tc.function.arguments if tc.function else ""}} for tc in response.tool_calls]}
             new_chatprompt = new_chatprompt.assistant(msg)
             logger.debug(f"Tool calls in response: {response.tool_calls}")
             
@@ -458,7 +524,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
                             
                             if has_tool_calls:
                                 # More tool calls - add to chat and continue loop
-                                msg = follow_up.model_dump()
+                                msg = follow_up.model_dump() if hasattr(follow_up, "model_dump") else {"role": "assistant", "content": follow_up.content, "tool_calls": [{"id": tc.id, "type": tc.type, "function": {"name": tc.function.name if tc.function else "", "arguments": tc.function.arguments if tc.function else ""}} for tc in follow_up.tool_calls]}
                                 current_chat = current_chat.assistant(msg)
                                 logger.debug(f"Tool calls in follow-up response: {follow_up.tool_calls}")
                                 response = follow_up  # Update for next iteration

--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -199,6 +199,31 @@ class ChatStreamListener:
 
 
 class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
+    @staticmethod
+    def _tool_response_to_dict(response) -> dict:
+        """Convert a response message with tool calls to a plain dictionary.
+
+        Uses ``model_dump()`` when available (e.g. Pydantic models), and falls
+        back to a manual construction otherwise.
+        """
+        if hasattr(response, "model_dump"):
+            return response.model_dump()
+        return {
+            "role": "assistant",
+            "content": response.content,
+            "tool_calls": [
+                {
+                    "id": tc.id,
+                    "type": tc.type,
+                    "function": {
+                        "name": tc.function.name if tc.function else "",
+                        "arguments": tc.function.arguments if tc.function else "",
+                    },
+                }
+                for tc in response.tool_calls
+            ],
+        }
+
     def _run_sync(self, coro, method_name: str):
         try:
             return asyncio.run(coro)
@@ -460,7 +485,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
                              num_calls=len(response.tool_calls))
                 
             # Add the assistant response with tool calls
-            msg = response.model_dump() if hasattr(response, "model_dump") else {"role": "assistant", "content": response.content, "tool_calls": [{"id": tc.id, "type": tc.type, "function": {"name": tc.function.name if tc.function else "", "arguments": tc.function.arguments if tc.function else ""}} for tc in response.tool_calls]}
+            msg = self._tool_response_to_dict(response)
             new_chatprompt = new_chatprompt.assistant(msg)
             logger.debug(f"Tool calls in response: {response.tool_calls}")
             
@@ -524,7 +549,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
                             
                             if has_tool_calls:
                                 # More tool calls - add to chat and continue loop
-                                msg = follow_up.model_dump() if hasattr(follow_up, "model_dump") else {"role": "assistant", "content": follow_up.content, "tool_calls": [{"id": tc.id, "type": tc.type, "function": {"name": tc.function.name if tc.function else "", "arguments": tc.function.arguments if tc.function else ""}} for tc in follow_up.tool_calls]}
+                                msg = self._tool_response_to_dict(follow_up)
                                 current_chat = current_chat.assistant(msg)
                                 logger.debug(f"Tool calls in follow-up response: {follow_up.tool_calls}")
                                 response = follow_up  # Update for next iteration

--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -73,6 +73,15 @@ class ChatStreamListener:
             return event.data.get("text", "")
         return None
 
+    @staticmethod
+    def _runtime_error_message(event):
+        error = event.data.get("error", {}) if isinstance(event.data, dict) else {}
+        if isinstance(error, dict):
+            message = error.get("message")
+            if message:
+                return message
+        return "Runtime stream emitted an error event"
+
     def _format_text_event(self, text: str):
         if self.event_schema == "v1":
             return {
@@ -122,6 +131,8 @@ class ChatStreamListener:
                         self.is_complete = True
                     elif event.type == "error":
                         self.is_complete = True
+                        if not self.events:
+                            raise RuntimeError(self._runtime_error_message(event))
                     rendered = self._event_from_runtime(event)
                     if rendered is not None:
                         yield rendered
@@ -170,6 +181,8 @@ class ChatStreamListener:
                         self.is_complete = True
                     elif event.type == "error":
                         self.is_complete = True
+                        if not self.events:
+                            raise RuntimeError(self._runtime_error_message(event))
                     rendered = self._event_from_runtime(event)
                     if rendered is not None:
                         yield rendered

--- a/chatsnack/runtime/__init__.py
+++ b/chatsnack/runtime/__init__.py
@@ -1,0 +1,27 @@
+from .types import (
+    EVENT_SCHEMA_VERSION,
+    RESERVED_EVENT_TYPES,
+    NormalizedAssistantMessage,
+    NormalizedCompletionResult,
+    NormalizedToolCall,
+    NormalizedToolFunction,
+    RuntimeAdapter,
+    RuntimeErrorPayload,
+    RuntimeStreamEvent,
+    RuntimeTerminalMetadata,
+)
+from .chat_completions_adapter import ChatCompletionsAdapter
+
+__all__ = [
+    "EVENT_SCHEMA_VERSION",
+    "RESERVED_EVENT_TYPES",
+    "RuntimeAdapter",
+    "NormalizedCompletionResult",
+    "NormalizedAssistantMessage",
+    "NormalizedToolCall",
+    "NormalizedToolFunction",
+    "RuntimeStreamEvent",
+    "RuntimeTerminalMetadata",
+    "RuntimeErrorPayload",
+    "ChatCompletionsAdapter",
+]

--- a/chatsnack/runtime/chat_completions_adapter.py
+++ b/chatsnack/runtime/chat_completions_adapter.py
@@ -23,17 +23,20 @@ class ChatCompletionsAdapter:
             return obj
         if hasattr(obj, "model_dump"):
             return obj.model_dump()
+        if hasattr(obj, "__dict__"):
+            return vars(obj)
         return dict(obj)
 
     def _normalize_message(self, message: Any) -> NormalizedAssistantMessage:
         message_dict = self._to_dict(message)
         tool_calls = []
         for tc in message_dict.get("tool_calls") or []:
-            function = tc.get("function") or {}
+            tc_dict = self._to_dict(tc)
+            function = self._to_dict(tc_dict.get("function") or {})
             tool_calls.append(
                 NormalizedToolCall(
-                    id=tc.get("id", ""),
-                    type=tc.get("type", "function"),
+                    id=tc_dict.get("id", ""),
+                    type=tc_dict.get("type", "function"),
                     function=NormalizedToolFunction(
                         name=function.get("name", ""),
                         arguments=function.get("arguments", ""),
@@ -48,8 +51,9 @@ class ChatCompletionsAdapter:
 
     def _normalize_completion(self, response: Any) -> NormalizedCompletionResult:
         response_dict = self._to_dict(response)
-        choice = (response_dict.get("choices") or [{}])[0]
-        message = self._normalize_message(choice.get("message", {}))
+        raw_choices = response_dict.get("choices") or [{}]
+        choice = self._to_dict(raw_choices[0]) if raw_choices else {}
+        message = self._normalize_message(choice.get("message") or {})
         return NormalizedCompletionResult(
             message=message,
             finish_reason=choice.get("finish_reason"),
@@ -77,8 +81,9 @@ class ChatCompletionsAdapter:
     def _normalize_chunk_to_events(self, chunk: Any, index: int):
         events = []
         chunk_dict = self._to_dict(chunk)
-        choice = (chunk_dict.get("choices") or [{}])[0]
-        delta = choice.get("delta") or {}
+        raw_choices = chunk_dict.get("choices") or [{}]
+        choice = self._to_dict(raw_choices[0]) if raw_choices else {}
+        delta = self._to_dict(choice.get("delta") or {})
 
         content = delta.get("content")
         if content is not None:

--- a/chatsnack/runtime/chat_completions_adapter.py
+++ b/chatsnack/runtime/chat_completions_adapter.py
@@ -1,0 +1,150 @@
+from typing import Any, Dict, List, Optional
+
+from .types import (
+    NormalizedAssistantMessage,
+    NormalizedCompletionResult,
+    NormalizedToolCall,
+    NormalizedToolFunction,
+    RuntimeErrorPayload,
+    RuntimeStreamEvent,
+    RuntimeTerminalMetadata,
+)
+
+
+class ChatCompletionsAdapter:
+    def __init__(self, ai_client):
+        self.ai_client = ai_client
+
+    @staticmethod
+    def _to_dict(obj: Any) -> Dict[str, Any]:
+        if obj is None:
+            return {}
+        if isinstance(obj, dict):
+            return obj
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return dict(obj)
+
+    def _normalize_message(self, message: Any) -> NormalizedAssistantMessage:
+        message_dict = self._to_dict(message)
+        tool_calls = []
+        for tc in message_dict.get("tool_calls") or []:
+            function = tc.get("function") or {}
+            tool_calls.append(
+                NormalizedToolCall(
+                    id=tc.get("id", ""),
+                    type=tc.get("type", "function"),
+                    function=NormalizedToolFunction(
+                        name=function.get("name", ""),
+                        arguments=function.get("arguments", ""),
+                    ),
+                )
+            )
+        return NormalizedAssistantMessage(
+            role=message_dict.get("role", "assistant"),
+            content=message_dict.get("content"),
+            tool_calls=tool_calls,
+        )
+
+    def _normalize_completion(self, response: Any) -> NormalizedCompletionResult:
+        response_dict = self._to_dict(response)
+        choice = (response_dict.get("choices") or [{}])[0]
+        message = self._normalize_message(choice.get("message", {}))
+        return NormalizedCompletionResult(
+            message=message,
+            finish_reason=choice.get("finish_reason"),
+            model=response_dict.get("model"),
+            usage=response_dict.get("usage"),
+        )
+
+    def create_completion(self, messages: List[Dict[str, Any]], **kwargs: Any) -> NormalizedCompletionResult:
+        response = self.ai_client.client.chat.completions.create(messages=messages, **kwargs)
+        return self._normalize_completion(response)
+
+    async def create_completion_a(self, messages: List[Dict[str, Any]], **kwargs: Any) -> NormalizedCompletionResult:
+        response = await self.ai_client.aclient.chat.completions.create(messages=messages, **kwargs)
+        return self._normalize_completion(response)
+
+    def _build_completed_event(self, index: int, text: str, finish_reason: Optional[str], model: Optional[str], usage: Optional[Dict[str, Any]]):
+        terminal = RuntimeTerminalMetadata(
+            finish_reason=finish_reason,
+            model=model,
+            usage=usage,
+            response_text=text,
+        )
+        return RuntimeStreamEvent(type="completed", index=index, data={"terminal": terminal.__dict__})
+
+    def _normalize_chunk_to_events(self, chunk: Any, index: int):
+        events = []
+        chunk_dict = self._to_dict(chunk)
+        choice = (chunk_dict.get("choices") or [{}])[0]
+        delta = choice.get("delta") or {}
+
+        content = delta.get("content")
+        if content is not None:
+            events.append(RuntimeStreamEvent(type="text_delta", index=index, data={"text": content}))
+            index += 1
+
+        for tc in delta.get("tool_calls") or []:
+            events.append(RuntimeStreamEvent(type="tool_call_delta", index=index, data={"tool_call": tc}))
+            index += 1
+
+        if chunk_dict.get("usage"):
+            events.append(RuntimeStreamEvent(type="usage", index=index, data={"usage": chunk_dict.get("usage")}))
+            index += 1
+
+        return events, index, choice.get("finish_reason"), chunk_dict.get("model")
+
+    def stream_completion(self, messages: List[Dict[str, Any]], **kwargs: Any):
+        kwargs = kwargs.copy()
+        kwargs["stream"] = True
+        response_gen = self.ai_client.client.chat.completions.create(messages=messages, **kwargs)
+
+        index = 0
+        full_text = ""
+        finish_reason = None
+        model = None
+        usage = None
+
+        try:
+            for chunk in response_gen:
+                events, index, finish_reason, model = self._normalize_chunk_to_events(chunk, index)
+                for event in events:
+                    if event.type == "text_delta":
+                        full_text += event.data.get("text", "")
+                    if event.type == "usage":
+                        usage = event.data.get("usage")
+                    yield event
+        except Exception as exc:
+            payload = RuntimeErrorPayload(message=str(exc))
+            yield RuntimeStreamEvent(type="error", index=index, data={"error": payload.__dict__})
+            return
+
+        yield self._build_completed_event(index, full_text, finish_reason, model, usage)
+
+    async def stream_completion_a(self, messages: List[Dict[str, Any]], **kwargs: Any):
+        kwargs = kwargs.copy()
+        kwargs["stream"] = True
+        response_gen = await self.ai_client.aclient.chat.completions.create(messages=messages, **kwargs)
+
+        index = 0
+        full_text = ""
+        finish_reason = None
+        model = None
+        usage = None
+
+        try:
+            async for chunk in response_gen:
+                events, index, finish_reason, model = self._normalize_chunk_to_events(chunk, index)
+                for event in events:
+                    if event.type == "text_delta":
+                        full_text += event.data.get("text", "")
+                    if event.type == "usage":
+                        usage = event.data.get("usage")
+                    yield event
+        except Exception as exc:
+            payload = RuntimeErrorPayload(message=str(exc))
+            yield RuntimeStreamEvent(type="error", index=index, data={"error": payload.__dict__})
+            return
+
+        yield self._build_completed_event(index, full_text, finish_reason, model, usage)

--- a/chatsnack/runtime/types.py
+++ b/chatsnack/runtime/types.py
@@ -1,0 +1,93 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Literal, Optional, Protocol, AsyncIterator, Iterator, runtime_checkable
+
+EVENT_SCHEMA_VERSION = "1.0"
+RESERVED_EVENT_TYPES = {
+    "text_delta",
+    "tool_call_delta",
+    "tool_result",
+    "phase",
+    "usage",
+    "completed",
+    "error",
+}
+
+
+@dataclass
+class NormalizedToolFunction:
+    name: str
+    arguments: str = ""
+
+
+@dataclass
+class NormalizedToolCall:
+    id: str
+    type: str = "function"
+    function: Optional[NormalizedToolFunction] = None
+
+
+@dataclass
+class NormalizedAssistantMessage:
+    role: str = "assistant"
+    content: Optional[str] = None
+    tool_calls: List[NormalizedToolCall] = field(default_factory=list)
+
+
+@dataclass
+class NormalizedCompletionResult:
+    message: NormalizedAssistantMessage
+    finish_reason: Optional[str] = None
+    model: Optional[str] = None
+    usage: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class RuntimeTerminalMetadata:
+    finish_reason: Optional[str] = None
+    model: Optional[str] = None
+    usage: Optional[Dict[str, Any]] = None
+    response_text: str = ""
+
+
+@dataclass
+class RuntimeErrorPayload:
+    message: str
+    code: Optional[str] = None
+    retriable: bool = False
+    details: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class RuntimeStreamEvent:
+    type: Literal[
+        "text_delta",
+        "tool_call_delta",
+        "tool_result",
+        "phase",
+        "usage",
+        "completed",
+        "error",
+    ]
+    index: int
+    data: Dict[str, Any]
+    schema_version: str = EVENT_SCHEMA_VERSION
+
+
+@runtime_checkable
+class RuntimeAdapter(Protocol):
+    """
+    RuntimeAdapter owns only provider I/O and normalization.
+    Prompt compilation and template expansion remain Chat-layer responsibilities.
+    """
+
+    def create_completion(self, messages: List[Dict[str, Any]], **kwargs: Any) -> NormalizedCompletionResult:
+        ...
+
+    async def create_completion_a(self, messages: List[Dict[str, Any]], **kwargs: Any) -> NormalizedCompletionResult:
+        ...
+
+    def stream_completion(self, messages: List[Dict[str, Any]], **kwargs: Any) -> Iterator[RuntimeStreamEvent]:
+        ...
+
+    async def stream_completion_a(self, messages: List[Dict[str, Any]], **kwargs: Any) -> AsyncIterator[RuntimeStreamEvent]:
+        ...

--- a/docs/rfcs/phase-1-runtime-adapter-rfc.md
+++ b/docs/rfcs/phase-1-runtime-adapter-rfc.md
@@ -1,0 +1,45 @@
+# Phase 1 RFC: Runtime Adapter Boundary and Normalized Runtime Types
+
+## Status
+Draft
+
+## Summary
+This RFC introduces an internal runtime boundary (`chatsnack/runtime/`) that isolates provider-specific SDK objects from the `Chat` layer.
+
+## Ownership boundary
+- **Chat layer owns prompt compilation**: fillings/template expansion, message construction, and feature orchestration remain in `chatsnack/chat/*`.
+- **Runtime adapter owns provider I/O**: calling provider SDKs and converting provider-specific payloads into normalized internal types.
+
+This split enables future provider backends and consistent listener event contracts.
+
+## New internal runtime model
+- `RuntimeAdapter` protocol for sync/async completion and stream operations.
+- `NormalizedCompletionResult` for non-stream responses.
+- `NormalizedAssistantMessage` and `NormalizedToolCall` for assistant/tool payloads.
+- `RuntimeStreamEvent` envelope for listener events with schema versioning.
+- `RuntimeTerminalMetadata` and `RuntimeErrorPayload` for stream terminal states.
+
+## Event schema (v1.0)
+Envelope fields:
+- `schema_version`
+- `type`
+- `index`
+- `data`
+
+Reserved event types:
+- `text_delta`
+- `tool_call_delta`
+- `tool_result`
+- `phase`
+- `usage`
+- `completed`
+- `error`
+
+## Initial adapter
+`ChatCompletionsAdapter` is the first implementation. It preserves current Chat Completions behavior while normalizing responses/chunks.
+
+## Migration notes
+- Existing prompt compilation paths stay unchanged in phase 1.
+- Listener `events=True` remains backward-compatible by default with legacy event payloads (`text_delta` + `done`).
+- The v1 envelope (`schema_version`, `type`, `index`, `data`) is available as an explicit opt-in (`event_schema="v1"`).
+- `ChatStreamListener` can consume runtime events in normalized mode while maintaining legacy plain text streaming behavior for compatibility.

--- a/tests/mixins/test_query_listen.py
+++ b/tests/mixins/test_query_listen.py
@@ -122,6 +122,7 @@ async def test_listen_a():
     assert output == ask_output
 
 from types import SimpleNamespace
+from chatsnack.runtime.types import RuntimeStreamEvent
 
 
 class _FakeStreamChunk:
@@ -291,3 +292,52 @@ async def test_listener_events_mode_async_v1_opt_in():
     assert events[0]["schema_version"] == "1.0"
     assert [e["type"] for e in events] == ["text_delta", "text_delta", "text_delta", "completed"]
     assert events[-1]["data"]["terminal"]["response_text"] == "AB"
+
+
+def _runtime_stream_with_error():
+    yield RuntimeStreamEvent(type="text_delta", index=0, data={"text": "partial"})
+    yield RuntimeStreamEvent(type="error", index=1, data={"error": {"message": "provider failed"}})
+
+
+async def _runtime_stream_with_error_async():
+    yield RuntimeStreamEvent(type="text_delta", index=0, data={"text": "partial"})
+    yield RuntimeStreamEvent(type="error", index=1, data={"error": {"message": "provider failed"}})
+
+
+def test_runtime_listener_text_mode_raises_on_error_event():
+    runtime = SimpleNamespace(stream_completion=lambda *args, **kwargs: _runtime_stream_with_error())
+    listener = ChatStreamListener(ai=None, prompt="[]", runtime=runtime, events=False)
+    listener.start()
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        list(listener)
+
+    assert listener.response == "partial"
+    assert listener.is_complete
+
+
+@pytest.mark.asyncio
+async def test_runtime_listener_text_mode_raises_on_error_event_async():
+    runtime = SimpleNamespace(stream_completion_a=lambda *args, **kwargs: _runtime_stream_with_error_async())
+    listener = ChatStreamListener(ai=None, prompt="[]", runtime=runtime, events=False)
+    await listener.start_a()
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        async for _ in listener:
+            pass
+
+    assert listener.response == "partial"
+    assert listener.is_complete
+
+
+def test_runtime_listener_events_mode_surfaces_error_event():
+    runtime = SimpleNamespace(stream_completion=lambda *args, **kwargs: _runtime_stream_with_error())
+    listener = ChatStreamListener(ai=None, prompt="[]", runtime=runtime, events=True)
+    listener.start()
+
+    events = list(listener)
+
+    assert events == [
+        {"type": "text_delta", "index": 0, "text": "partial"},
+        {"type": "error", "index": 1, "error": {"message": "provider failed"}},
+    ]

--- a/tests/mixins/test_query_listen.py
+++ b/tests/mixins/test_query_listen.py
@@ -251,3 +251,43 @@ async def test_listener_events_mode_async():
         events.append(event)
     assert [e["type"] for e in events] == ["text_delta", "text_delta", "text_delta", "done"]
     assert events[-1]["response"] == "AB"
+
+
+def test_listener_events_mode_sync_v1_opt_in():
+    ai = SimpleNamespace(
+        client=SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=lambda **kwargs: _sync_stream())
+            )
+        )
+    )
+    listener = ChatStreamListener(ai, "[]", events=True, event_schema="v1")
+    listener.start()
+    events = list(listener)
+    assert events[0]["schema_version"] == "1.0"
+    assert events[0]["type"] == "text_delta"
+    assert events[0]["data"]["text"] == "A"
+    assert events[-1]["type"] == "completed"
+    assert events[-1]["data"]["terminal"]["response_text"] == "AB"
+
+
+@pytest.mark.asyncio
+async def test_listener_events_mode_async_v1_opt_in():
+    async def create(**kwargs):
+        return _async_stream()
+
+    ai = SimpleNamespace(
+        aclient=SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=create)
+            )
+        )
+    )
+    listener = ChatStreamListener(ai, "[]", events=True, event_schema="v1")
+    await listener.start_a()
+    events = []
+    async for event in listener:
+        events.append(event)
+    assert events[0]["schema_version"] == "1.0"
+    assert [e["type"] for e in events] == ["text_delta", "text_delta", "text_delta", "completed"]
+    assert events[-1]["data"]["terminal"]["response_text"] == "AB"

--- a/tests/runtime/test_chat_completions_adapter.py
+++ b/tests/runtime/test_chat_completions_adapter.py
@@ -1,0 +1,114 @@
+import pytest
+from types import SimpleNamespace
+
+from chatsnack.runtime import (
+    ChatCompletionsAdapter,
+    EVENT_SCHEMA_VERSION,
+    RESERVED_EVENT_TYPES,
+)
+
+
+class _FakeObj:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def model_dump(self):
+        return self.payload
+
+
+def test_reserved_event_types_are_defined():
+    assert RESERVED_EVENT_TYPES == {
+        "text_delta",
+        "tool_call_delta",
+        "tool_result",
+        "phase",
+        "usage",
+        "completed",
+        "error",
+    }
+
+
+def test_normalizes_non_stream_completion_with_tool_calls():
+    response = _FakeObj(
+        {
+            "model": "gpt-test",
+            "usage": {"total_tokens": 4},
+            "choices": [
+                {
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": "get_weather", "arguments": '{"city":"Boston"}'},
+                            }
+                        ],
+                    },
+                }
+            ],
+        }
+    )
+
+    ai = SimpleNamespace(
+        client=SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=lambda **kwargs: response)))
+    )
+    adapter = ChatCompletionsAdapter(ai)
+
+    result = adapter.create_completion(messages=[{"role": "user", "content": "weather?"}])
+
+    assert result.model == "gpt-test"
+    assert result.finish_reason == "tool_calls"
+    assert result.usage == {"total_tokens": 4}
+    assert result.message.tool_calls[0].id == "call_1"
+    assert result.message.tool_calls[0].function.name == "get_weather"
+
+
+def test_normalizes_sync_stream_events_with_completed_terminal():
+    chunks = iter(
+        [
+            _FakeObj({"model": "gpt-test", "choices": [{"finish_reason": None, "delta": {"content": "Hi"}}]}),
+            _FakeObj({"model": "gpt-test", "choices": [{"finish_reason": None, "delta": {"tool_calls": [{"id": "tc1"}]}}]}),
+            _FakeObj({"model": "gpt-test", "usage": {"total_tokens": 3}, "choices": [{"finish_reason": "stop", "delta": {"content": "!"}}]}),
+        ]
+    )
+    ai = SimpleNamespace(
+        client=SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=lambda **kwargs: chunks)))
+    )
+    adapter = ChatCompletionsAdapter(ai)
+
+    events = list(adapter.stream_completion(messages=[]))
+
+    assert [e.type for e in events] == ["text_delta", "tool_call_delta", "text_delta", "usage", "completed"]
+    assert all(e.schema_version == EVENT_SCHEMA_VERSION for e in events)
+    assert events[-1].data["terminal"]["response_text"] == "Hi!"
+    assert events[-1].data["terminal"]["finish_reason"] == "stop"
+
+
+@pytest.mark.asyncio
+async def test_normalizes_async_stream_errors_into_error_event():
+    class _BadAsyncStream:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise RuntimeError("boom")
+
+    async def create(**kwargs):
+        return _BadAsyncStream()
+
+    ai = SimpleNamespace(
+        aclient=SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    )
+    adapter = ChatCompletionsAdapter(ai)
+
+    events = []
+    async for event in adapter.stream_completion_a(messages=[]):
+        events.append(event)
+
+    assert len(events) == 1
+    assert events[0].type == "error"
+    assert events[0].schema_version == EVENT_SCHEMA_VERSION
+    assert events[0].data["error"]["message"] == "boom"


### PR DESCRIPTION
### Motivation
- Introduce a clear runtime boundary to isolate provider SDK I/O and normalization from the Chat layer to enable provider-agnostic behavior and future backends.
- Normalize streaming and non-streaming completions into a consistent internal shape so listeners can consume a stable event envelope (`v1`) while remaining backward-compatible with legacy streaming.
- Add an initial adapter implementation to preserve existing Chat Completions behavior while providing normalized events and terminal metadata for richer tool-call handling.

### Description
- Add a new `chatsnack/runtime` package with `types.py` for normalized runtime dataclasses and the `RuntimeAdapter` protocol, and `chat_completions_adapter.py` implementing `ChatCompletionsAdapter` to normalize sync/async completions and streams.
- Wire the adapter into the Chat layer by creating `self.runtime = ChatCompletionsAdapter(self.ai)` in `Chat` and updating `ChatQueryMixin` to use the adapter for `create_completion`/`stream_completion` paths when present.
- Extend `ChatStreamListener` to accept a `runtime` and `event_schema` option, render normalized runtime `RuntimeStreamEvent` envelopes (v1) when opted-in, and preserve legacy plain-string streaming behavior for compatibility.
- Add RFC documentation `docs/rfcs/phase-1-runtime-adapter-rfc.md` describing the boundary and event schema, and update/extend tests to cover normalized adapter behavior and the new v1 event opt-in.

### Testing
- Added unit tests in `tests/runtime/test_chat_completions_adapter.py` exercising normalization of non-stream responses, sync stream events, and async stream error handling and they passed.
- Updated `tests/mixins/test_query_listen.py` to include v1 opt-in assertions for both sync and async listeners and those tests passed.
- Ran the modified test targets with `pytest` for the new and updated tests and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b5c7cee88331b135689a1b1e9e4a)