### PR TITLE
docs: mark Phase 1 runtime adapter RFC Accepted and add decision record

### DIFF
--- a/docs/rfcs/phase-1-runtime-adapter-rfc.md
+++ b/docs/rfcs/phase-1-runtime-adapter-rfc.md
@@ -1,7 +1,7 @@
 # Phase 1 RFC: Runtime Adapter Boundary and Normalized Runtime Types
 
 ## Status
-Draft
+Accepted.
 
 ## Summary
 This RFC introduces an internal runtime boundary (`chatsnack/runtime/`) that isolates provider-specific SDK objects from the `Chat` layer.
@@ -51,3 +51,8 @@ To eventually align defaults with the normalized runtime contract while minimizi
 2. **Phase 2 (deprecation window):** emit a deprecation warning when `events=True` is used without `event_schema`, advising consumers to set `event_schema="legacy"` or `event_schema="v1"` explicitly.
 3. **Phase 3 (default flip):** change the implicit default for `events=True` to `event_schema="v1"`; retain `event_schema="legacy"` as an explicit compatibility mode for one additional minor release.
 4. **Phase 4 (cleanup):** remove legacy implicit behavior after the compatibility window and keep explicit schema selection as the long-term contract.
+
+## Decision record
+- **Approval date:** 2026-03-12
+- **Approver/owner:** Chatsnack maintainers (runtime + chat compatibility owners)
+- **Baseline declaration:** This RFC is accepted as the implementation baseline for Phase 1 runtime adapter work merged in the commit line around `c5f38a5`; behaviors and contracts documented here are frozen as the authoritative baseline for adapter evolution unless superseded by a subsequent RFC update.


### PR DESCRIPTION
### Motivation
- Update the Phase 1 RFC to an accepted/finalized state and record an explicit decision so the runtime adapter work has a clear implementation baseline aligned with the Phase 0 freeze language.

### Description
- Update `docs/rfcs/phase-1-runtime-adapter-rfc.md` status from `Draft` to `Accepted` and add a `Decision record` section that includes the approval date (`2026-03-12`), approver/owner (`Chatsnack maintainers (runtime + chat compatibility owners)`), and a baseline declaration referencing adapter work merged around `c5f38a5`.

### Testing
- `sed -n '1,260p' docs/rfcs/phase-1-runtime-adapter-rfc.md` was used to verify the updated contents and repository state checks completed successfully; all validation commands returned success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b321d56488833191c5291c8ae2a5ad)