### PR TITLE
Add MkDocs documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,69 @@
+name: Docs
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      NO_MKDOCS_2_WARNING: "true"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            poetry.lock
+            docs/requirements.txt
+
+      - name: Install package and docs dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install -r docs/requirements.txt
+
+      - name: Build documentation
+        run: mkdocs build --strict
+
+      - name: Configure GitHub Pages
+        if: github.event_name != 'pull_request'
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,8 +9,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: docs-${{ github.ref }}
@@ -59,6 +57,9 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ datafiles/plunkylib/*/*.*
 samples*/*
 dist/**
 build/**
+site/**
 logs/**
 *.db
 _*.yml
@@ -15,6 +16,9 @@ __pycache__
 
 # don't ignore the .gitignore or the env template
 !.gitignore
+!.github/
+!.github/workflows/
+!.github/workflows/*.yml
 
 # we don't want completions even if they are samples
 datafiles/plunkylib/completions/**

--- a/chatsnack/chat/__init__.py
+++ b/chatsnack/chat/__init__.py
@@ -73,6 +73,7 @@ def _runtime_policy_from_env() -> tuple[str, Optional[str]]:
 
 @datafile(CHATSNACK_BASE_DIR + "/{self.name}.txt", manual=True)
 class Text(DatafileMixin):
+    """Reusable text asset that can be saved and expanded in other prompts."""
     name: str
     content: Optional[str] = None
     # TODO: All Text and Chat objects should automatically be added as snack fillings (even if not saved to disk)
@@ -87,21 +88,12 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
     messages: List[Dict[str,Union[str,List[Dict[str,str]]]]] = field(default_factory=lambda: [])
 
     def __init__(self, *args, **kwargs):
-        """ 
-        Initializes the chat prompt
-        :param args: if we get one arg, we'll assume it's the system message
-                        if we get two args, the first is the name and the second is the system message
+        """
+        Initialize a chat from a terse authored shape.
 
-        :param kwargs: (keyword arguments are as follows)
-        :param name: the name of the chat prompt (optional, defaults to _ChatPrompt-<date>-<uuid>)
-        :param params: the engine parameters (optional, defaults to None)
-        :param messages: the messages (optional, defaults to [])
-        :param system: the initial system message (optional, defaults to None)
-        :param engine: the engine name (optional, defaults to None, will overwrite params if specified)
-        :param utensils: tools available to this chat (optional, defaults to None)
-        :param auto_execute: whether to automatically execute tool calls (optional, defaults to True)
-        :param auto_feed: whether to automatically feed tool results back to the model (optional, defaults to True)
-        :param tool_choice: how to choose which tool to use (optional, defaults to "auto")
+        Common forms include `Chat("system message")`,
+        `Chat("Name", "system message")`, `Chat(name="SavedPrompt")`, and
+        `Chat(..., utensils=[...])`.
         """
         # Extract utensil-related parameters first
         utensils = kwargs.pop("utensils", None)
@@ -304,16 +296,18 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
         return ChatCompletionsAdapter(self.ai)
 
     def close_session(self):
+        """Close the active runtime session if the selected runtime supports it."""
         runtime = getattr(self, "runtime", None)
         if hasattr(runtime, "close_session"):
             runtime.close_session()
 
     @classmethod
     def close_all_sessions(cls):
+        """Close every tracked shared Responses WebSocket session."""
         ResponsesWebSocketAdapter.close_all_sessions()
 
     def reset(self) -> object:
-        """ Resets the chat prompt to its initial state, returns itself """
+        """Restore the chat to the state captured immediately after initialization."""
         self.name = self._initial_name
         self.params = self._initial_params
         self.messages = self._initial_messages

--- a/chatsnack/chat/mixin_messages.py
+++ b/chatsnack/chat/mixin_messages.py
@@ -61,7 +61,7 @@ class ChatMessagesMixin:
         return self.add_message("include", chatprompt_name, chat)
     
     def developer(self, content: str, chat=False) -> object:
-        """Alias for system(); accepts a ``developer`` message and stores it as ``system``."""
+        """Alias for `system()` that accepts a `developer` role name."""
         return self.system(content, chat=chat)
 
     def add_message(self, role: str, content: Union[str, List, Dict], chat: bool = False) -> object:

--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -672,7 +672,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
             return self.response
 
     def __call__(self, usermsg=None, **additional_vars) -> object:
-        """ Executes the query as-is and returns a Chat object with the response, shortcut for Chat.chat()"""
+        """Continue the conversation, matching the behavior of `chat()`."""
         if usermsg is not None:
             additional_vars["__user"] = usermsg
         return self.chat(**additional_vars)
@@ -685,7 +685,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         additional_vars = self._prepare_query_vars(usermsg, files=files, images=images, **additional_vars)
         return self._run_sync(self.ask_a(**additional_vars), "ask")
     async def ask_a(self, usermsg=None, files=None, images=None, **additional_vars) -> str:
-        """ Executes the query as-is, async version of ask()"""
+        """Async form of `ask()`."""
         if self.stream:
             raise Exception("Cannot use ask() with a stream")
         additional_vars = self._prepare_query_vars(usermsg, files=files, images=images, **additional_vars)
@@ -707,7 +707,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
             response.start()
         return response
     async def listen_a(self, usermsg=None, async_listen=True, events=False, event_schema="legacy", files=None, images=None, **additional_vars) -> ChatStreamListener:
-        """ Executes the query as-is, async version of listen()"""
+        """Async form of `listen()`."""
         if not self.stream:
             raise Exception("Cannot use listen() without a stream")
         additional_vars = self._prepare_query_vars(usermsg, files=files, images=images, **additional_vars)
@@ -727,7 +727,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         return self._run_sync(self.chat_a(**additional_vars), "chat")
         
     async def chat_a(self, usermsg=None, files=None, images=None, **additional_vars) -> object:
-        """Executes the query as-is, and returns a ChatPrompt object that contains the response. Async version of chat()"""
+        """Async form of `chat()`."""
         additional_vars = self._prepare_query_vars(usermsg, files=files, images=images, **additional_vars)
             
         if self.stream:

--- a/chatsnack/chat/mixin_serialization.py
+++ b/chatsnack/chat/mixin_serialization.py
@@ -8,14 +8,14 @@ def _safe_del_path(datafile_mapper):
 
 class DatafileMixin:
     def save(self, path: str = None):
-        """ Saves the text to disk """
+        """Persist the current datafile-backed object to disk."""
         # path is a cached property so we're going to delete it so it'll get recalculated
         _safe_del_path(self.datafile)
         if path is not None:
             self.datafile.path = Path(path)
         self.datafile.save()
     def load(self, path: str = None):
-        """ Loads the chat prompt from a file, can load from a new path but it won't work with snack expansion/vending """
+        """Load the object from disk, optionally from an explicit path."""
         # path is a cached property so we're going to delete it so it'll get recalculated
         _safe_del_path(self.datafile)
         if path is not None:
@@ -26,12 +26,12 @@ class DatafileMixin:
 class ChatSerializationMixin(DatafileMixin):
     @property
     def json(self) -> str:
-        """ Returns the flattened JSON for use in the API"""
+        """Return the expanded chat messages as JSON for API submission."""
         return json.dumps(self.get_messages())
     
     @property
     def json_unexpanded(self) -> str:
-        """ Returns the unflattened JSON for use in the API"""
+        """Return the chat messages as JSON before include expansion."""
         return json.dumps(self.get_messages(includes_expanded=False))
 
     @property

--- a/chatsnack/chat/mixin_utensil.py
+++ b/chatsnack/chat/mixin_utensil.py
@@ -124,7 +124,7 @@ class ChatUtensilMixin:
             if hasattr(self.params, 'tool_choice') and self.params.tool_choice is None:
                 self.params.tool_choice = "auto"
 
-    def set_utensils(self, utensils):
+    def set_utensils(self, utensils: Any):
         """
         Set the utensils available for this chat.
         

--- a/chatsnack/packs/__init__.py
+++ b/chatsnack/packs/__init__.py
@@ -1,1 +1,3 @@
+"""Built-in reusable chats and helpers for quick experiments with chatsnack."""
+
 from .snackpacks import *

--- a/chatsnack/packs/snackpacks.py
+++ b/chatsnack/packs/snackpacks.py
@@ -1,3 +1,5 @@
+"""Built-in snack packs and vending helpers exposed from `chatsnack.packs`."""
+
 import os
 from ..chat import Chat
 from .module_help_vendor import get_module_inspection_report
@@ -20,6 +22,7 @@ default_pack_path = get_data_path("default_packs")
 
 # ChatPromptProxy class such that whenever you try to call a method on it, it creates a new ChatPrompt and calls the method on that
 class ChatPromptProxy:
+    """Lazy proxy that materializes a `Chat` only when a method is accessed."""
     def __init__(self, default_system_message: str = None, default_engine: str = None):
         self.default_system_message = default_system_message
         self.default_engine = default_engine
@@ -81,6 +84,7 @@ locals().update(default_packs)
 # vending machine class that looks up snackpacks from the default_packs dict as a named attribute of itself
 # e.g. vending.Jane
 class VendingMachine:
+    """Attribute-based access to copies of the built-in snack packs."""
     def __getattr__(self, name):
         if name in default_packs:
             return default_packs[name].copy()

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -1,0 +1,23 @@
+:root {
+  --md-primary-fg-color: #0f766e;
+  --md-accent-fg-color: #d97706;
+}
+
+.hero-copy {
+  font-size: 1.08rem;
+  max-width: 48rem;
+}
+
+.callout-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  margin: 1.5rem 0;
+}
+
+.callout-grid > div {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  background: linear-gradient(180deg, rgba(15, 118, 110, 0.05), rgba(217, 119, 6, 0.04));
+}

--- a/docs/contributor-docs.md
+++ b/docs/contributor-docs.md
@@ -1,0 +1,43 @@
+# Contributor Docs
+
+This site keeps the public path small. The repo still contains deeper material for implementation work.
+
+## Docs authoring workflow
+
+Install docs dependencies into a virtual environment:
+
+```bash
+python -m pip install -e .
+python -m pip install -r docs/requirements.txt
+```
+
+Preview locally:
+
+```bash
+mkdocs serve
+```
+
+Build the site the same way CI does:
+
+```bash
+mkdocs build --strict
+```
+
+## Authoring rules
+
+- teach the `Chat(...)` path first
+- prefer short, copyable examples over provider-shaped setup
+- keep notebook-derived content as edited Markdown pages in `docs/`
+- keep API reference focused on stable public imports
+- add or improve docstrings when a public page would otherwise render thinly
+
+## Repo references
+
+- [Datafiles reference notes](https://github.com/Mattie/chatsnack/blob/master/docs/reference/datafiles.md)
+- [Phase 1 runtime adapter RFC](https://github.com/Mattie/chatsnack/blob/master/docs/rfcs/phase-1-runtime-adapter-rfc.md)
+- [Phase 3 Responses YAML RFC](https://github.com/Mattie/chatsnack/blob/master/docs/rfcs/phase-3-responses-yaml-rfc.md)
+- [Hosted tools and utensils checklist](https://github.com/Mattie/chatsnack/blob/master/docs/projects/phase-4a-hosted-tools-utensils-checklist.md)
+
+## Deployment
+
+The docs workflow in [`.github/workflows/docs.yml`](https://github.com/Mattie/chatsnack/blob/master/.github/workflows/docs.yml) builds on pull requests and deploys to GitHub Pages on pushes to `master`.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,15 @@
+# Examples
+
+These examples are shorter and cleaner than the notebooks, but they come from the same authored patterns.
+
+## Good starting points
+
+- [Prompt Recipes](prompt-recipes.md)
+- [`examples/run_chat_yaml.py`](https://github.com/Mattie/chatsnack/blob/master/examples/run_chat_yaml.py)
+- [`examples/reciperemix.py`](https://github.com/Mattie/chatsnack/blob/master/examples/reciperemix.py)
+- [`examples/snackbar-cli.py`](https://github.com/Mattie/chatsnack/blob/master/examples/snackbar-cli.py)
+
+## Raw notebooks
+
+- [Getting Started notebook](https://github.com/Mattie/chatsnack/blob/master/notebooks/GettingStartedWithChatsnack.ipynb)
+- [Experimenting notebook](https://github.com/Mattie/chatsnack/blob/master/notebooks/ExperimentingWithChatsnack.ipynb)

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,6 +1,6 @@
 # Examples
 
-These examples are shorter and cleaner than the notebooks, but they come from the same authored patterns.
+These examples are short, copyable snacks pulled from the same authored patterns as the notebooks.
 
 ## Good starting points
 

--- a/docs/examples/prompt-recipes.md
+++ b/docs/examples/prompt-recipes.md
@@ -1,0 +1,55 @@
+# Prompt Recipes
+
+## Smoke test
+
+```python
+from chatsnack import Chat
+
+print(Chat("Respond only with the word POPSICLE from now on.").ask("What is your name?"))
+```
+
+## Continue a useful thread
+
+```python
+from chatsnack import Chat
+
+thread = Chat("Respond tersely.").chat("What is chatsnack?")
+thread = thread.chat("Give me two practical examples.")
+print(thread.last)
+```
+
+## Save a prompt asset
+
+```python
+from chatsnack import Chat
+
+chat = Chat(name="SnackPoet").system("Write playful poetry about snacks.")
+chat.save()
+```
+
+## Build a reusable tool-enabled chat
+
+```python
+from chatsnack import Chat, utensil
+
+@utensil
+def get_weather(location: str):
+    """Return a tiny weather payload."""
+    return {"location": location, "forecast": "sunny"}
+
+weather_chat = Chat(
+    "Use tools when helpful and answer briefly.",
+    utensils=[get_weather],
+)
+```
+
+## Compose from saved ingredients
+
+```python
+from chatsnack import Chat, Text
+
+Text(name="SnackVoice", content="Respond like a delighted snack critic.").save()
+
+critic = Chat().system("{text.SnackVoice}")
+print(critic.ask("Review popcorn in one sentence."))
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,58 @@
+# Getting Started
+
+This page takes the shortest path from install to a working `Chat(...)`.
+
+## Install
+
+```bash
+pip install chatsnack
+```
+
+`chatsnack` requires Python 3.10 or newer.
+
+## Add an API key
+
+Add `OPENAI_API_KEY` to a local `.env` file. If a `.env` file is missing, chatsnack will create one in the current working directory the first time the package imports.
+
+## First response
+
+```python
+from chatsnack import Chat
+
+chat = Chat("Respond only with the word POPSICLE from now on.")
+print(chat.ask("What is your name?"))
+```
+
+That pattern is the core mental model:
+
+- `Chat("...")` starts with a system message.
+- `ask("...")` sends a user message and returns the assistant text.
+- `chat("...")` continues the conversation and returns a new `Chat` object.
+
+## Continue a thread
+
+```python
+from chatsnack.packs import ChatsnackHelp
+
+thread = ChatsnackHelp.chat("What is chatsnack?")
+print(thread.response)
+
+thread.user("Respond in only six word sentences from now on.")
+thread.asst("I promise I will do so.")
+print(thread.ask("How should I spend my day?"))
+```
+
+## Use a built-in pack
+
+```python
+from chatsnack.packs import Jolly
+
+thread = Jolly.chat("What snack should I eat?")
+print(thread.last)
+```
+
+## What to read next
+
+- [Chat Basics](guides/chat-basics.md)
+- [YAML and Saved Assets](guides/yaml-and-assets.md)
+- [Utensils](guides/utensils.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 This page takes the shortest path from install to a working `Chat(...)`.
 
-## Install
+## Got snack?
 
 ```bash
 pip install chatsnack
@@ -10,11 +10,11 @@ pip install chatsnack
 
 `chatsnack` requires Python 3.10 or newer.
 
-## Add an API key
+## Got keys?
 
 Add `OPENAI_API_KEY` to a local `.env` file. If a `.env` file is missing, chatsnack will create one in the current working directory the first time the package imports.
 
-## First response
+## Enjoy a quick snack
 
 ```python
 from chatsnack import Chat
@@ -23,13 +23,17 @@ chat = Chat("Respond only with the word POPSICLE from now on.")
 print(chat.ask("What is your name?"))
 ```
 
+> *"POPSICLE."*
+
+If you see `POPSICLE.`, setup worked.
+
 That pattern is the core mental model:
 
 - `Chat("...")` starts with a system message.
 - `ask("...")` sends a user message and returns the assistant text.
 - `chat("...")` continues the conversation and returns a new `Chat` object.
 
-## Continue a thread
+## Keep the chat going
 
 ```python
 from chatsnack.packs import ChatsnackHelp
@@ -42,7 +46,11 @@ thread.asst("I promise I will do so.")
 print(thread.ask("How should I spend my day?"))
 ```
 
-## Use a built-in pack
+> *"Explore hobbies, exercise, connect with friends."*
+
+This is the rhythm the notebooks teach: read one reply with `ask()`, or keep the conversation moving with `chat()`.
+
+## Try a built-in pack
 
 ```python
 from chatsnack.packs import Jolly
@@ -51,7 +59,7 @@ thread = Jolly.chat("What snack should I eat?")
 print(thread.last)
 ```
 
-## What to read next
+## Learn more
 
 - [Chat Basics](guides/chat-basics.md)
 - [YAML and Saved Assets](guides/yaml-and-assets.md)

--- a/docs/guides/chat-basics.md
+++ b/docs/guides/chat-basics.md
@@ -1,0 +1,71 @@
+# Chat Basics
+
+The common path in chatsnack starts from `Chat`.
+
+## `ask()` versus `chat()`
+
+Use `ask()` when we want the assistant text back immediately without creating a continuation object.
+
+```python
+from chatsnack import Chat
+
+chat = Chat("Respond tersely.")
+answer = chat.ask("What is chatsnack?")
+print(answer)
+```
+
+Use `chat()` when we want the next turn as a new `Chat` object.
+
+```python
+from chatsnack import Chat
+
+base = Chat("Respond tersely.")
+thread = base.chat("What is chatsnack?")
+print(thread.response)
+```
+
+## Message chaining
+
+The object stays readable even when we chain.
+
+```python
+from chatsnack import Chat
+
+thread = (
+    Chat("Respond only with the word POPSICLE from now on.")
+    .user("What is your name?")
+    .chat()
+)
+
+print(thread.response)
+```
+
+## Shorthand authoring
+
+- `Chat("...")` treats the first string as a system message.
+- `.ask("...")` and `.chat("...")` treat the string as a user message.
+- `.asst(...)` is an alias for `.assistant(...)`.
+- Calling a chat object directly continues the conversation like `.chat(...)`.
+
+```python
+from chatsnack import Chat
+
+popcorn = (
+    Chat("Respond with the certainty and creativity of a professional writer.")
+    ("Explain 3 rules to writing a clever poem that amazes your friends.")
+    ("Using those tips, write a scrumptious poem about popcorn.")
+)
+
+print(popcorn.last)
+```
+
+## Attachments on the default Responses path
+
+```python
+from chatsnack import Chat
+
+chat = Chat("Review the attachment and answer tersely.")
+print(chat.ask("Summarize these.", files=["./images/chart.png", "./data/sales.csv"]))
+```
+
+Attachment-aware turns stay serialized as expanded YAML blocks while plain text turns stay scalar-first.

--- a/docs/guides/fillings.md
+++ b/docs/guides/fillings.md
@@ -1,0 +1,63 @@
+# Fillings And Composition
+
+Fillings let us build larger prompts from named assets.
+
+## Reuse saved chats
+
+```python
+from chatsnack import Chat
+
+basechat = Chat(name="ExampleIncludedChat").system(
+    "Respond only with the word CARROTSTICKS from now on."
+)
+basechat.save()
+
+anotherchat = Chat().include("ExampleIncludedChat")
+print(anotherchat.ask("What is your name?"))
+```
+
+## Reuse saved text
+
+```python
+from chatsnack import Chat, Text
+
+mytext = Text(
+    name="SnackExplosion",
+    content="Respond only in explosions of snack emojis and happy faces.",
+)
+mytext.save()
+
+explosions = Chat(name="SnackSnackExplosions").system("{text.SnackExplosion}")
+print(explosions.ask("What is your name?"))
+```
+
+## Compose generated outputs
+
+```python
+from chatsnack import Chat
+
+snacknames = Chat(name="FiveSnackNames").system(
+    "Respond with high creativity and confidence."
+).user("Provide 5 random snacks.")
+snacknames.save()
+
+snackdunk = Chat(name="SnackDunk").system(
+    "Respond with high creativity and confidence."
+).user("Provide 3 dips or drinks that are great for snack dipping.")
+snackdunk.save()
+
+snackfull = Chat().system("Respond with high confidence.")
+snackfull.user(
+    """Choose 1 snack from this list:
+{chat.FiveSnackNames}
+
+Choose 1 dunking liquid from this list:
+{chat.SnackDunk}
+
+Recommend the best single snack and dip combo above."""
+)
+
+print(snackfull.chat().yaml)
+```
+
+This keeps the authoring surface small while still enabling multi-step prompt preparation.

--- a/docs/guides/utensils.md
+++ b/docs/guides/utensils.md
@@ -1,0 +1,60 @@
+# Utensils
+
+Local Python functions and hosted OpenAI tools share one `utensils=[...]` surface.
+
+## Local function tools
+
+```python
+from chatsnack import Chat, utensil
+
+@utensil
+def get_weather(location: str, unit: str = "celsius"):
+    """Get the current weather for a location."""
+    return {"temperature": 72, "condition": "sunny", "unit": unit}
+
+chat = Chat(
+    "Use tools only when useful.",
+    utensils=[get_weather],
+)
+```
+
+## Grouped tool namespaces
+
+```python
+from chatsnack import Chat, utensil
+
+crm = utensil.group("crm", "CRM tools for customer lookup.")
+
+@crm
+def get_customer(customer_id: str):
+    """Look up one customer by ID."""
+    return {"id": customer_id}
+
+chat = Chat(
+    "Use CRM tools only when useful.",
+    utensils=[crm, utensil.tool_search],
+)
+```
+
+## Hosted tools
+
+```python
+from chatsnack import Chat, utensil
+
+docs_search = utensil.web_search(domains=["docs.python.org"], sources=True)
+
+chat = Chat(
+    "Use tools only when useful.",
+    utensils=[utensil.tool_search, docs_search],
+)
+chat.reasoning.summary = "auto"
+```
+
+`sources=True` on `web_search(...)` automatically adds the matching `params.responses["include"]` entry.
+
+## Why this surface matters
+
+- local Python tools stay close to Python
+- grouped tools read like named capabilities
+- hosted tools stay off raw provider dicts in the common path
+- the `Chat(...)` constructor still reads like authored code

--- a/docs/guides/yaml-and-assets.md
+++ b/docs/guides/yaml-and-assets.md
@@ -1,0 +1,63 @@
+# YAML And Saved Assets
+
+One of chatsnack's best ideas is that chats are durable prompt assets.
+
+## Inspect YAML early
+
+```python
+from chatsnack import Chat
+
+chat = (
+    Chat("Respond only with the word POPSICLE from now on.")
+    .user("What is your name?")
+    .chat()
+)
+
+print(chat.yaml)
+```
+
+```yaml
+messages:
+  - system: Respond only with the word POPSICLE from now on.
+  - user: What is your name?
+  - assistant: POPSICLE.
+```
+
+## Save and reload a chat
+
+```python
+from chatsnack import Chat
+
+chat = Chat("Respond only with the word POPSICLE from now on.")
+chat.name = "Popsicle"
+chat.save()
+
+saved = Chat(name="Popsicle")
+print(saved.ask("What is your name?"))
+```
+
+## Save reusable text
+
+```python
+from chatsnack import Text
+
+voice = Text(
+    name="SnackExplosion",
+    content="Respond only in explosions of snack emojis and happy faces.",
+)
+voice.save()
+```
+
+`Text` objects let us keep prompt fragments in files instead of large strings embedded in Python code.
+
+## Parameter changes also serialize
+
+```python
+from chatsnack import Chat
+
+wisechat = Chat("Respond with professional writing based on the user query.")
+wisechat.user("Author an alliterative poem about good snacks to eat with coffee.")
+wisechat.model = "gpt-5-chat-latest"
+```
+
+That keeps a prompt asset close to the exact runtime configuration we meant to use.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,10 +2,16 @@
 
 chatsnack treats prompt work as something we author, save, remix, and compose.
 
+Wouldn't you rather your prompts be reusable rather than one-off code?
+
+Wouldn't you like to be able to work with them quickly in notebooks as you develop, but also save them as YAML files that can be version controlled, shared with non-coders, and loaded back into Python objects when you need to run them?
+
+If so, then chatsnack is your kind of library. It is a bit magical, silly, and opinionated, but it's intended to hide a lot of the provider API surface in a way that is flexible and compact.
+
 ![chatsnack features](chatsnack_features_smaller.jpg)
 
 {:.hero-copy}
-It's snack time. These docs start with a tiny smoke test, then move into YAML-backed chats, saved prompt assets, fillings, and utensils.
+## Chatsnack Guides
 
 <div class="callout-grid" markdown>
 <div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,41 +1,34 @@
 # chatsnack
 
-chatsnack is a Python library for authored chat workflows with reusable prompt assets, YAML-backed chats, and Python-native tools.
+chatsnack treats prompt work as something we author, save, remix, and compose.
 
 ![chatsnack features](chatsnack_features_smaller.jpg)
 
 {:.hero-copy}
-These docs focus on the common path we want people to learn first: start from `Chat(...)`, use `ask()` and `chat()` intentionally, save durable YAML assets, compose prompts with fillings, and add tools through `utensils=[...]`.
+It's snack time. These docs start with a tiny smoke test, then move into YAML-backed chats, saved prompt assets, fillings, and utensils.
 
 <div class="callout-grid" markdown>
 <div>
-### Start Here
+### Start Snacking
 
 - [Getting Started](getting-started.md)
 - [Chat Basics](guides/chat-basics.md)
 </div>
 <div>
-### Build With Assets
+### Save Ingredients
 
 - [YAML and Saved Assets](guides/yaml-and-assets.md)
 - [Fillings and Composition](guides/fillings.md)
 </div>
 <div>
-### Add Tools
+### Reach For Utensils
 
 - [Utensils](guides/utensils.md)
 - [API Reference](reference/index.md)
 </div>
 </div>
 
-## Why chatsnack
-
-- `Chat` is the center of gravity for one-shot prompts and continuing threads.
-- Chats serialize cleanly to YAML, so prompt work can live in version control.
-- Reusable `Text` and saved chats make composition part of the product.
-- `utensils=[...]` keeps local functions and hosted tools on one authored surface.
-
-## Quick snack
+## Enjoy a quick snack
 
 ```python
 from chatsnack import Chat
@@ -44,7 +37,19 @@ chat = Chat("Respond only with the word POPSICLE from now on.")
 print(chat.ask("What is your name?"))
 ```
 
-## What is in this site
+> *"POPSICLE."*
+
+If that works, chatsnack is up and ready.
+
+## Why chatsnack feels like chatsnack
+
+- `Chat` is the center of gravity for one-shot prompts and continuing threads.
+- Chats serialize cleanly to YAML, so prompt work can live in version control.
+- Reusable `Text` and saved chats make composition part of the product.
+- `utensils=[...]` keeps local functions and hosted tools on one authored surface.
+- The same small mental model scales from a tiny snack to more ambitious prompt craft.
+
+## Learn more
 
 - **Getting Started** trims the README and notebook flow into one short first run.
 - **Guides** explain the product story in the order people tend to need it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,58 @@
+# chatsnack
+
+chatsnack is a Python library for authored chat workflows with reusable prompt assets, YAML-backed chats, and Python-native tools.
+
+![chatsnack features](chatsnack_features_smaller.jpg)
+
+{:.hero-copy}
+These docs focus on the common path we want people to learn first: start from `Chat(...)`, use `ask()` and `chat()` intentionally, save durable YAML assets, compose prompts with fillings, and add tools through `utensils=[...]`.
+
+<div class="callout-grid" markdown>
+<div>
+### Start Here
+
+- [Getting Started](getting-started.md)
+- [Chat Basics](guides/chat-basics.md)
+</div>
+<div>
+### Build With Assets
+
+- [YAML and Saved Assets](guides/yaml-and-assets.md)
+- [Fillings and Composition](guides/fillings.md)
+</div>
+<div>
+### Add Tools
+
+- [Utensils](guides/utensils.md)
+- [API Reference](reference/index.md)
+</div>
+</div>
+
+## Why chatsnack
+
+- `Chat` is the center of gravity for one-shot prompts and continuing threads.
+- Chats serialize cleanly to YAML, so prompt work can live in version control.
+- Reusable `Text` and saved chats make composition part of the product.
+- `utensils=[...]` keeps local functions and hosted tools on one authored surface.
+
+## Quick snack
+
+```python
+from chatsnack import Chat
+
+chat = Chat("Respond only with the word POPSICLE from now on.")
+print(chat.ask("What is your name?"))
+```
+
+## What is in this site
+
+- **Getting Started** trims the README and notebook flow into one short first run.
+- **Guides** explain the product story in the order people tend to need it.
+- **Examples** collect a few compact patterns pulled from the notebooks and scripts.
+- **API Reference** covers the stable public surface used in the guides.
+
+## Raw source material
+
+- [README on GitHub](https://github.com/Mattie/chatsnack/blob/master/README.md)
+- [Getting Started notebook](https://github.com/Mattie/chatsnack/blob/master/notebooks/GettingStartedWithChatsnack.ipynb)
+- [Experimenting notebook](https://github.com/Mattie/chatsnack/blob/master/notebooks/ExperimentingWithChatsnack.ipynb)

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -1,0 +1,55 @@
+# Philosophy
+
+chatsnack treats prompt work as something we author, save, remix, and compose.
+
+## The short version
+
+- `Chat` is the primary unit of work.
+- Prompt assets deserve a readable file format.
+- Reuse should be easy enough for experiments and strong enough for real systems.
+- Composition matters more than giant prompt strings.
+- Good defaults and terse syntax help us stay in flow.
+- Python tools should stay close to Python.
+
+## `Chat` is the center of gravity
+
+Typical flows look like this:
+
+```python
+from chatsnack import Chat
+
+chat = Chat("Respond tersely.")
+answer = chat.ask("What is chatsnack?")
+thread = chat.chat("Continue with two examples.")
+```
+
+That keeps one-shot prompts and ongoing threads on the same object model.
+
+## Prompts are assets
+
+Chats serialize cleanly to YAML, which means our prompts can be readable, editable, versionable, and reusable.
+
+```yaml
+params:
+  model: gpt-5-chat-latest
+messages:
+  - system: Respond with professional writing based on the user query.
+  - user: Author an alliterative poem about good snacks to eat with coffee.
+```
+
+## Composition is a feature
+
+`Text` assets, saved chats, and fillings let us build prompts from parts instead of maintaining one giant string.
+
+## Opinionated convenience is part of the product
+
+- `Chat("...")` assumes a system message.
+- `.ask("...")` and `.chat("...")` assume a user message.
+- calling a chat object directly continues the conversation.
+- `.asst()` exists because short method names are pleasant in chains.
+
+## Python tools should feel native
+
+`utensils=[...]` keeps tooling in ordinary Python shapes instead of raw request assembly.
+
+For the full project write-up, see [PHILOSOPHY.md on GitHub](https://github.com/Mattie/chatsnack/blob/master/PHILOSOPHY.md).

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -25,6 +25,13 @@ thread = chat.chat("Continue with two examples.")
 
 That keeps one-shot prompts and ongoing threads on the same object model.
 
+The distinction between `ask()` and `chat()` matters:
+
+- `ask()` is for a response we want to read immediately.
+- `chat()` is for progressing the conversation and getting a new `Chat` back.
+
+That is one of the reasons experimentation feels pleasant in chatsnack. The semantics stay simple and visible.
+
 ## Prompts are assets
 
 Chats serialize cleanly to YAML, which means our prompts can be readable, editable, versionable, and reusable.
@@ -37,9 +44,13 @@ messages:
   - user: Author an alliterative poem about good snacks to eat with coffee.
 ```
 
+The durable artifact is a prompt asset we can inspect, keep, and compose into the next thing.
+
 ## Composition is a feature
 
 `Text` assets, saved chats, and fillings let us build prompts from parts instead of maintaining one giant string.
+
+That keeps advanced behavior additive to the common path. We still start from `Chat`, then scale up through saved ingredients and prompt composition.
 
 ## Opinionated convenience is part of the product
 
@@ -48,8 +59,53 @@ messages:
 - calling a chat object directly continues the conversation.
 - `.asst()` exists because short method names are pleasant in chains.
 
+Those shortcuts give chatsnack its rhythm. The code reads like an experimenter's notebook.
+
+## Snack packs express reusable behavior
+
+Snack packs package useful voices and directives so we can reach for them quickly, then keep chatting with the same `Chat` mental model.
+
+That is why the jump from a built-in helper pack to our own saved prompt assets feels natural.
+
+## The notebooks show the intended ceiling
+
+The notebooks are more than tutorials. They show the design target:
+
+- start from `Chat`
+- use `ask()` and `chat()` intentionally
+- inspect YAML early
+- save prompts as assets
+- compose with fillings
+- keep advanced examples on the same mental model
+
+The same primitives that make a quick smoke test pleasant are meant to support richer prompt workflows later.
+
+## chatsnack encourages iterative prompt craft
+
+The workflow has a quiet but important loop:
+
+- try something quickly
+- inspect the resulting chat
+- keep the useful version
+- reuse it as an asset
+- compose it into the next thing
+
+That is a big part of the product philosophy. chatsnack helps us move from a disposable experiment to a reusable prompt artifact without switching tools halfway through.
+
 ## Python tools should feel native
 
 `utensils=[...]` keeps tooling in ordinary Python shapes instead of raw request assembly.
+
+## Playful language, serious ideas
+
+The snack theme is playful, and the underlying ideas are serious:
+
+- prompt assets as files
+- composable prompt ingredients
+- reusable behavior through packs and saved chats
+- terse multi-step authoring
+- Python-native tools
+
+That mix is why chatsnack feels distinctive.
 
 For the full project write-up, see [PHILOSOPHY.md on GitHub](https://github.com/Mattie/chatsnack/blob/master/PHILOSOPHY.md).

--- a/docs/reference/api/chat.md
+++ b/docs/reference/api/chat.md
@@ -1,0 +1,5 @@
+# Chat
+
+`Chat` is the primary unit of work in chatsnack.
+
+::: chatsnack.Chat

--- a/docs/reference/api/packs.md
+++ b/docs/reference/api/packs.md
@@ -1,0 +1,16 @@
+# Packs
+
+The built-in packs are ready-to-use chat presets for quick experiments and demos.
+
+::: chatsnack.packs.snackpacks
+    options:
+      members:
+        - ChatsnackHelp
+        - Confectioner
+        - Jolly
+        - Chester
+        - Jane
+        - Data
+        - Summarizer
+        - Empty
+        - vending

--- a/docs/reference/api/text.md
+++ b/docs/reference/api/text.md
@@ -1,0 +1,5 @@
+# Text
+
+`Text` stores reusable prompt fragments that can be pulled into chats with fillings.
+
+::: chatsnack.Text

--- a/docs/reference/api/utensils.md
+++ b/docs/reference/api/utensils.md
@@ -1,0 +1,15 @@
+# Utensils
+
+The public tool surface revolves around the module-level `utensil` helper plus the reusable grouped and hosted tool types behind it.
+
+## `utensil`
+
+::: chatsnack.utensil.utensil
+
+## `UtensilGroup`
+
+::: chatsnack.utensil.UtensilGroup
+
+## `HostedUtensil`
+
+::: chatsnack.utensil.HostedUtensil

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,14 @@
+# API Reference
+
+The generated reference in this section stays focused on the stable public path we teach in the guides.
+
+## Start here
+
+- [Chat](api/chat.md)
+- [Text](api/text.md)
+- [Utensils](api/utensils.md)
+- [Packs](api/packs.md)
+
+## Scope
+
+The v1 reference favors the authored public surface over transport internals. Runtime adapters, RFCs, and project checklists remain available in-repo and through the contributor page.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+mkdocs>=1.6,<2.0
+mkdocs-material>=9.6,<10.0
+mkdocstrings[python]>=0.30,<1.0
+pymdown-extensions>=10.0,<11.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,100 @@
+site_name: chatsnack
+site_description: Authored guides, examples, and API reference for chatsnack.
+site_url: https://mattie.github.io/chatsnack/
+repo_url: https://github.com/Mattie/chatsnack
+repo_name: Mattie/chatsnack
+edit_uri: edit/master/docs/
+docs_dir: docs
+site_dir: site
+strict: true
+exclude_docs: |
+  projects/
+  rfcs/
+  reference/datafiles.md
+
+theme:
+  name: material
+  features:
+    - content.code.copy
+    - content.action.edit
+    - navigation.footer
+    - navigation.indexes
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - search.suggest
+    - toc.follow
+  palette:
+    - scheme: default
+      primary: teal
+      accent: amber
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            inherited_members: true
+            members_order: source
+            merge_init_into_class: true
+            show_root_heading: true
+            show_root_toc_entry: false
+            show_signature_annotations: true
+            show_source: false
+            filters:
+              - "!^_"
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+
+extra_css:
+  - assets/extra.css
+
+watch:
+  - README.md
+  - PHILOSOPHY.md
+  - chatsnack
+
+validation:
+  nav:
+    omitted_files: ignore
+  links:
+    not_found: warn
+    absolute_links: relative_to_docs
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Guides:
+      - guides/chat-basics.md
+      - guides/yaml-and-assets.md
+      - guides/fillings.md
+      - guides/utensils.md
+  - Examples:
+      - examples/index.md
+      - examples/prompt-recipes.md
+  - API Reference:
+      - reference/index.md
+      - Chat: reference/api/chat.md
+      - Text: reference/api/text.md
+      - Utensils: reference/api/utensils.md
+      - Packs: reference/api/packs.md
+  - Philosophy: philosophy.md
+  - Contributor Docs: contributor-docs.md


### PR DESCRIPTION
## Summary
- add an MkDocs + Material + mkdocstrings docs site
- add a GitHub Pages workflow that builds on pull requests and deploys on pushes to master
- add curated guides, examples, contributor docs, and compact API reference pages
- tighten a few public docstrings so generated reference pages read cleanly

## Verification
- `.venv\Scripts\python.exe -m mkdocs build --strict`