### PR TITLE
Add Responses API runtime adapter with normalized continuation metadata

### DIFF
--- a/chatsnack/runtime/__init__.py
+++ b/chatsnack/runtime/__init__.py
@@ -11,6 +11,7 @@ from .types import (
     RuntimeTerminalMetadata,
 )
 from .chat_completions_adapter import ChatCompletionsAdapter
+from .responses_adapter import ResponsesAdapter
 
 __all__ = [
     "EVENT_SCHEMA_VERSION",
@@ -24,4 +25,5 @@ __all__ = [
     "RuntimeTerminalMetadata",
     "RuntimeErrorPayload",
     "ChatCompletionsAdapter",
+    "ResponsesAdapter",
 ]

--- a/chatsnack/runtime/responses_adapter.py
+++ b/chatsnack/runtime/responses_adapter.py
@@ -59,7 +59,7 @@ class ResponsesAdapter:
                     {
                         "type": "message",
                         "role": "assistant",
-                        "content": [{"type": "output_text", "text": text_content}],
+                        "content": [{"type": "input_text", "text": text_content}],
                     }
                 )
             for tool_call in tool_calls:
@@ -77,7 +77,7 @@ class ResponsesAdapter:
         if role not in {"system", "developer", "user", "assistant"}:
             role = "user"
 
-        text_type = "output_text" if role == "assistant" else "input_text"
+        text_type = "input_text"
         return [
             {
                 "type": "message",

--- a/chatsnack/runtime/responses_adapter.py
+++ b/chatsnack/runtime/responses_adapter.py
@@ -1,0 +1,240 @@
+from typing import Any, Dict, List, Optional, Tuple
+
+from .types import (
+    NormalizedAssistantMessage,
+    NormalizedCompletionResult,
+    NormalizedToolCall,
+    NormalizedToolFunction,
+    RuntimeErrorPayload,
+    RuntimeStreamEvent,
+    RuntimeTerminalMetadata,
+)
+
+
+class ResponsesAdapter:
+    """Runtime adapter for the OpenAI Responses API."""
+
+    def __init__(self, ai_client):
+        self.ai_client = ai_client
+
+    @staticmethod
+    def _to_dict(obj: Any) -> Dict[str, Any]:
+        if obj is None:
+            return {}
+        if isinstance(obj, dict):
+            return obj
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        if hasattr(obj, "__dict__"):
+            return vars(obj)
+        return dict(obj)
+
+    @staticmethod
+    def _coerce_text(content: Any) -> str:
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        return str(content)
+
+    def _message_to_input_items(self, message: Dict[str, Any]) -> List[Dict[str, Any]]:
+        role = message.get("role")
+        content = message.get("content")
+
+        if role == "tool":
+            return [
+                {
+                    "type": "function_call_output",
+                    "call_id": message.get("tool_call_id", ""),
+                    "output": self._coerce_text(content),
+                }
+            ]
+
+        items: List[Dict[str, Any]] = []
+        tool_calls = message.get("tool_calls") or []
+        if tool_calls and role == "assistant":
+            text_content = self._coerce_text(content)
+            if text_content:
+                items.append(
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": text_content}],
+                    }
+                )
+            for tool_call in tool_calls:
+                function = self._to_dict(tool_call.get("function") or {})
+                items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": tool_call.get("id", ""),
+                        "name": function.get("name", ""),
+                        "arguments": function.get("arguments", ""),
+                    }
+                )
+            return items
+
+        if role not in {"system", "developer", "user", "assistant"}:
+            role = "user"
+
+        text_type = "output_text" if role == "assistant" else "input_text"
+        return [
+            {
+                "type": "message",
+                "role": role,
+                "content": [{"type": text_type, "text": self._coerce_text(content)}],
+            }
+        ]
+
+    def _map_messages_to_input(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        input_items: List[Dict[str, Any]] = []
+        for message in messages:
+            input_items.extend(self._message_to_input_items(message))
+        return input_items
+
+    @staticmethod
+    def _apply_profile_defaults(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        out = kwargs.copy()
+        profile = out.pop("profile", None)
+        if not isinstance(profile, dict):
+            return out
+
+        defaults = profile.get("defaults")
+        if isinstance(defaults, dict):
+            merged = defaults.copy()
+            merged.update(out)
+            out = merged
+
+        model = out.get("model")
+        model_overrides = profile.get("model_defaults")
+        if model and isinstance(model_overrides, dict) and isinstance(model_overrides.get(model), dict):
+            merged = model_overrides[model].copy()
+            merged.update(out)
+            out = merged
+
+        return out
+
+    def _build_responses_kwargs(self, messages: List[Dict[str, Any]], kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        options = self._apply_profile_defaults(kwargs)
+        options["input"] = self._map_messages_to_input(messages)
+        options.setdefault("store", False)
+        return options
+
+    def _normalize_output(self, response_dict: Dict[str, Any]) -> Tuple[NormalizedAssistantMessage, Optional[str]]:
+        content_parts: List[str] = []
+        tool_calls: List[NormalizedToolCall] = []
+        assistant_phase: Optional[str] = None
+
+        for item in response_dict.get("output") or []:
+            item_dict = self._to_dict(item)
+            item_type = item_dict.get("type")
+            if item_type == "message" and item_dict.get("role") == "assistant":
+                assistant_phase = assistant_phase or item_dict.get("status")
+                for part in item_dict.get("content") or []:
+                    part_dict = self._to_dict(part)
+                    if part_dict.get("type") == "output_text":
+                        content_parts.append(part_dict.get("text", ""))
+            elif item_type == "function_call":
+                tool_calls.append(
+                    NormalizedToolCall(
+                        id=item_dict.get("call_id", ""),
+                        type="function",
+                        function=NormalizedToolFunction(
+                            name=item_dict.get("name", ""),
+                            arguments=item_dict.get("arguments", ""),
+                        ),
+                    )
+                )
+
+        message = NormalizedAssistantMessage(
+            role="assistant",
+            content="".join(content_parts) or None,
+            tool_calls=tool_calls,
+        )
+        return message, assistant_phase
+
+    def _normalize_completion(self, response: Any, request_kwargs: Dict[str, Any]) -> NormalizedCompletionResult:
+        response_dict = self._to_dict(response)
+        message, assistant_phase = self._normalize_output(response_dict)
+
+        metadata = {
+            "response_id": response_dict.get("id"),
+            "previous_response_id": request_kwargs.get("previous_response_id"),
+            "assistant_phase": assistant_phase,
+            "provider_extras": {
+                "status": response_dict.get("status"),
+                "incomplete_details": response_dict.get("incomplete_details"),
+                "output": response_dict.get("output"),
+            },
+        }
+
+        return NormalizedCompletionResult(
+            message=message,
+            finish_reason=response_dict.get("status"),
+            model=response_dict.get("model"),
+            usage=response_dict.get("usage"),
+            metadata=metadata,
+        )
+
+    def create_completion(self, messages: List[Dict[str, Any]], **kwargs: Any) -> NormalizedCompletionResult:
+        request_kwargs = self._build_responses_kwargs(messages, kwargs)
+        response = self.ai_client.client.responses.create(**request_kwargs)
+        return self._normalize_completion(response, request_kwargs)
+
+    async def create_completion_a(self, messages: List[Dict[str, Any]], **kwargs: Any) -> NormalizedCompletionResult:
+        request_kwargs = self._build_responses_kwargs(messages, kwargs)
+        response = await self.ai_client.aclient.responses.create(**request_kwargs)
+        return self._normalize_completion(response, request_kwargs)
+
+    def stream_completion(self, messages: List[Dict[str, Any]], **kwargs: Any):
+        request_kwargs = self._build_responses_kwargs(messages, kwargs)
+        index = 0
+        try:
+            result = self.create_completion(messages, **kwargs)
+            text = result.message.content or ""
+            if text:
+                yield RuntimeStreamEvent(type="text_delta", index=index, data={"text": text})
+                index += 1
+            for tool_call in result.message.tool_calls:
+                yield RuntimeStreamEvent(type="tool_call_delta", index=index, data={"tool_call": tool_call.__dict__})
+                index += 1
+            if result.usage:
+                yield RuntimeStreamEvent(type="usage", index=index, data={"usage": result.usage})
+                index += 1
+            terminal = RuntimeTerminalMetadata(
+                finish_reason=result.finish_reason,
+                model=result.model,
+                usage=result.usage,
+                response_text=text,
+                metadata=result.metadata,
+            )
+            yield RuntimeStreamEvent(type="completed", index=index, data={"terminal": terminal.__dict__})
+        except Exception as exc:
+            payload = RuntimeErrorPayload(message=str(exc))
+            yield RuntimeStreamEvent(type="error", index=index, data={"error": payload.__dict__})
+
+    async def stream_completion_a(self, messages: List[Dict[str, Any]], **kwargs: Any):
+        index = 0
+        try:
+            result = await self.create_completion_a(messages, **kwargs)
+            text = result.message.content or ""
+            if text:
+                yield RuntimeStreamEvent(type="text_delta", index=index, data={"text": text})
+                index += 1
+            for tool_call in result.message.tool_calls:
+                yield RuntimeStreamEvent(type="tool_call_delta", index=index, data={"tool_call": tool_call.__dict__})
+                index += 1
+            if result.usage:
+                yield RuntimeStreamEvent(type="usage", index=index, data={"usage": result.usage})
+                index += 1
+            terminal = RuntimeTerminalMetadata(
+                finish_reason=result.finish_reason,
+                model=result.model,
+                usage=result.usage,
+                response_text=text,
+                metadata=result.metadata,
+            )
+            yield RuntimeStreamEvent(type="completed", index=index, data={"terminal": terminal.__dict__})
+        except Exception as exc:
+            payload = RuntimeErrorPayload(message=str(exc))
+            yield RuntimeStreamEvent(type="error", index=index, data={"error": payload.__dict__})

--- a/chatsnack/runtime/types.py
+++ b/chatsnack/runtime/types.py
@@ -39,6 +39,7 @@ class NormalizedCompletionResult:
     finish_reason: Optional[str] = None
     model: Optional[str] = None
     usage: Optional[Dict[str, Any]] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -47,6 +48,7 @@ class RuntimeTerminalMetadata:
     model: Optional[str] = None
     usage: Optional[Dict[str, Any]] = None
     response_text: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/tests/runtime/test_responses_adapter.py
+++ b/tests/runtime/test_responses_adapter.py
@@ -119,3 +119,28 @@ def test_profile_defaults_and_model_specific_options_are_applied():
     assert captured["temperature"] == 0.1
     assert captured["reasoning"] == {"effort": "medium"}
     assert captured["store"] is False
+
+
+def test_assistant_history_message_is_encoded_as_input_text():
+    captured = {}
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return _FakeObj({"id": "resp_3", "status": "completed", "model": "gpt-4.1", "output": []})
+
+    ai = SimpleNamespace(client=SimpleNamespace(responses=SimpleNamespace(create=create)))
+    adapter = ResponsesAdapter(ai)
+
+    adapter.create_completion(
+        messages=[
+            {"role": "assistant", "content": "Prior answer."},
+            {"role": "user", "content": "Follow up?"},
+        ],
+        model="gpt-4.1",
+    )
+
+    assert captured["input"][0] == {
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "input_text", "text": "Prior answer."}],
+    }

--- a/tests/runtime/test_responses_adapter.py
+++ b/tests/runtime/test_responses_adapter.py
@@ -1,0 +1,121 @@
+from types import SimpleNamespace
+
+from chatsnack.runtime import ResponsesAdapter
+
+
+class _FakeObj:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def model_dump(self):
+        return self.payload
+
+
+def test_maps_compiled_messages_to_responses_input_items_and_defaults_store_false():
+    captured = {}
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return _FakeObj({"id": "resp_1", "status": "completed", "model": "gpt-4.1", "output": []})
+
+    ai = SimpleNamespace(client=SimpleNamespace(responses=SimpleNamespace(create=create)))
+    adapter = ResponsesAdapter(ai)
+
+    adapter.create_completion(
+        messages=[
+            {"role": "developer", "content": "rules"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {"name": "lookup", "arguments": '{"q":"tea"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "tool result"},
+        ],
+        model="gpt-4.1",
+    )
+
+    assert captured["store"] is False
+    assert captured["input"][0] == {
+        "type": "message",
+        "role": "developer",
+        "content": [{"type": "input_text", "text": "rules"}],
+    }
+    assert captured["input"][1]["type"] == "function_call"
+    assert captured["input"][1]["call_id"] == "call_1"
+    assert captured["input"][2] == {
+        "type": "function_call_output",
+        "call_id": "call_1",
+        "output": "tool result",
+    }
+
+
+def test_normalizes_response_text_tool_calls_and_runtime_metadata():
+    response = _FakeObj(
+        {
+            "id": "resp_abc",
+            "status": "completed",
+            "model": "gpt-4.1",
+            "usage": {"total_tokens": 12},
+            "output": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "Done."}],
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_99",
+                    "name": "save_note",
+                    "arguments": '{"text":"Done."}',
+                },
+            ],
+        }
+    )
+
+    ai = SimpleNamespace(
+        client=SimpleNamespace(responses=SimpleNamespace(create=lambda **kwargs: response))
+    )
+    adapter = ResponsesAdapter(ai)
+
+    result = adapter.create_completion(
+        messages=[{"role": "user", "content": "hello"}],
+        model="gpt-4.1",
+        previous_response_id="resp_prev",
+    )
+
+    assert result.message.content == "Done."
+    assert result.message.tool_calls[0].id == "call_99"
+    assert result.metadata["response_id"] == "resp_abc"
+    assert result.metadata["previous_response_id"] == "resp_prev"
+    assert result.metadata["assistant_phase"] == "completed"
+    assert result.usage == {"total_tokens": 12}
+
+
+def test_profile_defaults_and_model_specific_options_are_applied():
+    captured = {}
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return _FakeObj({"id": "resp_2", "status": "completed", "model": "gpt-4.1", "output": []})
+
+    ai = SimpleNamespace(client=SimpleNamespace(responses=SimpleNamespace(create=create)))
+    adapter = ResponsesAdapter(ai)
+
+    adapter.create_completion(
+        messages=[{"role": "user", "content": "hi"}],
+        model="gpt-4.1",
+        profile={
+            "defaults": {"temperature": 0.1, "store": False},
+            "model_defaults": {"gpt-4.1": {"reasoning": {"effort": "medium"}}},
+        },
+    )
+
+    assert captured["temperature"] == 0.1
+    assert captured["reasoning"] == {"effort": "medium"}
+    assert captured["store"] is False


### PR DESCRIPTION
### Motivation
- Introduce a runtime adapter for the OpenAI Responses API to isolate provider I/O and normalization from the Chat layer. 
- Map compiled chat messages (including assistant tool-calls and tool outputs) into Responses `input` items so the Chat layer can remain responsible for prompt compilation and role remapping. 
- Preserve and surface continuation/metadata (`previous_response_id`, response id, usage, assistant phase, provider extras) so follow-up turns and tooling workflows can link responses reliably. 

### Description
- Add `ResponsesAdapter` in `chatsnack/runtime/responses_adapter.py` implementing the `RuntimeAdapter` contract with `create_completion`, `create_completion_a`, `stream_completion`, and `stream_completion_a` and mapping compiled chat messages to Responses `input` items. 
- Implement request option handling that applies `profile.defaults` and `profile.model_defaults[model]`, and enforces `store=False` by default in `_build_responses_kwargs`. 
- Normalize Responses outputs to existing internal types by mapping assistant text to `NormalizedAssistantMessage.content` and function-call items to `NormalizedToolCall`/`NormalizedToolFunction`, and emit `RuntimeStreamEvent` events including `text_delta`, `tool_call_delta`, `usage`, and a `completed` terminal with `RuntimeTerminalMetadata`. 
- Extend runtime types in `chatsnack/runtime/types.py` to retain `metadata` on `NormalizedCompletionResult` and `RuntimeTerminalMetadata` so `response_id`, `previous_response_id`, `assistant_phase`, and provider extras are carried through normalized results. 
- Export `ResponsesAdapter` from `chatsnack/runtime/__init__.py` and add focused tests in `tests/runtime/test_responses_adapter.py` covering request mapping, `store=false`, normalization, continuation metadata, and profile/model defaults. 

### Testing
- Ran the runtime adapter unit tests: `PYTHONPATH=. pytest -q tests/runtime/test_chat_completions_adapter.py tests/runtime/test_responses_adapter.py` which completed with `7 passed`. 
- An initial test invocation without `PYTHONPATH` failed during collection due to import path configuration, and the subsequent invocation with `PYTHONPATH=.` succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4548395188331b5d413aa8c238934)