### PR TITLE
Add NewResponsesExamples notebook demonstrating Responses runtime

### DIFF
--- a/notebooks/NewResponsesExamples.ipynb
+++ b/notebooks/NewResponsesExamples.ipynb
@@ -69,7 +69,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "classic = Chat(\"You are a concise tutor.\", model=\"gpt-4.1-mini\")\n",
+        "classic = Chat(\"You are a concise tutor.\", model=\"gpt-5.4-mini\")\n",
         "print(\"Runtime adapter:\", type(classic.runtime).__name__)\n",
         "classic.ask(\"Explain prompt engineering in one sentence.\")\n"
       ]
@@ -91,7 +91,7 @@
         "fresh = Chat(\n",
         "    \"You are a concise tutor.\",\n",
         "    runtime_selector=\"responses\",\n",
-        "    model=\"gpt-4.1-mini\",\n",
+        "    model=\"gpt-5.4-mini\",\n",
         ")\n",
         "print(\"Runtime adapter:\", type(fresh.runtime).__name__)\n",
         "fresh.ask(\"Explain prompt engineering in one sentence.\")\n"
@@ -111,7 +111,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "params = ChatParams(runtime=\"responses\", model=\"gpt-4.1-mini\", temperature=0.2)\n",
+        "params = ChatParams(runtime=\"responses\", model=\"gpt-5.4-mini\", temperature=0.2)\n",
         "teacher = Chat(\"You teach with short examples.\", params=params)\n",
         "teacher.ask(\"Give me a three-step checklist for my first prompt.\")\n"
       ]
@@ -120,10 +120,11 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## Speed taste test: old vs new\n",
-        "This quick benchmark compares *rough end-to-end latency* between runtimes.\n",
+        "## Speed taste test: continuation speed (old vs new)\n",
+        "This benchmark focuses on **follow-on turns in the same chat thread** (continuations).\n",
         "\n",
-        "> Note: network and model load vary. Run a few times and compare medians, not one-off results.\n"
+        "> We warm up one turn, then measure continuation `.chat(...)` calls only.\n",
+        "> Note: network and model load vary. Run multiple times and compare medians.\n"
       ]
     },
     {
@@ -135,29 +136,36 @@
         "from time import perf_counter\n",
         "from statistics import median\n",
         "\n",
-        "def sample_latency(runtime_selector=None, n=3):\n",
-        "    timings = []\n",
-        "    for _ in range(n):\n",
+        "def sample_continuation_latency(runtime_selector=None, rounds=3):\n",
+        "    continuation_timings = []\n",
+        "    for _ in range(rounds):\n",
         "        chat = Chat(\n",
         "            \"Reply in exactly seven words.\",\n",
         "            runtime_selector=runtime_selector,\n",
-        "            model=\"gpt-4.1-mini\",\n",
+        "            model=\"gpt-5.4-mini\",\n",
         "            temperature=0,\n",
         "        )\n",
-        "        t0 = perf_counter()\n",
-        "        chat.ask(\"Say hi to a new chatsnack user.\")\n",
-        "        timings.append(perf_counter() - t0)\n",
-        "    return timings\n",
         "\n",
-        "classic_times = sample_latency(runtime_selector=None, n=3)\n",
-        "responses_times = sample_latency(runtime_selector=\"responses\", n=3)\n",
+        "        # Warm-up turn (not measured): establishes thread state.\n",
+        "        chat = chat.chat(\"Say hello to a brand-new chatsnack user.\")\n",
+        "\n",
+        "        # Measure follow-on requests from the same chat (continuations).\n",
+        "        for i in range(3):\n",
+        "            t0 = perf_counter()\n",
+        "            chat = chat.chat(f\"Continuation turn {i+1}: keep it practical.\")\n",
+        "            continuation_timings.append(perf_counter() - t0)\n",
+        "\n",
+        "    return continuation_timings\n",
+        "\n",
+        "classic_times = sample_continuation_latency(runtime_selector=None, rounds=3)\n",
+        "responses_times = sample_continuation_latency(runtime_selector=\"responses\", rounds=3)\n",
         "\n",
         "classic_med = median(classic_times)\n",
         "responses_med = median(responses_times)\n",
-        "speedup = classic_med / responses_med if responses_med else float('inf')\n",
+        "speedup = classic_med / responses_med if responses_med else float(\"inf\")\n",
         "\n",
-        "print(f\"classic median:   {classic_med:.3f}s -> {classic_times}\")\n",
-        "print(f\"responses median: {responses_med:.3f}s -> {responses_times}\")\n",
+        "print(f\"classic continuation median:   {classic_med:.3f}s -> {classic_times}\")\n",
+        "print(f\"responses continuation median: {responses_med:.3f}s -> {responses_times}\")\n",
         "print(f\"speedup (classic / responses): {speedup:.2f}x\")\n"
       ]
     },

--- a/notebooks/NewResponsesExamples.ipynb
+++ b/notebooks/NewResponsesExamples.ipynb
@@ -1,0 +1,223 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# New Responses Examples \ud83c\udf7f\n",
+        "\n",
+        "Let's do a quick snack-sized walkthrough of chatsnack's Responses runtime.\n",
+        "\n",
+        "This notebook is intentionally beginner-friendly and follows the flavor of the existing chatsnack notebooks.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Setup\n",
+        "\n",
+        "### Got snack?\n",
+        "Install chatsnack and make sure your OpenAI SDK supports the Responses API (`openai>=1.66.0`).\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "!pip install -q chatsnack \"openai>=1.66.0\" python-dotenv\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Got keys?\n",
+        "Put your API key in a local `.env` file:\n",
+        "\n",
+        "```\n",
+        "OPENAI_API_KEY=sk-...\n",
+        "```\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from dotenv import load_dotenv\n",
+        "load_dotenv()\n",
+        "\n",
+        "from chatsnack import Chat\n",
+        "from chatsnack.chat.mixin_params import ChatParams\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Classic runtime (chat completions)\n",
+        "By default, chatsnack uses the chat completions runtime.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "classic = Chat(\"You are a concise tutor.\", model=\"gpt-4.1-mini\")\n",
+        "print(\"Runtime adapter:\", type(classic.runtime).__name__)\n",
+        "classic.ask(\"Explain prompt engineering in one sentence.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## New runtime (responses)\n",
+        "Now switch to the new Responses runtime with one argument.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fresh = Chat(\n",
+        "    \"You are a concise tutor.\",\n",
+        "    runtime_selector=\"responses\",\n",
+        "    model=\"gpt-4.1-mini\",\n",
+        ")\n",
+        "print(\"Runtime adapter:\", type(fresh.runtime).__name__)\n",
+        "fresh.ask(\"Explain prompt engineering in one sentence.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Same runtime choice via `ChatParams`\n",
+        "Useful when you want runtime selection and model settings bundled together.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "params = ChatParams(runtime=\"responses\", model=\"gpt-4.1-mini\", temperature=0.2)\n",
+        "teacher = Chat(\"You teach with short examples.\", params=params)\n",
+        "teacher.ask(\"Give me a three-step checklist for my first prompt.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Speed taste test: old vs new\n",
+        "This quick benchmark compares *rough end-to-end latency* between runtimes.\n",
+        "\n",
+        "> Note: network and model load vary. Run a few times and compare medians, not one-off results.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from time import perf_counter\n",
+        "from statistics import median\n",
+        "\n",
+        "def sample_latency(runtime_selector=None, n=3):\n",
+        "    timings = []\n",
+        "    for _ in range(n):\n",
+        "        chat = Chat(\n",
+        "            \"Reply in exactly seven words.\",\n",
+        "            runtime_selector=runtime_selector,\n",
+        "            model=\"gpt-4.1-mini\",\n",
+        "            temperature=0,\n",
+        "        )\n",
+        "        t0 = perf_counter()\n",
+        "        chat.ask(\"Say hi to a new chatsnack user.\")\n",
+        "        timings.append(perf_counter() - t0)\n",
+        "    return timings\n",
+        "\n",
+        "classic_times = sample_latency(runtime_selector=None, n=3)\n",
+        "responses_times = sample_latency(runtime_selector=\"responses\", n=3)\n",
+        "\n",
+        "classic_med = median(classic_times)\n",
+        "responses_med = median(responses_times)\n",
+        "speedup = classic_med / responses_med if responses_med else float('inf')\n",
+        "\n",
+        "print(f\"classic median:   {classic_med:.3f}s -> {classic_times}\")\n",
+        "print(f\"responses median: {responses_med:.3f}s -> {responses_times}\")\n",
+        "print(f\"speedup (classic / responses): {speedup:.2f}x\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Continue the conversation\n",
+        "`ask()` is a quick one-shot. `chat()` gives you a new chat with history carried forward.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "follow_up = teacher.chat(\"Now rewrite that checklist for a travel planner assistant.\")\n",
+        "follow_up.last\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Optional: stream output\n",
+        "If you want token-style output, iterate `listen(...)`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "for chunk in teacher.listen(\"Give me five tiny prompt-writing tips.\"):\n",
+        "    print(chunk, end=\"\")\n",
+        "print()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "You're ready to snack with the new Responses runtime.\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}


### PR DESCRIPTION
### Motivation
- Provide a beginner-friendly notebook that demonstrates chatsnack's new Responses runtime and how to switch from the classic chat completions runtime. 
- Give users runnable examples for setup, runtime selection via `runtime_selector` and `ChatParams`, simple latency benchmarking, continuing conversations, and streaming output with `listen()`.

### Description
- Add `notebooks/NewResponsesExamples.ipynb` which includes setup instructions and a `!pip install` snippet for `chatsnack` and `openai>=1.66.0` and shows loading keys via `dotenv`.
- Show default (classic) usage with `Chat(...)` and how to switch to the new runtime via `runtime_selector="responses"` and `ChatParams(runtime="responses", ...)`.
- Add a small latency benchmark function `sample_latency(...)` that compares end-to-end median timings of both runtimes and prints speedup results.
- Demonstrate continuing a conversation with `chat()` and streaming token-style output via `listen()`; include notebook metadata for Python 3.11 kernel.

### Testing
- No automated tests were added for the notebook itself. 
- No automated test runs were executed as part of this change and existing test suite was not modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69babaa137708331be1857194086d906)