### PR TITLE
Update GitHub Pages workflow for Node 24

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,9 @@ concurrency:
   group: docs-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,10 +25,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -49,7 +52,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: site
 


### PR DESCRIPTION
## Summary
This updates our docs workflow for GitHub's Node 24 transition.

The docs deploy was still succeeding, though GitHub warned that several actions in our workflow were still running on the deprecated Node 20 runtime. GitHub will switch the default JavaScript action runtime to Node 24 on June 2, 2026, and remove Node 20 from runners on September 16, 2026.

## Changes
- opt the workflow into Node 24 now with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`
- update `actions/checkout` from `v4` to `v5`
- update `actions/setup-python` from `v5` to `v6`
- update `actions/upload-pages-artifact` from `v3` to `v4`
- keep the rest of the docs build and Pages deploy flow unchanged

## Notes
GitHub's current official release lines still leave `actions/configure-pages` on `v5` and `actions/deploy-pages` on `v4`, so this PR uses the latest real tags there and lets the Node 24 opt-in handle the runtime transition.

## Verification
- `..\\chatsnack\\.venv\\Scripts\\python.exe -m mkdocs build --strict`