### PR TITLE
[codex] Default code_interpreter to auto container

### DIFF
--- a/chatsnack/compact_tools.py
+++ b/chatsnack/compact_tools.py
@@ -6,6 +6,19 @@ RESERVED_CHILD_KEYS = {"description", "args", "required", "defer_loading"}
 BUILTIN_TYPES = {"web_search", "file_search", "tool_search", "code_interpreter", "image_generation", "mcp"}
 
 
+def _apply_builtin_defaults(tool: Dict[str, Any]) -> Dict[str, Any]:
+    """Fill provider-required defaults for compact built-in tool authoring."""
+    if tool.get("type") == "code_interpreter" and "container" not in tool:
+        normalized = dict(tool)
+        normalized["container"] = {"type": "auto"}
+        return normalized
+    return tool
+
+
+def _is_default_code_interpreter_config(cfg: Dict[str, Any]) -> bool:
+    return cfg == {"container": {"type": "auto"}}
+
+
 class CompactToolSyntaxError(ValueError):
     """Raised when compact tool YAML cannot be parsed safely."""
 
@@ -195,7 +208,7 @@ def parse_tools_authoring(entries: Optional[List[Any]]) -> List[Dict[str, Any]]:
     parsed: List[Dict[str, Any]] = []
     for entry in entries:
         if isinstance(entry, str):
-            parsed.append({"type": entry})
+            parsed.append(_apply_builtin_defaults({"type": entry}))
             continue
 
         if not isinstance(entry, dict):
@@ -253,7 +266,7 @@ def parse_tools_authoring(entries: Optional[List[Any]]) -> List[Dict[str, Any]]:
                         if required_args:
                             compiled["required"] = required_args
                         tool["args"] = compiled
-                parsed.append(tool)
+                parsed.append(_apply_builtin_defaults(tool))
                 continue
 
         # fallback passthrough for unknown authored mapping
@@ -432,6 +445,9 @@ def serialize_tools_authoring(provider_tools: Optional[List[Dict[str, Any]]]) ->
 
         cfg = {k: v for k, v in tool.items() if k != "type"}
         if t in BUILTIN_TYPES:
+            if t == "code_interpreter" and _is_default_code_interpreter_config(cfg):
+                out.append(t)
+                continue
             if not cfg:
                 out.append(t)
             else:

--- a/chatsnack/utensil.py
+++ b/chatsnack/utensil.py
@@ -442,7 +442,7 @@ class _UtensilNamespace:
 
     @property
     def code_interpreter(self) -> HostedUtensil:
-        return HostedUtensil("code_interpreter")
+        return HostedUtensil("code_interpreter", {"container": {"type": "auto"}})
 
     @property
     def image_generation(self) -> HostedUtensil:

--- a/tests/test_compact_tools_yaml.py
+++ b/tests/test_compact_tools_yaml.py
@@ -9,8 +9,10 @@ from chatsnack.runtime.types import NormalizedAssistantMessage, NormalizedComple
 from chatsnack.yamlformat import _normalize_data_on_load
 
 
-def test_compact_tools_yaml_round_trip_and_internal_split(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
+def test_compact_tools_yaml_round_trip_and_internal_split(monkeypatch):
+    temp_dir = Path.cwd() / ".tmp_compact_tools_yaml_round_trip"
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(temp_dir)
     data_dir = Path(CHATSNACK_BASE_DIR)
     data_dir.mkdir(parents=True, exist_ok=True)
     authored = {
@@ -53,6 +55,9 @@ def test_compact_tools_yaml_round_trip_and_internal_split(tmp_path, monkeypatch)
     assert "tool_search" in tool_types
     assert "web_search" in tool_types
     assert "namespace" in tool_types
+    code_interpreter = next((t for t in tools if t.get("type") == "code_interpreter"), None)
+    assert code_interpreter is not None
+    assert code_interpreter["container"]["type"] == "auto"
 
     namespace = [t for t in tools if t.get("type") == "namespace"][0]
     children = namespace["tools"]

--- a/tests/test_compact_tools_yaml.py
+++ b/tests/test_compact_tools_yaml.py
@@ -9,9 +9,8 @@ from chatsnack.runtime.types import NormalizedAssistantMessage, NormalizedComple
 from chatsnack.yamlformat import _normalize_data_on_load
 
 
-def test_compact_tools_yaml_round_trip_and_internal_split(monkeypatch):
-    temp_dir = Path.cwd() / ".tmp_compact_tools_yaml_round_trip"
-    temp_dir.mkdir(parents=True, exist_ok=True)
+def test_compact_tools_yaml_round_trip_and_internal_split(monkeypatch, tmp_path):
+    temp_dir = tmp_path
     monkeypatch.chdir(temp_dir)
     data_dir = Path(CHATSNACK_BASE_DIR)
     data_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_hosted_utensils.py
+++ b/tests/test_hosted_utensils.py
@@ -363,10 +363,8 @@ class TestYamlRoundTrip:
         includes = (loaded.params.responses or {}).get("include", [])
         assert "web_search_call.action.sources" in includes
 
-    def test_code_interpreter_yaml_round_trip_uses_scalar_and_auto_container(self, monkeypatch):
-        temp_dir = Path.cwd() / ".tmp_code_interpreter_yaml_round_trip"
-        temp_dir.mkdir(parents=True, exist_ok=True)
-        monkeypatch.chdir(temp_dir)
+    def test_code_interpreter_yaml_round_trip_uses_scalar_and_auto_container(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
         data_dir = Path(CHATSNACK_BASE_DIR)
         data_dir.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_hosted_utensils.py
+++ b/tests/test_hosted_utensils.py
@@ -10,6 +10,7 @@ from ruamel.yaml import YAML
 
 from chatsnack import Chat, utensil, HostedUtensil, CHATSNACK_BASE_DIR
 from chatsnack.chat.mixin_params import ChatParams
+from chatsnack.runtime.responses_common import ResponsesNormalizationMixin
 from chatsnack.utensil import (
     UtensilGroup, UtensilFunction, HostedUtensil,
     get_openai_tools, extract_utensil_functions, collect_include_entries,
@@ -173,7 +174,10 @@ class TestHostedUtensils:
     def test_zero_config_code_interpreter(self):
         ci = utensil.code_interpreter
         assert isinstance(ci, HostedUtensil)
-        assert ci.to_tool_dict() == {"type": "code_interpreter"}
+        assert ci.to_tool_dict() == {
+            "type": "code_interpreter",
+            "container": {"type": "auto"},
+        }
 
     def test_zero_config_image_generation(self):
         ig = utensil.image_generation
@@ -298,6 +302,22 @@ class TestChatIntegration:
         assert len(ns_tools) == 1
         assert ns_tools[0]["name"] == "test_ns"
 
+    def test_code_interpreter_builtin_builds_request_with_default_container(self):
+        chat = Chat("Be helpful.", utensils=[utensil.code_interpreter])
+        mixin = ResponsesNormalizationMixin()
+
+        request = mixin.build_responses_request(
+            [{"role": "user", "content": "hi"}],
+            {
+                "model": "gpt-5.4",
+                "tools": chat.params.get_tools(),
+            },
+        )
+
+        ci = next((t for t in request["tools"] if t.get("type") == "code_interpreter"), None)
+        assert ci is not None
+        assert ci["container"]["type"] == "auto"
+
 
 class TestYamlRoundTrip:
     """Hosted utensils and groups round-trip through YAML correctly."""
@@ -342,6 +362,34 @@ class TestYamlRoundTrip:
         # Include entries survive the round-trip
         includes = (loaded.params.responses or {}).get("include", [])
         assert "web_search_call.action.sources" in includes
+
+    def test_code_interpreter_yaml_round_trip_uses_scalar_and_auto_container(self, monkeypatch):
+        temp_dir = Path.cwd() / ".tmp_code_interpreter_yaml_round_trip"
+        temp_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.chdir(temp_dir)
+        data_dir = Path(CHATSNACK_BASE_DIR)
+        data_dir.mkdir(parents=True, exist_ok=True)
+
+        chat = Chat(
+            "Use tools when useful.",
+            name="yaml_code_interpreter_round_trip_test",
+            utensils=[utensil.code_interpreter],
+        )
+
+        yaml_text = chat.yaml
+        assert "- code_interpreter" in yaml_text
+
+        yaml_obj = YAML()
+        with open(data_dir / "yaml_code_interpreter_round_trip_test.yml", "w", encoding="utf-8") as f:
+            yaml_obj.dump(yaml_obj.load(yaml_text), f)
+
+        loaded = Chat(name="yaml_code_interpreter_round_trip_test")
+        tools = loaded.params.get_tools()
+        ci = next((t for t in tools if t.get("type") == "code_interpreter"), None)
+
+        assert ci is not None
+        assert ci["container"]["type"] == "auto"
+        assert "- code_interpreter" in loaded.yaml
 
 
 # ── Unit tests ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- default the built-in `utensil.code_interpreter` helper to `{"container": {"type": "auto"}}`
- keep compact YAML ergonomic by loading scalar `code_interpreter` into the provider-ready tool shape and saving the default auto-container form back as scalar authoring
- add regression coverage for hosted utensil serialization, request building, and YAML round-trip behavior

## Validation
- `& 'C:\Users\matti\Documents\dev\codex\csnack\chatsnack\.venv\Scripts\python.exe' -m pytest tests\test_hosted_utensils.py tests\test_compact_tools_yaml.py tests\test_phase3_runtime.py -k "code_interpreter or compact_tools_yaml_round_trip_and_internal_split or mixed_function_and_native_tools" -ra -o cache_dir=.pytest_cache_code_interpreter_fix_pr2`
- Result: `6 passed`

## Notes
- existing passthrough support for explicit provider-native `code_interpreter` configs stays intact
- this branch is based on `master` commit `37d71907601cea543b8ad26509e3e7030a36df7d`
