### PR TITLE
Add runtime selection hook for Responses and expand Phase 2 parity tests

### DIFF
--- a/chatsnack/chat/__init__.py
+++ b/chatsnack/chat/__init__.py
@@ -8,7 +8,7 @@ from datafiles import datafile
 
 from ..aiclient import AiClient
 from ..defaults import CHATSNACK_BASE_DIR
-from ..runtime import ChatCompletionsAdapter
+from ..runtime import ChatCompletionsAdapter, ResponsesAdapter
 from .mixin_query import ChatQueryMixin
 from .mixin_params import ChatParams, ChatParamsMixin
 from .mixin_serialization import DatafileMixin, ChatSerializationMixin
@@ -64,6 +64,7 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
         auto_execute = kwargs.pop("auto_execute", None)
         tool_choice = kwargs.pop("tool_choice", None)
         auto_feed = kwargs.pop("auto_feed", None)
+        runtime = kwargs.pop("runtime", None)
         
         # get name from kwargs, if it's there
         if "name" in kwargs:
@@ -143,10 +144,35 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
         self._initial_registry = getattr(self, '_local_registry', None)
 
         self.ai = AiClient()
-        self.runtime = ChatCompletionsAdapter(self.ai)
+        runtime_selector = kwargs.get("runtime_selector")
+        profile = None
+        if hasattr(self, "params") and self.params is not None:
+            profile = getattr(self.params, "profile", None)
+            runtime_selector = runtime_selector or getattr(self.params, "runtime", None)
+        self.runtime = self._select_runtime(runtime=runtime, runtime_selector=runtime_selector, profile=profile)
 
 
    
+    @staticmethod
+    def _is_responses_runtime_selected(runtime_selector) -> bool:
+        if runtime_selector is None:
+            return False
+        if isinstance(runtime_selector, str):
+            return runtime_selector.strip().lower() in {"responses", "responses_api"}
+        return False
+
+    def _select_runtime(self, runtime=None, runtime_selector=None, profile=None):
+        if runtime is not None:
+            return runtime
+
+        if self._is_responses_runtime_selected(runtime_selector):
+            return ResponsesAdapter(self.ai)
+
+        if isinstance(profile, dict) and self._is_responses_runtime_selected(profile.get("runtime")):
+            return ResponsesAdapter(self.ai)
+
+        return ChatCompletionsAdapter(self.ai)
+
     def reset(self) -> object:
         """ Resets the chat prompt to its initial state, returns itself """
         self.name = self._initial_name

--- a/chatsnack/chat/__init__.py
+++ b/chatsnack/chat/__init__.py
@@ -163,6 +163,13 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
 
     def _select_runtime(self, runtime=None, runtime_selector=None, profile=None):
         if runtime is not None:
+            # Recreate known adapter types bound to this chat's own ai client so
+            # that cloned/continued chats are fully independent (not sharing the
+            # source chat's ai_client or any adapter state).
+            if isinstance(runtime, (ResponsesAdapter, ChatCompletionsAdapter)):
+                return type(runtime)(self.ai)
+            # Unknown / custom runtime objects are passed through verbatim to
+            # preserve intentional injection (e.g. test doubles).
             return runtime
 
         if self._is_responses_runtime_selected(runtime_selector):

--- a/chatsnack/chat/mixin_params.py
+++ b/chatsnack/chat/mixin_params.py
@@ -281,6 +281,8 @@ class ChatParams:
     api_key_env: Optional[str] = None
 
     response_pattern: Optional[str] = None  # internal usage, not passed to the API
+    runtime: Optional[str] = None  # internal runtime selector, not passed to provider API
+    profile: Optional[dict] = None  # runtime profile/options, not passed to provider API
 
 
     """
@@ -366,6 +368,10 @@ class ChatParams:
         # response_pattern is for internal usage only; remove it
         if "response_pattern" in out:
             del out["response_pattern"]
+        if "runtime" in out:
+            del out["runtime"]
+        if "profile" in out:
+            del out["profile"]
 
         # Convert tool definitions to API format
         if "tools" in out and out["tools"]:

--- a/chatsnack/chat/mixin_params.py
+++ b/chatsnack/chat/mixin_params.py
@@ -282,7 +282,7 @@ class ChatParams:
 
     response_pattern: Optional[str] = None  # internal usage, not passed to the API
     runtime: Optional[str] = None  # internal runtime selector, not passed to provider API
-    profile: Optional[dict] = None  # runtime profile/options, not passed to provider API
+    profile: Optional[dict] = None  # runtime profile/options; forwarded to adapters, stripped before provider API
 
 
     """
@@ -370,8 +370,6 @@ class ChatParams:
             del out["response_pattern"]
         if "runtime" in out:
             del out["runtime"]
-        if "profile" in out:
-            del out["profile"]
 
         # Convert tool definitions to API format
         if "tools" in out and out["tools"]:

--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -466,11 +466,10 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         prompt, response = await self._submit_for_response_and_prompt(**additional_vars)
         
         # create a new chatprompt with the new name, copy it from this one
-        new_chatprompt = self.__class__()
-        
-        # Copy params if available
-        if hasattr(self, 'params') and self.params is not None:
-            new_chatprompt.params = self.params
+        new_chatprompt = self.__class__(
+            params=getattr(self, "params", None),
+            runtime=getattr(self, "runtime", None),
+        )
 
         logger.trace("Expanded prompt: " + prompt)
         new_chatprompt.add_messages_json(prompt)
@@ -589,8 +588,9 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
     def copy(self, name: str = None, system = None, expand_includes: bool = False, expand_fillings: bool = False, **additional_vars) -> object:
         """ Returns a new ChatPrompt object that is a copy of this one, optionally with a new name ⭐"""
         import copy
+        copied_params = copy.copy(self.params)
         if name is not None:
-            new_chat = self.__class__(name=name)
+            new_chat = self.__class__(name=name, params=copied_params, runtime=getattr(self, "runtime", None))
         else:
             # if the existing name ends with _{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}-{uuid.uuid4()}" then we need to trim that off and add a new one
             # use a regex to match at the end of the name
@@ -601,8 +601,11 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
                 name = self.name[:match.start()]
             else:
                 name = self.name
-            new_chat = self.__class__(name=name + f"_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}-{uuid.uuid4()}")
-        new_chat.params = copy.copy(self.params)
+            new_chat = self.__class__(
+                name=name + f"_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}-{uuid.uuid4()}",
+                params=copied_params,
+                runtime=getattr(self, "runtime", None),
+            )
 
         # copy local registry
         new_chat._local_registry = copy.deepcopy(self._local_registry) if hasattr(self, '_local_registry') else None

--- a/chatsnack/runtime/chat_completions_adapter.py
+++ b/chatsnack/runtime/chat_completions_adapter.py
@@ -62,10 +62,12 @@ class ChatCompletionsAdapter:
         )
 
     def create_completion(self, messages: List[Dict[str, Any]], **kwargs: Any) -> NormalizedCompletionResult:
+        kwargs.pop("profile", None)
         response = self.ai_client.client.chat.completions.create(messages=messages, **kwargs)
         return self._normalize_completion(response)
 
     async def create_completion_a(self, messages: List[Dict[str, Any]], **kwargs: Any) -> NormalizedCompletionResult:
+        kwargs.pop("profile", None)
         response = await self.ai_client.aclient.chat.completions.create(messages=messages, **kwargs)
         return self._normalize_completion(response)
 
@@ -102,6 +104,7 @@ class ChatCompletionsAdapter:
 
     def stream_completion(self, messages: List[Dict[str, Any]], **kwargs: Any):
         kwargs = kwargs.copy()
+        kwargs.pop("profile", None)
         kwargs["stream"] = True
         response_gen = self.ai_client.client.chat.completions.create(messages=messages, **kwargs)
 
@@ -129,6 +132,7 @@ class ChatCompletionsAdapter:
 
     async def stream_completion_a(self, messages: List[Dict[str, Any]], **kwargs: Any):
         kwargs = kwargs.copy()
+        kwargs.pop("profile", None)
         kwargs["stream"] = True
         response_gen = await self.ai_client.aclient.chat.completions.create(messages=messages, **kwargs)
 

--- a/chatsnack/runtime/responses_adapter.py
+++ b/chatsnack/runtime/responses_adapter.py
@@ -146,6 +146,9 @@ class ResponsesAdapter:
                     )
                 )
 
+        if not content_parts and response_dict.get("output_text"):
+            content_parts.append(self._coerce_text(response_dict.get("output_text")))
+
         message = NormalizedAssistantMessage(
             role="assistant",
             content="".join(content_parts) or None,
@@ -187,7 +190,7 @@ class ResponsesAdapter:
         return self._normalize_completion(response, request_kwargs)
 
     def stream_completion(self, messages: List[Dict[str, Any]], **kwargs: Any):
-        request_kwargs = self._build_responses_kwargs(messages, kwargs)
+        """Compatibility shim over non-stream Responses requests; not true provider streaming."""
         index = 0
         try:
             result = self.create_completion(messages, **kwargs)
@@ -214,6 +217,7 @@ class ResponsesAdapter:
             yield RuntimeStreamEvent(type="error", index=index, data={"error": payload.__dict__})
 
     async def stream_completion_a(self, messages: List[Dict[str, Any]], **kwargs: Any):
+        """Compatibility shim over non-stream Responses requests; not true provider streaming."""
         index = 0
         try:
             result = await self.create_completion_a(messages, **kwargs)

--- a/tests/mixins/test_chatparams.py
+++ b/tests/mixins/test_chatparams.py
@@ -105,6 +105,13 @@ def test_get_non_none_params_default_model_fallback(chat_params):
     assert out["model"] == DEFAULT_MODEL_FALLBACK
 
 
+def test_get_non_none_params_preserves_profile(chat_params):
+    chat_params.profile = {"defaults": {"temperature": 0.5}}
+    out = chat_params._get_non_none_params()
+    assert "profile" in out
+    assert out["profile"] == {"defaults": {"temperature": 0.5}}
+
+
 @pytest.mark.asyncio
 async def test_reasoning_model_role_remap_to_developer(chat_params_mixin):
     chat_params_mixin.model = "o1"

--- a/tests/mixins/test_query.py
+++ b/tests/mixins/test_query.py
@@ -165,6 +165,24 @@ def test_default_runtime_selection_preserves_phase0_behavior(chat, monkeypatch):
     assert chat.ask() == "legacy-shape"
 
 
+def test_profile_forwarded_to_adapter_via_submit(chat, monkeypatch):
+    """profile set in ChatParams must be forwarded to adapter.create_completion_a."""
+    captured_kwargs = {}
+
+    async def fake_create_completion_a(messages, **kwargs):
+        captured_kwargs.update(kwargs)
+        return SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=[]))
+
+    profile = {"defaults": {"temperature": 0.7}}
+    chat.params = ChatParams(profile=profile)
+    monkeypatch.setattr(chat.runtime, "create_completion_a", fake_create_completion_a)
+
+    chat.ask()
+
+    assert "profile" in captured_kwargs
+    assert captured_kwargs["profile"] == profile
+
+
 @pytest.mark.asyncio
 async def test_chat_a_tool_recursion_with_responses_runtime(chat, monkeypatch):
     chat.runtime = ResponsesAdapter(chat.ai)

--- a/tests/mixins/test_query.py
+++ b/tests/mixins/test_query.py
@@ -1,5 +1,9 @@
 import pytest
+import json
+from types import SimpleNamespace
 from chatsnack import Chat, Text, CHATSNACK_BASE_DIR
+from chatsnack.chat.mixin_params import ChatParams
+from chatsnack.runtime import ChatCompletionsAdapter, ResponsesAdapter
 from chatsnack.chat.mixin_params import DEFAULT_MODEL_FALLBACK
 
 import os
@@ -67,6 +71,109 @@ def _set_runtime_mode(chat, use_runtime_adapter: bool):
         assert chat.runtime is not None
     else:
         chat.runtime = None
+
+
+
+def test_default_runtime_is_chat_completions_adapter():
+    chat = Chat()
+    assert isinstance(chat.runtime, ChatCompletionsAdapter)
+
+
+def test_runtime_selector_selects_responses_adapter():
+    chat = Chat(runtime_selector="responses")
+    assert isinstance(chat.runtime, ResponsesAdapter)
+
+
+def test_runtime_profile_selects_responses_adapter():
+    chat = Chat(params=ChatParams(runtime="responses"))
+    assert isinstance(chat.runtime, ResponsesAdapter)
+
+
+def test_runtime_injection_takes_precedence_over_selector():
+    runtime = object()
+    chat = Chat(runtime=runtime, runtime_selector="responses")
+    assert chat.runtime is runtime
+
+
+def test_ask_with_responses_runtime_returns_str(chat, monkeypatch):
+    chat.runtime = ResponsesAdapter(chat.ai)
+
+    async def fake_create_completion_a(messages, **kwargs):
+        return SimpleNamespace(message=SimpleNamespace(content="reply", tool_calls=[]))
+
+    monkeypatch.setattr(chat.runtime, "create_completion_a", fake_create_completion_a)
+
+    out = chat.ask()
+    assert isinstance(out, str)
+    assert out == "reply"
+
+
+def test_chat_with_responses_runtime_returns_chat_with_assistant_history(chat, monkeypatch):
+    chat.runtime = ResponsesAdapter(chat.ai)
+
+    async def fake_create_completion_a(messages, **kwargs):
+        return SimpleNamespace(message=SimpleNamespace(content="reply", tool_calls=[]))
+
+    monkeypatch.setattr(chat.runtime, "create_completion_a", fake_create_completion_a)
+
+    result = chat.chat("hello")
+    assert isinstance(result, Chat)
+    assert result.get_messages()[-1] == {"role": "assistant", "content": "reply"}
+
+
+
+def test_default_runtime_selection_preserves_phase0_behavior(chat, monkeypatch):
+    assert isinstance(chat.runtime, ChatCompletionsAdapter)
+
+    async def fake_create_completion_a(messages, **kwargs):
+        return SimpleNamespace(message=SimpleNamespace(content="legacy-shape", tool_calls=[]))
+
+    monkeypatch.setattr(chat.runtime, "create_completion_a", fake_create_completion_a)
+    assert chat.ask() == "legacy-shape"
+
+
+@pytest.mark.asyncio
+async def test_chat_a_tool_recursion_with_responses_runtime(chat, monkeypatch):
+    chat.runtime = ResponsesAdapter(chat.ai)
+    chat.auto_execute = True
+    chat.auto_feed = True
+    chat.user("hello")
+
+    class _ToolCall:
+        id = "call_1"
+        function = SimpleNamespace(name="echo", arguments='{"x":1}')
+
+    class _ToolMessage:
+        content = None
+        tool_calls = [_ToolCall()]
+
+        def model_dump(self):
+            return {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "echo", "arguments": '{"x":1}'},
+                    }
+                ],
+            }
+
+    async def fake_submit(**kwargs):
+        return json.dumps(chat.get_messages()), _ToolMessage()
+
+    async def fake_follow_up(self, prompt, **kwargs):
+        return "final"
+
+    monkeypatch.setattr(chat, "_submit_for_response_and_prompt", fake_submit)
+    monkeypatch.setattr(chat, "execute_tool_call", lambda tc: {"ok": True})
+    monkeypatch.setattr(Chat, "_cleaned_chat_completion", fake_follow_up)
+
+    output = await chat.chat_a()
+    roles = [msg["role"] for msg in output.get_messages()]
+    assert roles == ["user", "assistant", "tool", "assistant"]
+    assert output.get_messages()[-1]["content"] == "final"
 
 def test_copy_chatprompt_same_name():
     """Copying a ChatPrompt with the same name should succeed."""
@@ -167,7 +274,6 @@ def test_copy_chatprompt_generated_name_length():
 
 
 import asyncio
-from types import SimpleNamespace
 
 
 class _FakeMessage:
@@ -332,6 +438,7 @@ async def test_chat_a_parity_tool_recursion_history(chat, monkeypatch, use_runti
     _set_runtime_mode(chat, use_runtime_adapter)
     chat.auto_execute = True
     chat.auto_feed = True
+    chat.user("hello")
 
     class _ToolCall:
         id = "call_1"

--- a/tests/mixins/test_query.py
+++ b/tests/mixins/test_query.py
@@ -118,7 +118,17 @@ def test_chat_with_responses_runtime_returns_chat_with_assistant_history(chat, m
 
     result = chat.chat("hello")
     assert isinstance(result, Chat)
+    assert isinstance(result.runtime, ResponsesAdapter)
     assert result.get_messages()[-1] == {"role": "assistant", "content": "reply"}
+
+
+def test_copy_preserves_responses_runtime_selection_from_params():
+    chat = Chat(params=ChatParams(runtime="responses"))
+    assert isinstance(chat.runtime, ResponsesAdapter)
+
+    copied = chat.copy()
+
+    assert isinstance(copied.runtime, ResponsesAdapter)
 
 
 

--- a/tests/mixins/test_query.py
+++ b/tests/mixins/test_query.py
@@ -131,6 +131,29 @@ def test_copy_preserves_responses_runtime_selection_from_params():
     assert isinstance(copied.runtime, ResponsesAdapter)
 
 
+def test_copy_creates_independent_adapter_instances():
+    """Cloned chats must not share the parent's adapter instance."""
+    chat = Chat(params=ChatParams(runtime="responses"))
+    copied = chat.copy()
+    assert copied.runtime is not chat.runtime
+    assert copied.runtime.ai_client is not chat.runtime.ai_client
+
+
+def test_chat_continuation_creates_independent_adapter_instance(chat, monkeypatch):
+    """chat() continuation must not share the source chat's adapter instance."""
+    chat.runtime = ResponsesAdapter(chat.ai)
+
+    async def fake_create_completion_a(messages, **kwargs):
+        return SimpleNamespace(message=SimpleNamespace(content="reply", tool_calls=[]))
+
+    monkeypatch.setattr(chat.runtime, "create_completion_a", fake_create_completion_a)
+
+    result = chat.chat("hello")
+    assert isinstance(result.runtime, ResponsesAdapter)
+    assert result.runtime is not chat.runtime
+    assert result.runtime.ai_client is not chat.runtime.ai_client
+
+
 
 def test_default_runtime_selection_preserves_phase0_behavior(chat, monkeypatch):
     assert isinstance(chat.runtime, ChatCompletionsAdapter)

--- a/tests/runtime/test_chat_completions_adapter.py
+++ b/tests/runtime/test_chat_completions_adapter.py
@@ -112,3 +112,49 @@ async def test_normalizes_async_stream_errors_into_error_event():
     assert events[0].type == "error"
     assert events[0].schema_version == EVENT_SCHEMA_VERSION
     assert events[0].data["error"]["message"] == "boom"
+
+
+def test_profile_is_stripped_before_api_call():
+    captured = {}
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return _FakeObj(
+            {
+                "model": "gpt-4.1",
+                "choices": [{"finish_reason": "stop", "message": {"role": "assistant", "content": "hi"}}],
+            }
+        )
+
+    ai = SimpleNamespace(client=SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create))))
+    adapter = ChatCompletionsAdapter(ai)
+
+    adapter.create_completion(
+        messages=[{"role": "user", "content": "hello"}],
+        model="gpt-4.1",
+        profile={"defaults": {"temperature": 0.5}},
+    )
+
+    assert "profile" not in captured
+
+
+def test_profile_is_stripped_in_stream_completion():
+    captured = {}
+    chunks = iter([
+        _FakeObj({"model": "gpt-4.1", "choices": [{"finish_reason": "stop", "delta": {"content": "hi"}}]}),
+    ])
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return chunks
+
+    ai = SimpleNamespace(client=SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create))))
+    adapter = ChatCompletionsAdapter(ai)
+
+    list(adapter.stream_completion(
+        messages=[{"role": "user", "content": "hello"}],
+        model="gpt-4.1",
+        profile={"defaults": {"temperature": 0.5}},
+    ))
+
+    assert "profile" not in captured

--- a/tests/runtime/test_responses_adapter.py
+++ b/tests/runtime/test_responses_adapter.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from chatsnack.runtime import ResponsesAdapter
 
 
@@ -11,7 +13,7 @@ class _FakeObj:
         return self.payload
 
 
-def test_maps_compiled_messages_to_responses_input_items_and_defaults_store_false():
+def test_sync_request_path_passes_expected_kwargs_and_defaults_store_false():
     captured = {}
 
     def create(**kwargs):
@@ -22,39 +24,73 @@ def test_maps_compiled_messages_to_responses_input_items_and_defaults_store_fals
     adapter = ResponsesAdapter(ai)
 
     adapter.create_completion(
-        messages=[
-            {"role": "developer", "content": "rules"},
-            {
-                "role": "assistant",
-                "content": None,
-                "tool_calls": [
-                    {
-                        "id": "call_1",
-                        "function": {"name": "lookup", "arguments": '{"q":"tea"}'},
-                    }
-                ],
-            },
-            {"role": "tool", "tool_call_id": "call_1", "content": "tool result"},
-        ],
+        messages=[{"role": "user", "content": "hello"}],
         model="gpt-4.1",
+        reasoning={"effort": "medium"},
     )
 
+    assert captured["model"] == "gpt-4.1"
     assert captured["store"] is False
-    assert captured["input"][0] == {
-        "type": "message",
-        "role": "developer",
-        "content": [{"type": "input_text", "text": "rules"}],
-    }
-    assert captured["input"][1]["type"] == "function_call"
-    assert captured["input"][1]["call_id"] == "call_1"
-    assert captured["input"][2] == {
-        "type": "function_call_output",
-        "call_id": "call_1",
-        "output": "tool result",
-    }
+    assert captured["reasoning"] == {"effort": "medium"}
+    assert captured["input"] == [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "hello"}],
+        }
+    ]
 
 
-def test_normalizes_response_text_tool_calls_and_runtime_metadata():
+@pytest.mark.asyncio
+async def test_async_request_path_passes_expected_kwargs():
+    captured = {}
+
+    async def create(**kwargs):
+        captured.update(kwargs)
+        return _FakeObj({"id": "resp_2", "status": "completed", "model": "gpt-4.1", "output": []})
+
+    ai = SimpleNamespace(aclient=SimpleNamespace(responses=SimpleNamespace(create=create)))
+    adapter = ResponsesAdapter(ai)
+
+    await adapter.create_completion_a(
+        messages=[{"role": "developer", "content": "rules"}],
+        model="gpt-4.1",
+        store=True,
+    )
+
+    assert captured["model"] == "gpt-4.1"
+    assert captured["store"] is True
+    assert captured["input"][0]["role"] == "developer"
+
+
+def test_continuation_previous_response_id_passthrough_and_metadata_mirror():
+    captured = {}
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return _FakeObj(
+            {
+                "id": "resp_abc",
+                "status": "completed",
+                "model": "gpt-4.1",
+                "output": [],
+            }
+        )
+
+    ai = SimpleNamespace(client=SimpleNamespace(responses=SimpleNamespace(create=create)))
+    adapter = ResponsesAdapter(ai)
+
+    result = adapter.create_completion(
+        messages=[{"role": "user", "content": "continue"}],
+        model="gpt-4.1",
+        previous_response_id="resp_prev",
+    )
+
+    assert captured["previous_response_id"] == "resp_prev"
+    assert result.metadata["previous_response_id"] == "resp_prev"
+
+
+def test_normalizes_assistant_text_tool_calls_usage_model_status_and_metadata():
     response = _FakeObj(
         {
             "id": "resp_abc",
@@ -78,50 +114,41 @@ def test_normalizes_response_text_tool_calls_and_runtime_metadata():
         }
     )
 
-    ai = SimpleNamespace(
-        client=SimpleNamespace(responses=SimpleNamespace(create=lambda **kwargs: response))
-    )
+    ai = SimpleNamespace(client=SimpleNamespace(responses=SimpleNamespace(create=lambda **kwargs: response)))
     adapter = ResponsesAdapter(ai)
 
-    result = adapter.create_completion(
-        messages=[{"role": "user", "content": "hello"}],
-        model="gpt-4.1",
-        previous_response_id="resp_prev",
-    )
+    result = adapter.create_completion(messages=[{"role": "user", "content": "hello"}], model="gpt-4.1")
 
     assert result.message.content == "Done."
     assert result.message.tool_calls[0].id == "call_99"
-    assert result.metadata["response_id"] == "resp_abc"
-    assert result.metadata["previous_response_id"] == "resp_prev"
-    assert result.metadata["assistant_phase"] == "completed"
+    assert result.finish_reason == "completed"
+    assert result.model == "gpt-4.1"
     assert result.usage == {"total_tokens": 12}
+    assert result.metadata["response_id"] == "resp_abc"
+    assert result.metadata["assistant_phase"] == "completed"
+    assert result.metadata["provider_extras"]["status"] == "completed"
 
 
-def test_profile_defaults_and_model_specific_options_are_applied():
-    captured = {}
-
-    def create(**kwargs):
-        captured.update(kwargs)
-        return _FakeObj({"id": "resp_2", "status": "completed", "model": "gpt-4.1", "output": []})
-
-    ai = SimpleNamespace(client=SimpleNamespace(responses=SimpleNamespace(create=create)))
-    adapter = ResponsesAdapter(ai)
-
-    adapter.create_completion(
-        messages=[{"role": "user", "content": "hi"}],
-        model="gpt-4.1",
-        profile={
-            "defaults": {"temperature": 0.1, "store": False},
-            "model_defaults": {"gpt-4.1": {"reasoning": {"effort": "medium"}}},
-        },
+def test_normalization_falls_back_to_output_text_when_output_items_missing():
+    response = _FakeObj(
+        {
+            "id": "resp_out_text",
+            "status": "completed",
+            "model": "gpt-4.1",
+            "output_text": "Fallback text",
+            "output": [],
+        }
     )
 
-    assert captured["temperature"] == 0.1
-    assert captured["reasoning"] == {"effort": "medium"}
-    assert captured["store"] is False
+    ai = SimpleNamespace(client=SimpleNamespace(responses=SimpleNamespace(create=lambda **kwargs: response)))
+    adapter = ResponsesAdapter(ai)
+
+    result = adapter.create_completion(messages=[{"role": "user", "content": "hello"}], model="gpt-4.1")
+
+    assert result.message.content == "Fallback text"
 
 
-def test_assistant_history_message_is_encoded_as_input_text():
+def test_profile_default_merge_model_overrides_and_explicit_kwarg_precedence():
     captured = {}
 
     def create(**kwargs):
@@ -132,15 +159,80 @@ def test_assistant_history_message_is_encoded_as_input_text():
     adapter = ResponsesAdapter(ai)
 
     adapter.create_completion(
+        messages=[{"role": "user", "content": "hi"}],
+        model="gpt-4.1",
+        temperature=0.2,
+        profile={
+            "defaults": {"temperature": 0.1, "store": False},
+            "model_defaults": {
+                "gpt-4.1": {"reasoning": {"effort": "medium"}, "temperature": 0.3}
+            },
+        },
+    )
+
+    assert captured["reasoning"] == {"effort": "medium"}
+    assert captured["temperature"] == 0.2
+    assert captured["store"] is False
+
+
+def test_mapping_developer_system_user_assistant_messages_assistant_tool_calls_and_tool_output():
+    captured = {}
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return _FakeObj({"id": "resp_4", "status": "completed", "model": "gpt-4.1", "output": []})
+
+    ai = SimpleNamespace(client=SimpleNamespace(responses=SimpleNamespace(create=create)))
+    adapter = ResponsesAdapter(ai)
+
+    adapter.create_completion(
         messages=[
-            {"role": "assistant", "content": "Prior answer."},
-            {"role": "user", "content": "Follow up?"},
+            {"role": "developer", "content": "rules"},
+            {"role": "system", "content": "system msg"},
+            {"role": "user", "content": "question"},
+            {
+                "role": "assistant",
+                "content": "Prior answer",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {"name": "lookup", "arguments": '{"q":"tea"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "tool result"},
         ],
         model="gpt-4.1",
     )
 
     assert captured["input"][0] == {
         "type": "message",
+        "role": "developer",
+        "content": [{"type": "input_text", "text": "rules"}],
+    }
+    assert captured["input"][1] == {
+        "type": "message",
+        "role": "system",
+        "content": [{"type": "input_text", "text": "system msg"}],
+    }
+    assert captured["input"][2] == {
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": "question"}],
+    }
+    assert captured["input"][3] == {
+        "type": "message",
         "role": "assistant",
-        "content": [{"type": "input_text", "text": "Prior answer."}],
+        "content": [{"type": "input_text", "text": "Prior answer"}],
+    }
+    assert captured["input"][4] == {
+        "type": "function_call",
+        "call_id": "call_1",
+        "name": "lookup",
+        "arguments": '{"q":"tea"}',
+    }
+    assert captured["input"][5] == {
+        "type": "function_call_output",
+        "call_id": "call_1",
+        "output": "tool result",
     }


### PR DESCRIPTION
### Motivation

- Allow the public `Chat` path to select the new OpenAI Responses runtime while keeping `ChatCompletionsAdapter` as the default until parity is proven.
- Keep Responses API I/O isolated to a single adapter and tighten its mapping/normalization to match the current Responses contract.
- Add coverage to validate parity (sync/async, continuation, mapping, normalization, and chat-level behavior) required for Phase 2.

### Description

- Add a small runtime-selection hook to `Chat` that defaults to `ChatCompletionsAdapter` and can pick `ResponsesAdapter` via `runtime_selector`, `params.runtime`, or direct `runtime` injection, keeping selection out of `ChatQueryMixin` (`chatsnack/chat/__init__.py`).
- Extend `ChatParams` with internal `runtime` and `profile` fields and strip them from provider-bound kwargs (`chatsnack/chat/mixin_params.py`).
- Tighten `ResponsesAdapter` normalization to use `response.output` as the primary source and fall back to `output_text` when needed, preserve `previous_response_id`, `store=False` default, and mark stream methods as compatibility shims over non-stream Responses requests (`chatsnack/runtime/responses_adapter.py`).
- Add and expand unit tests to cover sync/async request paths, continuation, normalization (text/tool calls/usage/model/status/metadata), profile/default merging, full message mapping cases, and chat-level runtime-selection and parity scenarios (`tests/runtime/test_responses_adapter.py`, `tests/mixins/test_query.py`).

### Testing

- Ran the focused test command `PYTHONPATH=. pytest -q tests/runtime/test_responses_adapter.py tests/mixins/test_query.py -k 'not live'` as part of validation and iterated fixes until green.
- Final automated test results: the targeted suite completed with all assertions passing: `45 passed, 14 deselected` and two environment-related async teardown warnings that do not affect the assertions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4cd6873448331a08402362d0f837a)