### PR TITLE
Document legacy events=True compatibility exception and add migration plan + tests

### DIFF
--- a/docs/rfcs/phase-1-runtime-adapter-rfc.md
+++ b/docs/rfcs/phase-1-runtime-adapter-rfc.md
@@ -40,6 +40,14 @@ Reserved event types:
 
 ## Migration notes
 - Existing prompt compilation paths stay unchanged in phase 1.
-- Listener `events=True` remains backward-compatible by default with legacy event payloads (`text_delta` + `done`).
+- **Compatibility exception (phase 1):** listener `events=True` intentionally keeps the legacy default payload shape (`text_delta` + `done`) even though the runtime boundary introduces the v1 event envelope. This is a product/contract decision to avoid breaking existing event consumers during the phase 1 rollout.
 - The v1 envelope (`schema_version`, `type`, `index`, `data`) is available as an explicit opt-in (`event_schema="v1"`).
 - `ChatStreamListener` can consume runtime events in normalized mode while maintaining legacy plain text streaming behavior for compatibility.
+
+## Migration plan for default event schema
+To eventually align defaults with the normalized runtime contract while minimizing migration risk:
+
+1. **Phase 1 (current):** keep `events=True` defaulting to legacy events and document this as a compatibility exception.
+2. **Phase 2 (deprecation window):** emit a deprecation warning when `events=True` is used without `event_schema`, advising consumers to set `event_schema="legacy"` or `event_schema="v1"` explicitly.
+3. **Phase 3 (default flip):** change the implicit default for `events=True` to `event_schema="v1"`; retain `event_schema="legacy"` as an explicit compatibility mode for one additional minor release.
+4. **Phase 4 (cleanup):** remove legacy implicit behavior after the compatibility window and keep explicit schema selection as the long-term contract.

--- a/tests/mixins/test_query.py
+++ b/tests/mixins/test_query.py
@@ -297,6 +297,54 @@ async def test_tool_recursion_auto_feed_false_keeps_tool_messages(chat, monkeypa
     assert any(msg["role"] == "tool" for msg in messages)
 
 
+
+
+def test_listen_events_true_defaults_to_legacy_schema(chat, monkeypatch):
+    class _DummyListener:
+        def __init__(self):
+            self.events = False
+            self.event_schema = None
+            self.started = False
+
+        def start(self):
+            self.started = True
+
+    async def fake_submit(**kwargs):
+        return "[]", _DummyListener()
+
+    chat.stream = True
+    monkeypatch.setattr(chat, "_submit_for_response_and_prompt", fake_submit)
+
+    listener = chat.listen(events=True)
+
+    assert listener.events is True
+    assert listener.event_schema == "legacy"
+    assert listener.started is True
+
+
+@pytest.mark.asyncio
+async def test_listen_a_events_true_defaults_to_legacy_schema(chat, monkeypatch):
+    class _DummyListener:
+        def __init__(self):
+            self.events = False
+            self.event_schema = None
+            self.started = False
+
+        async def start_a(self):
+            self.started = True
+
+    async def fake_submit(**kwargs):
+        return "[]", _DummyListener()
+
+    chat.stream = True
+    monkeypatch.setattr(chat, "_submit_for_response_and_prompt", fake_submit)
+
+    listener = await chat.listen_a(events=True)
+
+    assert listener.events is True
+    assert listener.event_schema == "legacy"
+    assert listener.started is True
+
 def test_listen_returns_plain_str_payload_when_stream_disabled(chat, monkeypatch):
     async def fake_submit(**kwargs):
         return "[]", "plain-completion"


### PR DESCRIPTION
### Motivation
- Preserve backward compatibility for consumers that rely on the legacy streaming payload shape when `events=True` during the phase 1 runtime adapter rollout. 
- Provide an explicit product/contract statement and a clear, staged migration path to move the default to the normalized `v1` envelope in a later phase.

### Description
- Update `docs/rfcs/phase-1-runtime-adapter-rfc.md` to declare a **Compatibility exception (phase 1)** that `events=True` defaults to the legacy payload (`text_delta` + `done`) and add a 4-phase migration plan to flip the default to `event_schema="v1"` over time. 
- Add two tests to `tests/mixins/test_query.py`: `test_listen_events_true_defaults_to_legacy_schema` and `test_listen_a_events_true_defaults_to_legacy_schema` which assert that `Chat.listen(events=True)` and `Chat.listen_a(events=True)` set `event_schema == "legacy"` and start the listener. 
- Keep existing `ChatStreamListener` behavior unchanged and rely on explicit opt-in `event_schema="v1"` for normalized events.

### Testing
- Installed the package in editable mode with `python -m pip install -e .` which completed successfully. 
- Ran the targeted test matrix with `pytest -q tests/mixins/test_query.py::test_listen_events_true_defaults_to_legacy_schema tests/mixins/test_query.py::test_listen_a_events_true_defaults_to_legacy_schema tests/mixins/test_query_listen.py::test_listener_events_mode_sync tests/mixins/test_query_listen.py::test_listener_events_mode_async_v1_opt_in` and all tests passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2ebeba6708331a95b846e4484df54)