### PR TITLE
Preserve auto-feed request kwargs

### DIFF
--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -387,6 +387,31 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         prompt = await self._gather_format(aformatter.async_format, **filling_machine(promptvars))
         return prompt
 
+    def _build_completion_request_kwargs(self) -> Dict[str, object]:
+        """Build provider-facing kwargs for one completion request."""
+        kwargs = {}
+        params = getattr(self, "params", None)
+        if params is not None:
+            kwargs = params._get_non_none_params()
+
+            # Phase 3: merge provider-facing Responses options into the
+            # request kwargs only for Responses-family runtimes.
+            if self._runtime_supports_continuation():
+                responses_opts = params._get_responses_api_options()
+                if responses_opts:
+                    merged = responses_opts.copy()
+                    merged.update(kwargs)
+                    kwargs = merged
+
+        if hasattr(self, "get_tools"):
+            tools = self.get_tools()
+            if tools:
+                kwargs["tools"] = tools
+                if params and params.tool_choice:
+                    kwargs["tool_choice"] = params.tool_choice
+
+        return kwargs
+
     async def _submit_for_response_and_prompt(self, track_continuation: bool = False, **additional_vars):
         """ Executes the query as-is and returns a tuple of the final prompt and the response"""
         prompter = self
@@ -399,29 +424,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
             del additional_vars["__user"]
         prompt = await prompter._build_final_prompt(additional_vars)
         
-        kwargs = {}
-        if hasattr(self, 'params') and self.params is not None:
-            kwargs = self.params._get_non_none_params()
-
-            # Phase 3: merge provider-facing Responses options (text, reasoning,
-            # include, store, …) into the request kwargs so they reach the
-            # Responses API.  These are lower-priority than explicit kwargs.
-            # Only merge when the active runtime is a Responses-family adapter;
-            # Chat Completions does not understand these keys.
-            if self._runtime_supports_continuation():
-                responses_opts = self.params._get_responses_api_options()
-                if responses_opts:
-                    merged = responses_opts.copy()
-                    merged.update(kwargs)
-                    kwargs = merged
-        
-        # Add tools if available
-        if hasattr(self, 'get_tools'):
-            tools = self.get_tools()
-            if tools:
-                kwargs['tools'] = tools
-                if self.params and self.params.tool_choice:
-                    kwargs['tool_choice'] = self.params.tool_choice
+        kwargs = self._build_completion_request_kwargs()
         
         if hasattr(self, 'params') and self.params and self.params.stream:
             # we're streaming so we need to use the wrapper object
@@ -824,6 +827,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
                         follow_up = await temp_chat._cleaned_chat_completion(
                             new_prompt,
                             track_continuation=True,
+                            **temp_chat._build_completion_request_kwargs(),
                         )
                         
                         # Check if the follow-up response has tool calls

--- a/tests/mixins/test_query.py
+++ b/tests/mixins/test_query.py
@@ -2,7 +2,7 @@ import base64
 import pytest
 import json
 from types import SimpleNamespace
-from chatsnack import Chat, Text, CHATSNACK_BASE_DIR
+from chatsnack import Chat, Text, CHATSNACK_BASE_DIR, utensil
 from chatsnack.chat.mixin_params import ChatParams
 from chatsnack.runtime import ChatCompletionsAdapter, ResponsesAdapter, ResponsesWebSocketAdapter
 from chatsnack.chat.mixin_params import DEFAULT_MODEL_FALLBACK
@@ -736,6 +736,57 @@ async def test_chat_a_parity_tool_recursion_history(chat, monkeypatch, use_runti
     roles = [msg["role"] for msg in output.get_messages()]
     assert roles == ["assistant", "tool", "assistant"]
     assert output.get_messages()[-1]["content"] == "final"
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_auto_feed_preserves_request_kwargs(monkeypatch):
+    @utensil(name="issue63_echo", description="Echo test data for issue 63.")
+    def issue63_echo(x: int):
+        return {"x": x}
+
+    captured_calls = []
+
+    async def fake_create_completion_a(self, messages, **kwargs):
+        captured_calls.append({"messages": messages, "kwargs": kwargs.copy()})
+        if len(captured_calls) == 1:
+            tool_call = SimpleNamespace(
+                id="call_issue63",
+                type="function",
+                function=SimpleNamespace(name="issue63_echo", arguments='{"x":7}'),
+            )
+            return SimpleNamespace(
+                message=SimpleNamespace(content=None, tool_calls=[tool_call]),
+                metadata={"response_id": "resp_tool", "assistant_phase": "tool_calls"},
+            )
+        return SimpleNamespace(
+            message=SimpleNamespace(content="final", tool_calls=[]),
+            metadata={"response_id": "resp_final", "assistant_phase": "completed"},
+        )
+
+    monkeypatch.setattr(ChatCompletionsAdapter, "create_completion_a", fake_create_completion_a)
+
+    chat = Chat(
+        "Use tools when useful.",
+        runtime="chat_completions",
+        model="z-ai/glm-5.2",
+        utensils=[issue63_echo],
+        auto_execute=True,
+        auto_feed=True,
+        tool_choice="required",
+    )
+
+    output = await chat.chat_a("Call issue63_echo with x=7.")
+
+    assert len(captured_calls) == 2
+    for call in captured_calls:
+        assert call["kwargs"]["model"] == "z-ai/glm-5.2"
+        assert call["kwargs"]["tool_choice"] == "required"
+        assert call["kwargs"]["tools"][0]["function"]["name"] == "issue63_echo"
+
+    messages = output.get_messages()
+    assert [msg["role"] for msg in messages[-3:]] == ["assistant", "tool", "assistant"]
+    assert messages[-2]["tool_call_id"] == "call_issue63"
+    assert messages[-1]["content"] == "final"
 
 
 def test_listen_events_true_defaults_to_legacy_schema(chat, monkeypatch):


### PR DESCRIPTION
## Summary

- Extract shared completion request kwargs building for `ChatQueryMixin` requests.
- Reuse that kwargs builder for `auto_execute` + `auto_feed` continuation calls.
- Add a regression test proving chat-completions tool follow-ups preserve the configured model, tools, and `tool_choice`.

## Root Cause

The initial request path compiled provider-facing kwargs from `Chat.params`, tools, and `tool_choice`, but the auto-feed tool-result follow-up called `_cleaned_chat_completion()` directly with only `track_continuation=True`. That let `_cleaned_chat_completion()` fall back to `DEFAULT_MODEL_FALLBACK`, which breaks OpenRouter chat-completions runs using a configured non-default model.

Closes #63.

## Validation

- `./.venv/Scripts/python.exe -m pytest tests/mixins/test_query.py::test_chat_completions_auto_feed_preserves_request_kwargs -q`
- `./.venv/Scripts/python.exe -m pytest tests/mixins/test_query.py -q`
- `./.venv/Scripts/python.exe -m pytest tests/test_responses_continuation.py tests/runtime/test_chat_completions_adapter.py -q`
- `git diff --cached --check`