### PR TITLE
Add Responses runtime capability checks, descriptive errors, and bump openai to >=1.66.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Add your OpenAI API key to your .env file. If you don't have a .env file, the li
 ### Learn More!
 Read more below, watch the [intro video](https://www.youtube.com/watch?v=Yjwi54rHrhw) or check out the [Getting Started notebook](notebooks/).
 
+### Response API Support
+If you wish to use the Responses runtime (`runtime_selector="responses"` or `params.runtime="responses"`), chatsnack will require the OpenAI Python client to be `openai>=1.66.0` (or newer) to ensure compatibility.
+
 ## Usage
 
 ### Enjoy a Quick Snack

--- a/chatsnack/aiclient.py
+++ b/chatsnack/aiclient.py
@@ -65,3 +65,26 @@ class AiClient:
         self._api_key = value
         self.aclient.api_key = value
         self.client.api_key = value
+
+    @staticmethod
+    def _supports_responses_endpoint(client) -> bool:
+        responses = getattr(client, "responses", None)
+        return responses is not None and callable(getattr(responses, "create", None))
+
+    def ensure_responses_support(self) -> None:
+        sync_supported = self._supports_responses_endpoint(getattr(self, "client", None))
+        async_supported = self._supports_responses_endpoint(getattr(self, "aclient", None))
+        if sync_supported and async_supported:
+            return
+
+        missing = []
+        if not sync_supported:
+            missing.append("client.responses.create")
+        if not async_supported:
+            missing.append("aclient.responses.create")
+
+        raise RuntimeError(
+            "Responses runtime requires OpenAI clients with Responses endpoints. Missing: "
+            + ", ".join(missing)
+            + ". Upgrade the `openai` package to >=1.66.0 and/or inject compatible clients."
+        )

--- a/chatsnack/chat/__init__.py
+++ b/chatsnack/chat/__init__.py
@@ -173,9 +173,11 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
             return runtime
 
         if self._is_responses_runtime_selected(runtime_selector):
+            self.ai.ensure_responses_support()
             return ResponsesAdapter(self.ai)
 
         if isinstance(profile, dict) and self._is_responses_runtime_selected(profile.get("runtime")):
+            self.ai.ensure_responses_support()
             return ResponsesAdapter(self.ai)
 
         return ChatCompletionsAdapter(self.ai)

--- a/chatsnack/runtime/responses_adapter.py
+++ b/chatsnack/runtime/responses_adapter.py
@@ -17,6 +17,21 @@ class ResponsesAdapter:
     def __init__(self, ai_client):
         self.ai_client = ai_client
 
+    def _get_responses_create(self, *, async_mode: bool = False):
+        client_name = "aclient" if async_mode else "client"
+        client = getattr(self.ai_client, client_name, None)
+        responses = getattr(client, "responses", None) if client is not None else None
+        create = getattr(responses, "create", None) if responses is not None else None
+        if callable(create):
+            return create
+
+        endpoint = f"{client_name}.responses.create"
+        raise RuntimeError(
+            "ResponsesAdapter requires an ai_client exposing "
+            f"`{endpoint}`. Inject a compatible OpenAI client (openai>=1.66.0) "
+            "or select the chat_completions runtime."
+        )
+
     @staticmethod
     def _to_dict(obj: Any) -> Dict[str, Any]:
         if obj is None:
@@ -181,12 +196,12 @@ class ResponsesAdapter:
 
     def create_completion(self, messages: List[Dict[str, Any]], **kwargs: Any) -> NormalizedCompletionResult:
         request_kwargs = self._build_responses_kwargs(messages, kwargs)
-        response = self.ai_client.client.responses.create(**request_kwargs)
+        response = self._get_responses_create(async_mode=False)(**request_kwargs)
         return self._normalize_completion(response, request_kwargs)
 
     async def create_completion_a(self, messages: List[Dict[str, Any]], **kwargs: Any) -> NormalizedCompletionResult:
         request_kwargs = self._build_responses_kwargs(messages, kwargs)
-        response = await self.ai_client.aclient.responses.create(**request_kwargs)
+        response = await self._get_responses_create(async_mode=True)(**request_kwargs)
         return self._normalize_completion(response, request_kwargs)
 
     def stream_completion(self, messages: List[Dict[str, Any]], **kwargs: Any):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ datafiles = "^2.0"
 python-dotenv = "^1.0.0"
 loguru = "^0.6.0"
 nest-asyncio = "^1.5.6"
-openai = "^1.2.4"
+openai = "^1.66.0"
 Flask = {version = "^2.1", optional = true}
 questionary = {version = "^1.10.0", optional = true}
 rich = {version = "^13.3.2", optional = true}

--- a/tests/mixins/test_query.py
+++ b/tests/mixins/test_query.py
@@ -714,3 +714,13 @@ async def test_live_listen_a_stream_parity(use_runtime_adapter):
     assert _POPSICLE in full_text.upper()
     assert listener.is_complete
     assert _POPSICLE in listener.response.upper()
+
+
+def test_runtime_selector_responses_surfaces_aiclient_capability_error(chat):
+    def _raise():
+        raise RuntimeError("missing responses endpoints")
+
+    chat.ai = SimpleNamespace(ensure_responses_support=_raise)
+
+    with pytest.raises(RuntimeError, match="missing responses endpoints"):
+        chat._select_runtime(runtime_selector="responses")

--- a/tests/runtime/test_responses_adapter.py
+++ b/tests/runtime/test_responses_adapter.py
@@ -236,3 +236,30 @@ def test_mapping_developer_system_user_assistant_messages_assistant_tool_calls_a
         "call_id": "call_1",
         "output": "tool result",
     }
+
+
+def test_unsupported_sync_client_raises_descriptive_runtime_error():
+    adapter = ResponsesAdapter(SimpleNamespace(client=SimpleNamespace()))
+
+    with pytest.raises(RuntimeError, match=r"client\.responses\.create"):
+        adapter.create_completion(messages=[{"role": "user", "content": "hello"}], model="gpt-4.1")
+
+
+@pytest.mark.asyncio
+async def test_unsupported_async_client_raises_descriptive_runtime_error():
+    adapter = ResponsesAdapter(SimpleNamespace(aclient=SimpleNamespace()))
+
+    with pytest.raises(RuntimeError, match=r"aclient\.responses\.create"):
+        await adapter.create_completion_a(messages=[{"role": "user", "content": "hello"}], model="gpt-4.1")
+
+
+def test_supported_client_path_succeeds_without_capability_error():
+    ai = SimpleNamespace(
+        client=SimpleNamespace(responses=SimpleNamespace(create=lambda **kwargs: _FakeObj({"id": "resp_ok", "status": "completed", "model": "gpt-4.1", "output": []}))),
+        aclient=SimpleNamespace(responses=SimpleNamespace(create=lambda **kwargs: _FakeObj({"id": "resp_ok", "status": "completed", "model": "gpt-4.1", "output": []}))),
+    )
+    adapter = ResponsesAdapter(ai)
+
+    result = adapter.create_completion(messages=[{"role": "user", "content": "hello"}], model="gpt-4.1")
+
+    assert result.metadata["response_id"] == "resp_ok"


### PR DESCRIPTION
### Motivation

- Ensure the library fails fast and with a clear message when the Responses runtime is selected but the injected OpenAI client lacks the `responses.create` endpoint. 
- Make the `responses` runtime selection safe by validating client capabilities before instantiating the adapter. 
- Require a compatible `openai` package version so the Responses runtime is actually available. 

### Description

- Added `AiClient._supports_responses_endpoint` and `AiClient.ensure_responses_support` to detect and surface missing `responses.create` capabilities on both sync and async clients. 
- Updated `Chat._select_runtime` to call `self.ai.ensure_responses_support()` when `responses` is selected via `runtime`/`profile` or `runtime_selector`. 
- Implemented `ResponsesAdapter._get_responses_create` to locate a callable `responses.create` on `client`/`aclient` and raise a descriptive `RuntimeError` if missing, and switched `create_completion`/`create_completion_a` to use it. 
- Bumped the `openai` dependency in `pyproject.toml` to `^1.66.0` and added a README note explaining that the Responses runtime requires `openai>=1.66.0`. 
- Added unit tests to validate capability checks and error messages: `test_runtime_selector_responses_surfaces_aiclient_capability_error`, `test_unsupported_sync_client_raises_descriptive_runtime_error`, `test_unsupported_async_client_raises_descriptive_runtime_error`, and a success-path `test_supported_client_path_succeeds_without_capability_error`. 

### Testing

- Ran the test suite with `pytest` and the new unit tests for Responses capability checks passed. 
- `test_runtime_selector_responses_surfaces_aiclient_capability_error` passed and verifies `Chat._select_runtime` surfaces the ai client error. 
- `test_unsupported_sync_client_raises_descriptive_runtime_error` and `test_unsupported_async_client_raises_descriptive_runtime_error` passed and assert the raised errors reference the missing endpoints. 
- `test_supported_client_path_succeeds_without_capability_error` passed and verifies the happy path when `responses.create` is present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7103f31bc8331b0bc64ec1b1fc131)