### PR TITLE
[codex] Preserve complex utensil schemas

### DIFF
--- a/chatsnack/chat/mixin_params.py
+++ b/chatsnack/chat/mixin_params.py
@@ -295,9 +295,19 @@ class FunctionDefinition:
             name=data.get("name", ""),
             description=data.get("description")
         )
-        
-        # Extract parameters
-        params = data.get("parameters", {})
+
+        # Compact YAML may carry both a shallow authored parameters mapping and
+        # a richer parameters_json field. Prefer the richer schema when present.
+        params_json = data.get("parameters_json")
+        params = {}
+        if params_json:
+            try:
+                params = json.loads(params_json)
+            except (json.JSONDecodeError, TypeError):
+                params = data.get("parameters", {})
+        else:
+            params = data.get("parameters", {})
+
         if params:
             # Store the complete parameters schema as JSON
             function_def.parameters_json = json.dumps(params)
@@ -335,31 +345,13 @@ class ToolDefinition:
     def from_dict(cls, data: Dict) -> 'ToolDefinition':
         """Create a ToolDefinition from an API-format dictionary"""
         tool_type = data.get("type", "function")
-        
-        # Create the function definition
+
+        # Preserve the original function schema so complex parameter shapes
+        # like anyOf, arrays of objects, and additionalProperties survive the
+        # set_tools()/get_tools() round-trip without collapsing to strings.
         function_data = data.get("function", {})
-        function_def = FunctionDefinition(
-            name=function_data.get("name", ""),
-            description=function_data.get("description")
-        )
-        
-        # Extract parameters
-        params = function_data.get("parameters", {})
-        properties = params.get("properties", {})
-        
-        # Store the original parameters dictionary structure
-        function_def.parameters = {
-            param_name: ParameterSchema.from_dict(param_props)
-            for param_name, param_props in properties.items()
-        }
-        
-        # Extract required fields
-        function_def.required = params.get("required", [])
-        
-        # Extract strict flag
-        if "strict" in function_data:
-            function_def.strict = function_data["strict"]
-        
+        function_def = FunctionDefinition.from_dict(function_data)
+
         return cls(type=tool_type, function=function_def)
 
 @datafile

--- a/tests/test_utensils.py
+++ b/tests/test_utensils.py
@@ -1,9 +1,11 @@
 import os
 import json
 import pytest
+from chatsnack.runtime.responses_common import ResponsesNormalizationMixin
+from chatsnack.yamlformat import YAML as ChatsnackYAML
 from chatsnack.utensil import _REGISTRY, utensil, get_openai_tools, handle_tool_call, get_tool_definitions
 from chatsnack.chat import Chat
-from chatsnack.chat.mixin_params import ChatParams
+from chatsnack.chat.mixin_params import ChatParams, ToolDefinition
 
 # List of engines that support tool calls based on your compatibility chart
 TOOL_COMPATIBLE_ENGINES = [
@@ -125,6 +127,118 @@ def test_get_openai_tools():
     
     assert isinstance(args_val, str), "arguments should be a string"
     assert func_data.get("name") == "test_format_tool"
+
+def _assert_complex_schema_properties(properties):
+    armor_anyof = properties["armor_class"]["anyOf"]
+    speed_anyof = properties["speed"]["anyOf"]
+    traits_anyof = properties["traits"]["anyOf"]
+
+    armor_schema = next(schema for schema in armor_anyof if schema.get("type") == "integer")
+    speed_schema = next(schema for schema in speed_anyof if schema.get("type") == "object")
+    traits_schema = next(schema for schema in traits_anyof if schema.get("type") == "array")
+
+    assert armor_schema["type"] == "integer"
+    assert speed_schema["additionalProperties"]["type"] == "string"
+    assert traits_schema["items"]["type"] == "object"
+    assert traits_schema["items"]["additionalProperties"]["type"] == "string"
+
+def test_tool_definition_round_trip_preserves_complex_parameter_schema():
+    @utensil(name="test_complex_schema_roundtrip_tool", description="A tool with nested parameter shapes")
+    def test_complex_schema_roundtrip_tool(
+        armor_class: int | None = None,
+        speed: dict[str, str] | None = None,
+        traits: list[dict[str, str]] | None = None,
+    ):
+        return {"ok": True}
+
+    tool_dict = get_openai_tools([test_complex_schema_roundtrip_tool])[0]
+    round_tripped = ToolDefinition.from_dict(tool_dict).to_dict()
+    properties = round_tripped["function"]["parameters"]["properties"]
+
+    _assert_complex_schema_properties(properties)
+
+def test_chat_preserves_complex_tool_parameter_schema():
+    @utensil(name="test_complex_schema_tool", description="A tool with nested parameter shapes")
+    def test_complex_schema_tool(
+        armor_class: int | None = None,
+        speed: dict[str, str] | None = None,
+        traits: list[dict[str, str]] | None = None,
+    ):
+        return {"ok": True}
+
+    chat = Chat(
+        name="complex_schema_tool_chat",
+        utensils=[test_complex_schema_tool],
+    )
+
+    tools = chat.params.get_tools()
+    sample = next((t for t in tools if t.get("function", {}).get("name") == "test_complex_schema_tool"), None)
+
+    assert sample is not None, "Complex schema tool should be present in params.get_tools()"
+
+    properties = sample["function"]["parameters"]["properties"]
+
+    _assert_complex_schema_properties(properties)
+
+def test_chat_yaml_round_trip_preserves_complex_tool_parameter_schema():
+    @utensil(name="test_complex_schema_yaml_tool", description="A tool with nested parameter shapes")
+    def test_complex_schema_yaml_tool(
+        armor_class: int | None = None,
+        speed: dict[str, str] | None = None,
+        traits: list[dict[str, str]] | None = None,
+    ):
+        return {"ok": True}
+
+    from io import StringIO
+
+    chat = Chat(
+        name="complex_schema_yaml_chat",
+        utensils=[test_complex_schema_yaml_tool],
+    )
+    data = ChatsnackYAML.deserialize(StringIO(chat.yaml))
+
+    restored_params = ChatParams()
+    restored_params.responses = data["params"].get("responses")
+    restored_params.set_tools(data["params"]["tools"])
+
+    tools = restored_params.get_tools()
+    sample = next((t for t in tools if t.get("function", {}).get("name") == "test_complex_schema_yaml_tool"), None)
+
+    assert sample is not None, "Complex schema tool should survive YAML round-trip"
+
+    properties = sample["function"]["parameters"]["properties"]
+
+    _assert_complex_schema_properties(properties)
+
+def test_build_responses_request_preserves_complex_tool_parameter_schema():
+    @utensil(name="test_complex_schema_request_tool", description="A tool with nested parameter shapes")
+    def test_complex_schema_request_tool(
+        armor_class: int | None = None,
+        speed: dict[str, str] | None = None,
+        traits: list[dict[str, str]] | None = None,
+    ):
+        return {"ok": True}
+
+    chat = Chat(
+        name="complex_schema_request_chat",
+        utensils=[test_complex_schema_request_tool],
+    )
+    mixin = ResponsesNormalizationMixin()
+    request = mixin.build_responses_request(
+        [{"role": "user", "content": "hi"}],
+        {
+            "model": "gpt-5.4",
+            "tools": chat.params.get_tools(),
+        },
+    )
+
+    sample = next((t for t in request["tools"] if t.get("name") == "test_complex_schema_request_tool"), None)
+
+    assert sample is not None, "Complex schema tool should survive request build"
+
+    properties = sample["parameters"]["properties"]
+
+    _assert_complex_schema_properties(properties)
 
 # === Test 3: Tool Call Execution and Tool Call ID Propagation ===
 def test_handle_tool_call():


### PR DESCRIPTION
## Summary
Preserve complex utensil parameter schemas across chatsnack tool serialization paths.

## What changed
- keep full function parameter schemas when `ToolDefinition.from_dict()` rebuilds tool definitions
- honor `parameters_json` during `FunctionDefinition.from_dict()` so compact YAML round-trips keep rich schemas
- add regression tests for direct tool-definition round-trip, `Chat.params.get_tools()`, YAML deserialize/load round-trip, and Responses request building

## Root cause
Our tool schema started rich at utensil creation time, then collapsed during `set_tools()/get_tools()` and compact YAML round-trip. Fields like `int | None`, `dict[str, str]`, and `list[dict[str, str]]` degraded into plain `string` parameters. Model then emitted string payloads for structured fields, which broke callback code that expected mappings and entry objects.

## Impact
- structured tool params stay structured at request time
- YAML-authored or YAML-round-tripped chats keep complex tool schemas
- DnD statblock extraction callbacks and similar structured tools stop receiving schema-induced string payloads

## Validation
- `./.venv/Scripts/python.exe -m pytest tests/test_utensils.py -q -o cache_dir=.pytest_cache_schema_edges8 -k "test_tool_definition_round_trip_preserves_complex_parameter_schema or test_chat_preserves_complex_tool_parameter_schema or test_chat_yaml_round_trip_preserves_complex_tool_parameter_schema or test_build_responses_request_preserves_complex_tool_parameter_schema or test_get_openai_tools or test_handle_tool_call"`
- `./.venv/Scripts/python.exe -m pytest tests/test_responses_tool_normalization.py -q -o cache_dir=.pytest_cache_tool_norm_regress`

## Notes
Pytest emitted Windows cache permission warnings in this environment. Test assertions passed.