### PR TITLE
Add trusted publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,8 +22,25 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
+  validate-target:
+    name: Validate publish target
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Reject production publish from non-release refs
+        if: inputs.target == 'pypi' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/v')
+        run: |
+          echo "::error::PyPI publishing is restricted to master or v* tags. Current ref is $GITHUB_REF."
+          exit 1
+
+      - name: Confirm publish target
+        run: echo "Publishing target '${{ inputs.target }}' from ref '${{ github.ref }}'."
+
   build:
     name: Build distributions
+    needs: validate-target
     runs-on: ubuntu-latest
     # The build job uploads package distributions for a later publish job.
     # Keep artifact write access out of the OIDC-enabled publish jobs.
@@ -90,7 +107,9 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    if: inputs.target == 'pypi'
+    # Defense in depth: validate-target fails invalid refs before build, and
+    # this condition prevents production upload if the dependency graph changes.
+    if: inputs.target == 'pypi' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,113 @@
+name: Publish package
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Package index to publish to
+        required: true
+        type: choice
+        options:
+          - testpypi
+          - pypi
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-${{ inputs.target }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    # The build job uploads package distributions for a later publish job.
+    # Keep artifact write access out of the OIDC-enabled publish jobs.
+    permissions:
+      contents: read
+      actions: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            poetry.lock
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Check package metadata
+        run: python -m twine check dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v6
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    if: inputs.target == 'testpypi'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/chatsnack/
+    # Read the checked package artifacts and mint an OIDC token for TestPyPI.
+    # Do not grant artifact write access in the publish job.
+    permissions:
+      actions: read
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v6
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish package distributions to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  publish-pypi:
+    name: Publish to PyPI
+    if: inputs.target == 'pypi'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/chatsnack/
+    # Read the checked package artifacts and mint an OIDC token for PyPI.
+    # The pypi environment supplies the required manual approval gate.
+    permissions:
+      actions: read
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v6
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,3 +111,5 @@ jobs:
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true


### PR DESCRIPTION
## Summary

- Add a manual `Publish package` GitHub Actions workflow for TestPyPI and PyPI.
- Use PyPI Trusted Publishing/OIDC via `pypa/gh-action-pypi-publish@release/v1`, with static GitHub environments `testpypi` and `pypi`.
- Keep publishing manual-only; the `pypi` job uses the protected `pypi` environment for required approval before upload.

## Validation

- `.venv\Scripts\python.exe -m build`
- `.venv\Scripts\python.exe -m twine check dist\*`

Result: built `chatsnack-0.6.0.tar.gz` and `chatsnack-0.6.0-py3-none-any.whl`; `twine check` passed for both distributions.