### PR TITLE
Publish package from GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,6 +71,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
 
   verify-testpypi:
     name: Verify TestPyPI install
@@ -83,16 +84,20 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install from TestPyPI
+      - name: Download from TestPyPI
         shell: bash
         run: |
           python -m pip install --upgrade pip
           version="${GITHUB_REF_NAME#v}"
+          mkdir -p testpypi-dist
           for attempt in 1 2 3 4 5; do
-            python -m pip install \
+            python -m pip download \
+              --no-deps \
+              --only-binary=:all: \
               --index-url https://test.pypi.org/simple/ \
-              --extra-index-url https://pypi.org/simple/ \
-              "chatsnack==${version}" && break
+              --dest testpypi-dist \
+              "chatsnack==${version}" \
+              && break
             if [ "${attempt}" = "5" ]; then
               exit 1
             fi
@@ -100,7 +105,9 @@ jobs:
           done
 
       - name: Run import smoke test
-        run: python -c "import chatsnack; from chatsnack import Chat, Text"
+        run: |
+          python -m pip install testpypi-dist/chatsnack-*.whl
+          python -c "import chatsnack; from chatsnack import Chat, Text"
 
   publish-pypi:
     name: Publish to PyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,9 @@ permissions:
   contents: read
 
 concurrency:
-  group: publish-${{ github.event_name == 'workflow_dispatch' && inputs.target || 'pypi' }}-${{ github.ref }}
+  # Use the commit SHA instead of the ref so branch and tag pushes for the
+  # same release commit cannot race each other through the PyPI approval gate.
+  group: publish-${{ github.event_name == 'workflow_dispatch' && inputs.target || 'pypi' }}-${{ github.sha }}
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,9 @@ permissions:
 concurrency:
   # Use the commit SHA instead of the ref so branch and tag pushes for the
   # same release commit cannot race each other through the PyPI approval gate.
-  group: publish-${{ github.event_name == 'workflow_dispatch' && inputs.target || 'pypi' }}-${{ github.sha }}
+  # Read manual inputs from the event payload so push-triggered runs can still
+  # evaluate the workflow-level expression and fall back to PyPI.
+  group: publish-${{ github.event.inputs.target || 'pypi' }}-${{ github.sha }}
   cancel-in-progress: false
 
 env:
@@ -37,19 +39,15 @@ jobs:
 
     steps:
       - name: Reject production publish from non-release refs
-        if: github.event_name == 'workflow_dispatch' && inputs.target == 'pypi' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/v')
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'pypi' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/v')
         run: |
           echo "::error::PyPI publishing is restricted to master or v* tags. Current ref is $GITHUB_REF."
           exit 1
 
       - name: Confirm publish target
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            target="${{ inputs.target }}"
-          else
-            target="pypi"
-          fi
-          echo "Publishing target '$target' from ref '${{ github.ref }}'."
+        env:
+          PUBLISH_TARGET: ${{ github.event.inputs.target || 'pypi' }}
+        run: echo "Publishing target '$PUBLISH_TARGET' from ref '${{ github.ref }}'."
 
   build:
     name: Build distributions
@@ -93,7 +91,7 @@ jobs:
 
   publish-testpypi:
     name: Publish to TestPyPI
-    if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'testpypi'
     needs: build
     runs-on: ubuntu-latest
     environment:
@@ -122,7 +120,7 @@ jobs:
     name: Publish to PyPI
     # Defense in depth: validate-target fails invalid refs before build, and
     # this condition prevents production upload if the dependency graph changes.
-    if: (github.event_name == 'push' || inputs.target == 'pypi') && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
+    if: (github.event_name == 'push' || github.event.inputs.target == 'pypi') && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,11 @@
 name: Publish package
 
 on:
+  push:
+    branches:
+      - master
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       target:
@@ -15,7 +20,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: publish-${{ inputs.target }}-${{ github.ref }}
+  group: publish-${{ github.event_name == 'workflow_dispatch' && inputs.target || 'pypi' }}-${{ github.ref }}
   cancel-in-progress: false
 
 env:
@@ -30,13 +35,19 @@ jobs:
 
     steps:
       - name: Reject production publish from non-release refs
-        if: inputs.target == 'pypi' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/v')
+        if: github.event_name == 'workflow_dispatch' && inputs.target == 'pypi' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/v')
         run: |
           echo "::error::PyPI publishing is restricted to master or v* tags. Current ref is $GITHUB_REF."
           exit 1
 
       - name: Confirm publish target
-        run: echo "Publishing target '${{ inputs.target }}' from ref '${{ github.ref }}'."
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            target="${{ inputs.target }}"
+          else
+            target="pypi"
+          fi
+          echo "Publishing target '$target' from ref '${{ github.ref }}'."
 
   build:
     name: Build distributions
@@ -80,7 +91,7 @@ jobs:
 
   publish-testpypi:
     name: Publish to TestPyPI
-    if: inputs.target == 'testpypi'
+    if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
     needs: build
     runs-on: ubuntu-latest
     environment:
@@ -109,7 +120,7 @@ jobs:
     name: Publish to PyPI
     # Defense in depth: validate-target fails invalid refs before build, and
     # this condition prevents production upload if the dependency graph changes.
-    if: inputs.target == 'pypi' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
+    if: (github.event_name == 'push' || inputs.target == 'pypi') && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,59 +1,20 @@
 name: Publish package
 
 on:
-  push:
-    branches:
-      - master
-    tags:
-      - "v*"
-  workflow_dispatch:
-    inputs:
-      target:
-        description: Package index to publish to
-        required: true
-        type: choice
-        options:
-          - testpypi
-          - pypi
+  release:
+    types: [published]
 
 permissions:
   contents: read
-
-concurrency:
-  # Use the commit SHA instead of the ref so branch and tag pushes for the
-  # same release commit cannot race each other through the PyPI approval gate.
-  # Read manual inputs from the event payload so push-triggered runs can still
-  # evaluate the workflow-level expression and fall back to PyPI.
-  group: publish-${{ github.event.inputs.target || 'pypi' }}-${{ github.sha }}
-  cancel-in-progress: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
-  validate-target:
-    name: Validate publish target
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - name: Reject production publish from non-release refs
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'pypi' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/v')
-        run: |
-          echo "::error::PyPI publishing is restricted to master or v* tags. Current ref is $GITHUB_REF."
-          exit 1
-
-      - name: Confirm publish target
-        env:
-          PUBLISH_TARGET: ${{ github.event.inputs.target || 'pypi' }}
-        run: echo "Publishing target '$PUBLISH_TARGET' from ref '${{ github.ref }}'."
-
   build:
     name: Build distributions
-    needs: validate-target
     runs-on: ubuntu-latest
-    # The build job uploads package distributions for a later publish job.
+    # The build job uploads package distributions for later publish jobs.
     # Keep artifact write access out of the OIDC-enabled publish jobs.
     permissions:
       contents: read
@@ -72,26 +33,22 @@ jobs:
             pyproject.toml
             poetry.lock
 
-      - name: Install build tooling
+      - name: Build and check distributions
         run: |
           python -m pip install --upgrade pip
           python -m pip install build twine
-
-      - name: Build package
-        run: python -m build
-
-      - name: Check package metadata
-        run: python -m twine check dist/*
+          python -m build
+          python -m twine check dist/*
 
       - name: Upload distributions
         uses: actions/upload-artifact@v6
         with:
           name: python-package-distributions
           path: dist/
+          if-no-files-found: error
 
   publish-testpypi:
     name: Publish to TestPyPI
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'testpypi'
     needs: build
     runs-on: ubuntu-latest
     environment:
@@ -114,14 +71,40 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
+
+  verify-testpypi:
+    name: Verify TestPyPI install
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install from TestPyPI
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          version="${GITHUB_REF_NAME#v}"
+          for attempt in 1 2 3 4 5; do
+            python -m pip install \
+              --index-url https://test.pypi.org/simple/ \
+              --extra-index-url https://pypi.org/simple/ \
+              "chatsnack==${version}" && break
+            if [ "${attempt}" = "5" ]; then
+              exit 1
+            fi
+            sleep 15
+          done
+
+      - name: Run import smoke test
+        run: python -c "import chatsnack; from chatsnack import Chat, Text"
 
   publish-pypi:
     name: Publish to PyPI
-    # Defense in depth: validate-target fails invalid refs before build, and
-    # this condition prevents production upload if the dependency graph changes.
-    if: (github.event_name == 'push' || github.event.inputs.target == 'pypi') && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
-    needs: build
+    needs: verify-testpypi
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -141,5 +124,3 @@ jobs:
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          skip-existing: true


### PR DESCRIPTION
## Summary

- Start package publishing from the GitHub Release `published` event.
- Build distributions once, publish them to TestPyPI, verify installation from TestPyPI, then publish to PyPI.
- Keep real PyPI uploads protected by the `pypi` GitHub environment approval gate.
- Remove the mixed push/manual target matrix and its ref/input validation logic.

## Behavior

- Publish a GitHub Release: build distributions, publish to TestPyPI, verify `chatsnack==<tag without leading v>` installs from TestPyPI, then wait at the `pypi` environment approval before uploading to PyPI.
- Docs workflow behavior is unchanged; `.github/workflows/docs.yml` is not touched.

## Validation

- `actionlint 1.7.12 .github/workflows/publish.yml`
- Python workflow assertions for release trigger, removed push/manual/concurrency paths, and PyPI gate
- `.venv\Scripts\python.exe -m build`
- `.venv\Scripts\python.exe -m twine check dist\*`

Result: built `chatsnack-0.6.0.tar.gz` and `chatsnack-0.6.0-py3-none-any.whl`; `twine check` passed for both distributions.