### PR TITLE
Add Closed Loop Artifact Workflow example to Experimenting notebook

### DIFF
--- a/notebooks/ExperimentingWithChatsnack.ipynb
+++ b/notebooks/ExperimentingWithChatsnack.ipynb
@@ -432,7 +432,7 @@
     {
      "data": {
       "text/plain": [
-       "'🍎🥕🥦🥒🍇🍓🥜🥗🍿🍦🥨🍫'"
+       "'\ud83c\udf4e\ud83e\udd55\ud83e\udd66\ud83e\udd52\ud83c\udf47\ud83c\udf53\ud83e\udd5c\ud83e\udd57\ud83c\udf7f\ud83c\udf66\ud83e\udd68\ud83c\udf6b'"
       ]
      },
      "execution_count": 30,
@@ -479,6 +479,62 @@
    ],
    "source": [
     "print(x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Closed Loop Artifact Workflow\n",
+    "Tool call -> artifact metadata -> file feedback loop, with a YAML trail at the end."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import csv\n",
+    "from chatsnack import Chat, utensil\n",
+    "\n",
+    "@utensil\n",
+    "def build_quick_sales_csv(path: str = \"artifacts/sales_q1.csv\") -> dict:\n",
+    "    \"\"\"Create a tiny CSV artifact and return path metadata for follow-up turns.\"\"\"\n",
+    "    p = Path(path)\n",
+    "    p.parent.mkdir(parents=True, exist_ok=True)\n",
+    "    rows = [\n",
+    "        [\"week\", \"region\", \"sales\"],\n",
+    "        [1, \"north\", 120],\n",
+    "        [1, \"south\", 95],\n",
+    "        [2, \"north\", 142],\n",
+    "        [2, \"south\", 110],\n",
+    "    ]\n",
+    "    with p.open(\"w\", newline=\"\") as f:\n",
+    "        csv.writer(f).writerows(rows)\n",
+    "    return {\"path\": str(p), \"rows\": len(rows) - 1, \"columns\": rows[0]}\n",
+    "\n",
+    "artifact_chat = Chat(\n",
+    "    \"Use tools when helpful. Keep answers short and practical.\",\n",
+    "    runtime_selector=\"responses\",\n",
+    "    utensils=[build_quick_sales_csv],\n",
+    ")\n",
+    "\n",
+    "turn1 = artifact_chat.chat(\n",
+    "    \"Run build_quick_sales_csv, then report artifact path + metadata as YAML.\"\n",
+    ")\n",
+    "artifact_path = \"artifacts/sales_q1.csv\"\n",
+    "artifact_meta = {\"path\": artifact_path, \"bytes\": Path(artifact_path).stat().st_size}\n",
+    "\n",
+    "turn2 = turn1.chat(\n",
+    "    f\"Critique this artifact and propose one refinement. Artifact metadata: {artifact_meta}\",\n",
+    "    files=[artifact_path],\n",
+    ")\n",
+    "\n",
+    "print(turn2.last)\n",
+    "print(turn2.yaml)\n",
+    "\n"
    ]
   }
  ],


### PR DESCRIPTION
### Motivation
- Provide a concise, end-to-end example of an artifact lifecycle in the experimental notebook to demonstrate chatsnack's tool + attachment workflow. 
- Show the common loop of generating an artifact with a local tool, capturing file metadata, passing the artifact back via `files=` for critique/refinement, and emitting a YAML transcript for reproducibility. 

### Description
- Added a new markdown section `## Closed Loop Artifact Workflow` to `notebooks/ExperimentingWithChatsnack.ipynb` with a short one-line description. 
- Inserted a code cell that defines a local `@utensil` function `build_quick_sales_csv` which creates `artifacts/sales_q1.csv` and returns path metadata. 
- Demonstrated an end-to-end chat sequence using `Chat(..., runtime_selector="responses", utensils=[build_quick_sales_csv])` that runs the utensil, captures `artifact_meta`, sends the artifact back with `files=[artifact_path]` for critique, and prints the final assistant reply plus `turn2.yaml`. 

### Testing
- Validated the modified notebook JSON is syntactically correct with `python -m json.tool notebooks/ExperimentingWithChatsnack.ipynb >/dev/null`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5b42759ac8331abcb8b923eda9913)