### PR TITLE
Deduplicate async websocket tool calls

### DIFF
--- a/chatsnack/runtime/responses_websocket_adapter.py
+++ b/chatsnack/runtime/responses_websocket_adapter.py
@@ -869,24 +869,10 @@ class ResponsesWebSocketAdapter(ResponsesNormalizationMixin):
             response_dict.setdefault("status", (terminal or {}).get("finish_reason"))
             response_dict.setdefault("model", (terminal or {}).get("model"))
             response_dict.setdefault("usage", (terminal or {}).get("usage"))
-            if tool_calls_by_id:
-                existing_output = list(response_dict.get("output") or [])
-                # Deduplicate tool calls by (type, call_id) to avoid duplicating
-                # entries that may already be present in the terminal payload.
-                seen_keys = set()
-                for item in existing_output:
-                    item_type = item.get("type")
-                    item_call_id = item.get("call_id")
-                    if item_type is not None and item_call_id is not None:
-                        seen_keys.add((item_type, item_call_id))
-                for tool_call in tool_calls_by_id.values():
-                    key = (tool_call.get("type"), tool_call.get("call_id"))
-                    if key in seen_keys:
-                        continue
-                    if key[0] is not None and key[1] is not None:
-                        seen_keys.add(key)
-                    existing_output.append(tool_call)
-                response_dict["output"] = existing_output
+            response_dict["output"] = self._merge_streamed_call_output(
+                response_dict.get("output"),
+                tool_calls_by_id,
+            )
             return self.normalize_completion(response_dict, kwargs)
         response_text = (terminal or {}).get("response_text")
         if not response_text:
@@ -949,10 +935,10 @@ class ResponsesWebSocketAdapter(ResponsesNormalizationMixin):
             response_dict.setdefault("status", (terminal or {}).get("finish_reason"))
             response_dict.setdefault("model", (terminal or {}).get("model"))
             response_dict.setdefault("usage", (terminal or {}).get("usage"))
-            if tool_calls_by_id:
-                existing_output = list(response_dict.get("output") or [])
-                existing_output.extend(tool_calls_by_id.values())
-                response_dict["output"] = existing_output
+            response_dict["output"] = self._merge_streamed_call_output(
+                response_dict.get("output"),
+                tool_calls_by_id,
+            )
             return self.normalize_completion(response_dict, kwargs)
         response_text = (terminal or {}).get("response_text")
         if not response_text:
@@ -976,3 +962,34 @@ class ResponsesWebSocketAdapter(ResponsesNormalizationMixin):
             )
         response_dict["output"].extend(tool_calls_by_id.values())
         return self.normalize_completion(response_dict, kwargs)
+
+    @staticmethod
+    def _merge_streamed_call_output(
+        existing_output: Optional[List[Dict[str, Any]]],
+        streamed_calls_by_id: Dict[str, Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        merged_output = list(existing_output or [])
+        if not streamed_calls_by_id:
+            return merged_output
+
+        # The terminal response payload can already contain completed call items
+        # that were also reconstructed incrementally from streamed deltas. Merge
+        # by (type, call_id) so chat history only executes each provider call once.
+        seen_keys = set()
+        for item in merged_output:
+            if not isinstance(item, dict):
+                continue
+            item_type = item.get("type")
+            item_call_id = item.get("call_id")
+            if item_type is not None and item_call_id is not None:
+                seen_keys.add((item_type, item_call_id))
+
+        for streamed_call in streamed_calls_by_id.values():
+            key = (streamed_call.get("type"), streamed_call.get("call_id"))
+            if key in seen_keys:
+                continue
+            if key[0] is not None and key[1] is not None:
+                seen_keys.add(key)
+            merged_output.append(streamed_call)
+
+        return merged_output

--- a/tests/runtime/test_responses_websocket_adapter.py
+++ b/tests/runtime/test_responses_websocket_adapter.py
@@ -247,6 +247,70 @@ def test_create_completion_preserves_streamed_tool_calls(monkeypatch):
     assert result.message.tool_calls[0].function.arguments == '{"q": "snack"}'
 
 
+def test_create_completion_dedupes_terminal_function_call_already_reconstructed_from_stream(monkeypatch):
+    ai = SimpleNamespace(api_key="x", base_url=None, client=None, aclient=None)
+    adapter = ResponsesWebSocketAdapter(ai, session=ResponsesWebSocketSession(mode="inherit"))
+
+    def fake_stream(messages, **kwargs):
+        yield SimpleNamespace(
+            type="tool_call_delta",
+            index=0,
+            data={"tool_call": {"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": '{"q"'}}},
+        )
+        yield SimpleNamespace(
+            type="tool_call_delta",
+            index=1,
+            data={"tool_call": {"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": ': "snack"}'}}},
+        )
+        yield SimpleNamespace(
+            type="completed",
+            index=2,
+            data={
+                "terminal": {
+                    "finish_reason": "completed",
+                    "model": "gpt-4.1",
+                    "usage": {"total_tokens": 5},
+                    "response_text": "hello",
+                    "metadata": {
+                        "response_id": "resp_1",
+                        "response": {
+                            "id": "resp_1",
+                            "status": "completed",
+                            "model": "gpt-4.1",
+                            "usage": {"total_tokens": 5},
+                            "output": [
+                                {
+                                    "type": "message",
+                                    "role": "assistant",
+                                    "content": [
+                                        {"type": "output_text", "text": "hello"},
+                                        {"type": "reasoning", "summary": [{"text": "step"}]},
+                                    ],
+                                },
+                                {
+                                    "type": "function_call",
+                                    "call_id": "call_1",
+                                    "name": "lookup",
+                                    "arguments": '{"q": "snack"}',
+                                },
+                            ],
+                        },
+                    },
+                }
+            },
+        )
+
+    monkeypatch.setattr(adapter, "stream_completion", fake_stream)
+
+    result = adapter.create_completion(messages=[{"role": "user", "content": "hi"}], model="gpt-4.1")
+
+    assert result.message.content == "hello"
+    assert result.message.reasoning == "step"
+    assert len(result.message.tool_calls) == 1
+    assert result.message.tool_calls[0].id == "call_1"
+    assert result.message.tool_calls[0].function.arguments == '{"q": "snack"}'
+
+
 def test_create_completion_raises_on_stream_error_event(monkeypatch):
     ai = SimpleNamespace(api_key="x", base_url=None, client=None, aclient=None)
     adapter = ResponsesWebSocketAdapter(ai, session=ResponsesWebSocketSession(mode="inherit"))
@@ -288,6 +352,71 @@ async def test_create_completion_a_raises_on_stream_error_event(monkeypatch):
     from chatsnack.runtime.responses_websocket_adapter import ResponsesSessionBusyError
     with pytest.raises(ResponsesSessionBusyError, match="busy session"):
         await adapter.create_completion_a(messages=[{"role": "user", "content": "hi"}], model="gpt-4.1")
+
+
+@pytest.mark.asyncio
+async def test_create_completion_a_dedupes_terminal_function_call_already_reconstructed_from_stream(monkeypatch):
+    ai = SimpleNamespace(api_key="x", base_url=None, client=None, aclient=None)
+    adapter = ResponsesWebSocketAdapter(ai, session=ResponsesWebSocketSession(mode="inherit"))
+
+    async def fake_stream(messages, **kwargs):
+        yield SimpleNamespace(
+            type="tool_call_delta",
+            index=0,
+            data={"tool_call": {"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": '{"q"'}}},
+        )
+        yield SimpleNamespace(
+            type="tool_call_delta",
+            index=1,
+            data={"tool_call": {"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": ': "snack"}'}}},
+        )
+        yield SimpleNamespace(
+            type="completed",
+            index=2,
+            data={
+                "terminal": {
+                    "finish_reason": "completed",
+                    "model": "gpt-4.1",
+                    "usage": {"total_tokens": 5},
+                    "response_text": "hello",
+                    "metadata": {
+                        "response_id": "resp_1",
+                        "response": {
+                            "id": "resp_1",
+                            "status": "completed",
+                            "model": "gpt-4.1",
+                            "usage": {"total_tokens": 5},
+                            "output": [
+                                {
+                                    "type": "message",
+                                    "role": "assistant",
+                                    "content": [
+                                        {"type": "output_text", "text": "hello"},
+                                        {"type": "reasoning", "summary": [{"text": "step"}]},
+                                    ],
+                                },
+                                {
+                                    "type": "function_call",
+                                    "call_id": "call_1",
+                                    "name": "lookup",
+                                    "arguments": '{"q": "snack"}',
+                                },
+                            ],
+                        },
+                    },
+                }
+            },
+        )
+
+    monkeypatch.setattr(adapter, "stream_completion_a", fake_stream)
+
+    result = await adapter.create_completion_a(messages=[{"role": "user", "content": "hi"}], model="gpt-4.1")
+
+    assert result.message.content == "hello"
+    assert result.message.reasoning == "step"
+    assert len(result.message.tool_calls) == 1
+    assert result.message.tool_calls[0].id == "call_1"
+    assert result.message.tool_calls[0].function.arguments == '{"q": "snack"}'
 
 
 def test_shared_session_enforces_single_in_flight_across_adapters(monkeypatch):

--- a/tests/test_phase2_sessions.py
+++ b/tests/test_phase2_sessions.py
@@ -480,3 +480,251 @@ def test_chat_with_utensils_executes_tool_and_feeds_back(monkeypatch):
     # The result should be a Chat with the final response
     assert "Popcorn has 100 calories!" in result.response
     assert call_count["n"] == 2
+
+
+def test_chat_with_websocket_duplicate_provider_tool_call_executes_once(monkeypatch):
+    """A duplicated provider tool call from streamed deltas + terminal payload
+    should execute once and record one assistant/tool turn pair."""
+    from chatsnack.utensil import utensil
+    from chatsnack.runtime import RuntimeStreamEvent
+
+    @utensil
+    def snack_lookup(name: str) -> str:
+        """Look up snack info by name."""
+        return f"{name} has 100 calories"
+
+    chat = Chat(
+        "You are a snack expert.",
+        runtime="responses",
+        session="inherit",
+        utensils=[snack_lookup],
+    )
+
+    call_count = {"n": 0}
+
+    async def fake_stream_completion_a(self, messages, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            yield RuntimeStreamEvent(
+                type="tool_call_delta",
+                index=0,
+                data={
+                    "tool_call": {
+                        "id": "call_abc",
+                        "type": "function",
+                        "function": {"name": "snack_lookup", "arguments": '{"name"'},
+                    }
+                },
+            )
+            yield RuntimeStreamEvent(
+                type="tool_call_delta",
+                index=1,
+                data={
+                    "tool_call": {
+                        "id": "call_abc",
+                        "type": "function",
+                        "function": {"name": "snack_lookup", "arguments": ': "popcorn"}'},
+                    }
+                },
+            )
+            yield RuntimeStreamEvent(
+                type="completed",
+                index=2,
+                data={
+                    "terminal": {
+                        "finish_reason": "completed",
+                        "model": "gpt-5.4-mini",
+                        "usage": {"total_tokens": 5},
+                        "response_text": "",
+                        "metadata": {
+                            "response_id": "resp_tool_1",
+                            "response": {
+                                "id": "resp_tool_1",
+                                "status": "completed",
+                                "model": "gpt-5.4-mini",
+                                "usage": {"total_tokens": 5},
+                                "output": [
+                                    {
+                                        "type": "function_call",
+                                        "call_id": "call_abc",
+                                        "name": "snack_lookup",
+                                        "arguments": '{"name": "popcorn"}',
+                                    }
+                                ],
+                            },
+                        },
+                    }
+                },
+            )
+            return
+
+        yield RuntimeStreamEvent(
+            type="completed",
+            index=0,
+            data={
+                "terminal": {
+                    "finish_reason": "completed",
+                    "model": "gpt-5.4-mini",
+                    "usage": {"total_tokens": 3},
+                    "response_text": "Popcorn has 100 calories!",
+                    "metadata": {
+                        "response_id": "resp_tool_2",
+                        "response": {
+                            "id": "resp_tool_2",
+                            "status": "completed",
+                            "model": "gpt-5.4-mini",
+                            "usage": {"total_tokens": 3},
+                            "output": [
+                                {
+                                    "type": "message",
+                                    "role": "assistant",
+                                    "content": [{"type": "output_text", "text": "Popcorn has 100 calories!"}],
+                                }
+                            ],
+                        },
+                    },
+                }
+            },
+        )
+
+    monkeypatch.setattr(ResponsesWebSocketAdapter, "stream_completion_a", fake_stream_completion_a)
+    result = chat.chat("How many calories in popcorn?")
+
+    assistant_tool_turns = [
+        m for m in result.messages
+        if "assistant" in m and isinstance(m["assistant"], dict) and m["assistant"].get("tool_calls")
+    ]
+    tool_turns = [m for m in result.messages if "tool" in m]
+
+    assert result.response == "Popcorn has 100 calories!"
+    assert call_count["n"] == 2
+    assert len(assistant_tool_turns) == 1
+    assert len(assistant_tool_turns[0]["assistant"]["tool_calls"]) == 1
+    assert assistant_tool_turns[0]["assistant"]["tool_calls"][0]["id"] == "call_abc"
+    assert len(tool_turns) == 1
+    assert tool_turns[0]["tool"]["tool_call_id"] == "call_abc"
+
+
+def test_chat_with_websocket_duplicate_invalid_provider_tool_call_errors_once(monkeypatch):
+    """A duplicated invalid provider tool call should surface one execution error."""
+    from chatsnack.utensil import utensil
+    from chatsnack.runtime import RuntimeStreamEvent
+
+    @utensil
+    def snack_lookup(name: str) -> str:
+        """Look up snack info by name."""
+        return f"{name} has 100 calories"
+
+    chat = Chat(
+        "You are a snack expert.",
+        runtime="responses",
+        session="inherit",
+        utensils=[snack_lookup],
+    )
+
+    call_count = {"n": 0}
+
+    async def fake_stream_completion_a(self, messages, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            yield RuntimeStreamEvent(
+                type="tool_call_delta",
+                index=0,
+                data={
+                    "tool_call": {
+                        "id": "call_bad",
+                        "type": "function",
+                        "function": {"name": "snack_lookup", "arguments": '{"unexpected"'},
+                    }
+                },
+            )
+            yield RuntimeStreamEvent(
+                type="tool_call_delta",
+                index=1,
+                data={
+                    "tool_call": {
+                        "id": "call_bad",
+                        "type": "function",
+                        "function": {"name": "snack_lookup", "arguments": ': "popcorn"}'},
+                    }
+                },
+            )
+            yield RuntimeStreamEvent(
+                type="completed",
+                index=2,
+                data={
+                    "terminal": {
+                        "finish_reason": "completed",
+                        "model": "gpt-5.4-mini",
+                        "usage": {"total_tokens": 5},
+                        "response_text": "",
+                        "metadata": {
+                            "response_id": "resp_tool_bad_1",
+                            "response": {
+                                "id": "resp_tool_bad_1",
+                                "status": "completed",
+                                "model": "gpt-5.4-mini",
+                                "usage": {"total_tokens": 5},
+                                "output": [
+                                    {
+                                        "type": "function_call",
+                                        "call_id": "call_bad",
+                                        "name": "snack_lookup",
+                                        "arguments": '{"unexpected": "popcorn"}',
+                                    }
+                                ],
+                            },
+                        },
+                    }
+                },
+            )
+            return
+
+        yield RuntimeStreamEvent(
+            type="completed",
+            index=0,
+            data={
+                "terminal": {
+                    "finish_reason": "completed",
+                    "model": "gpt-5.4-mini",
+                    "usage": {"total_tokens": 3},
+                    "response_text": "done",
+                    "metadata": {
+                        "response_id": "resp_tool_bad_2",
+                        "response": {
+                            "id": "resp_tool_bad_2",
+                            "status": "completed",
+                            "model": "gpt-5.4-mini",
+                            "usage": {"total_tokens": 3},
+                            "output": [
+                                {
+                                    "type": "message",
+                                    "role": "assistant",
+                                    "content": [{"type": "output_text", "text": "done"}],
+                                }
+                            ],
+                        },
+                    },
+                }
+            },
+        )
+
+    monkeypatch.setattr(ResponsesWebSocketAdapter, "stream_completion_a", fake_stream_completion_a)
+    result = chat.chat("How many calories in popcorn?")
+
+    assistant_tool_turns = [
+        m for m in result.messages
+        if "assistant" in m and isinstance(m["assistant"], dict) and m["assistant"].get("tool_calls")
+    ]
+    tool_turns = [m for m in result.messages if "tool" in m]
+    error_turns = [
+        m for m in tool_turns
+        if "unexpected keyword argument 'unexpected'" in m["tool"]["content"]
+    ]
+
+    assert result.response == "done"
+    assert call_count["n"] == 2
+    assert len(assistant_tool_turns) == 1
+    assert len(assistant_tool_turns[0]["assistant"]["tool_calls"]) == 1
+    assert len(tool_turns) == 1
+    assert len(error_turns) == 1


### PR DESCRIPTION
﻿## Summary
- dedupe streamed and terminal function-call output in the async Responses WebSocket adapter
- reuse the same merge behavior in sync and async paths so one provider call becomes one assistant tool call and one execution
- add adapter and chat-level regressions for duplicated provider tool calls, including the invalid-argument error case

## Testing
- `.\.venv\Scripts\python.exe -m pytest tests\runtime\test_responses_websocket_adapter.py tests\test_phase2_sessions.py tests\test_responses_continuation.py -ra -k "not test_live_http_responses_tool_loop" -o cache_dir=.pytest_cache_ws_dedupe_pr2 --basetemp .\.pytest_tmp_ws_dedupe_pr2`

## Notes
- the live HTTP continuation test was excluded in this verification run because the current environment exposes an invalid `OPENAI_API_KEY` value, which causes a 401 unrelated to this change
- follow-up YAML issue for `parameters_json` / top-level function tool authoring: #58
