### PR TITLE
Harden WebSocket retry policy

### DIFF
--- a/chatsnack/runtime/responses_websocket_adapter.py
+++ b/chatsnack/runtime/responses_websocket_adapter.py
@@ -165,12 +165,7 @@ class ResponsesWebSocketAdapter(ResponsesNormalizationMixin):
         try:
             conn = client.responses.connect().enter()
         except Exception as exc:
-            raise ResponsesWebSocketTransportError(
-                str(exc) or "socket_connect_failed",
-                code="socket_connect_failed",
-                retriable=True,
-                details={"phase": "opening_handshake"},
-            ) from exc
+            raise self._connect_error_from_exception(exc) from exc
         self.session.sync_connection = conn
         self.session.connected_at = time.time()
         return conn
@@ -186,12 +181,7 @@ class ResponsesWebSocketAdapter(ResponsesNormalizationMixin):
         try:
             conn = await aclient.responses.connect().enter()
         except Exception as exc:
-            raise ResponsesWebSocketTransportError(
-                str(exc) or "socket_connect_failed",
-                code="socket_connect_failed",
-                retriable=True,
-                details={"phase": "opening_handshake"},
-            ) from exc
+            raise self._connect_error_from_exception(exc) from exc
         self.session.async_connection = conn
         self.session.connected_at = time.time()
         return conn
@@ -487,7 +477,11 @@ class ResponsesWebSocketAdapter(ResponsesNormalizationMixin):
         }
 
     @classmethod
-    def _extract_sdk_api_error_details(cls, exc: Exception, request_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    def _extract_sdk_api_error_details(
+        cls,
+        exc: Exception,
+        request_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         """Extract structured error fields from an OpenAI SDK API exception.
 
         Works with ``openai.APIStatusError`` and its subclasses (BadRequestError,
@@ -498,6 +492,9 @@ class ResponsesWebSocketAdapter(ResponsesNormalizationMixin):
         details: Dict[str, Any] = {}
         # HTTP status
         status_code = getattr(exc, "status_code", None)
+        if status_code is None:
+            response = getattr(exc, "response", None)
+            status_code = getattr(response, "status_code", None) or getattr(response, "status", None)
         if status_code is not None:
             details["http_status"] = status_code
         # Request ID
@@ -507,16 +504,57 @@ class ResponsesWebSocketAdapter(ResponsesNormalizationMixin):
         # Parsed body (OpenAI SDK parses JSON body into .body dict)
         body = getattr(exc, "body", None)
         if isinstance(body, dict):
+            provider_body = body.get("error") if isinstance(body.get("error"), dict) else body
             for key in ("code", "message", "param", "type"):
-                val = body.get(key)
+                val = provider_body.get(key)
                 if val is not None:
                     details[f"provider_{key}"] = val
             details["raw_error"] = body
         elif body is not None:
             details["raw_error"] = str(body)
         # Request context
-        details["request_summary"] = cls._request_summary(request_kwargs)
+        if request_kwargs is not None:
+            details["request_summary"] = cls._request_summary(request_kwargs)
         return details
+
+    @classmethod
+    def _connect_error_from_exception(cls, exc: Exception) -> ResponsesWebSocketTransportError:
+        """Classify WebSocket opening-handshake failures.
+
+        Plain socket/timeout failures stay retryable transport failures. If the
+        SDK exposes provider-shaped metadata during the upgrade, preserve that
+        classification so auth, permission, and validation failures fail fast.
+        """
+        details = cls._extract_sdk_api_error_details(exc)
+        details["phase"] = "opening_handshake"
+        provider_msg = details.get("provider_message")
+        provider_code = details.get("provider_code")
+
+        if provider_msg or provider_code:
+            code = provider_code or "api_error"
+            details["transport_code"] = "socket_connect_failed"
+            return ResponsesWebSocketTransportError(
+                provider_msg or str(exc) or code,
+                code=code,
+                retriable=cls._provider_error_is_retriable(code, details),
+                details=details,
+            )
+
+        if details.get("http_status") is not None:
+            details["transport_code"] = "socket_connect_failed"
+            return ResponsesWebSocketTransportError(
+                str(exc) or "api_error",
+                code="api_error",
+                retriable=cls._provider_error_is_retriable("api_error", details),
+                details=details,
+            )
+
+        return ResponsesWebSocketTransportError(
+            str(exc) or "socket_connect_failed",
+            code="socket_connect_failed",
+            retriable=True,
+            details=details,
+        )
 
     @classmethod
     def _extract_stream_error_details(

--- a/chatsnack/runtime/responses_websocket_adapter.py
+++ b/chatsnack/runtime/responses_websocket_adapter.py
@@ -17,6 +17,44 @@ _SDK_VERSION_GUIDANCE = (
     "Upgrade OpenAI or install openai[realtime]."
 )
 
+_AUTH_ERROR_CODES = {
+    "auth_error",
+    "authentication_error",
+    "unauthorized",
+    "invalid_api_key",
+}
+
+_NON_RETRIABLE_PROVIDER_CODES = {
+    "bad_request",
+    "invalid_request",
+    "invalid_request_error",
+    "invalid_tools",
+    "invalid_value",
+    "missing_required_parameter",
+    "permission_denied",
+    "session_busy",
+    "sdk_unsupported",
+}
+
+_NON_RETRIABLE_PROVIDER_TYPES = {
+    "authentication_error",
+    "invalid_request_error",
+    "permission_error",
+}
+
+_RETRYABLE_PROVIDER_CODES = {
+    "engine_overloaded",
+    "internal_server_error",
+    "rate_limit",
+    "rate_limit_exceeded",
+    "server_error",
+    "service_unavailable",
+    "timeout",
+    "websocket_connection_limit_reached",
+}
+
+_RETRYABLE_HTTP_STATUSES = {408, 409, 425, 429}
+
 
 class ResponsesSessionBusyError(RuntimeError):
     """Raised when a shared session already has an in-flight response."""
@@ -97,7 +135,12 @@ class ResponsesWebSocketAdapter(ResponsesNormalizationMixin):
         responses = getattr(client, "responses", None)
         connect = getattr(responses, "connect", None) if responses else None
         if not callable(connect):
-            raise RuntimeError(_SDK_VERSION_GUIDANCE)
+            raise ResponsesWebSocketTransportError(
+                _SDK_VERSION_GUIDANCE,
+                code="sdk_unsupported",
+                retriable=False,
+                details={"category": "configuration"},
+            )
 
     # ------------------------------------------------------------------
     # Connection management – uses SDK context managers
@@ -119,7 +162,15 @@ class ResponsesWebSocketAdapter(ResponsesNormalizationMixin):
         self._drop_sync_connection()
         client = self._get_sync_client()
         self._check_sdk_support(client)
-        conn = client.responses.connect().enter()
+        try:
+            conn = client.responses.connect().enter()
+        except Exception as exc:
+            raise ResponsesWebSocketTransportError(
+                str(exc) or "socket_connect_failed",
+                code="socket_connect_failed",
+                retriable=True,
+                details={"phase": "opening_handshake"},
+            ) from exc
         self.session.sync_connection = conn
         self.session.connected_at = time.time()
         return conn
@@ -132,7 +183,15 @@ class ResponsesWebSocketAdapter(ResponsesNormalizationMixin):
         await self._drop_async_connection()
         aclient = self._get_async_client()
         self._check_sdk_support(aclient)
-        conn = await aclient.responses.connect().enter()
+        try:
+            conn = await aclient.responses.connect().enter()
+        except Exception as exc:
+            raise ResponsesWebSocketTransportError(
+                str(exc) or "socket_connect_failed",
+                code="socket_connect_failed",
+                retriable=True,
+                details={"phase": "opening_handshake"},
+            ) from exc
         self.session.async_connection = conn
         self.session.connected_at = time.time()
         return conn
@@ -282,11 +341,68 @@ class ResponsesWebSocketAdapter(ResponsesNormalizationMixin):
 
     @staticmethod
     def _is_auth_error_code(code: Optional[str]) -> bool:
-        return (code or "").lower() in {"auth_error", "authentication_error", "unauthorized", "invalid_api_key"}
+        return (code or "").lower() in _AUTH_ERROR_CODES
 
     @staticmethod
     def _is_non_retriable_retry_code(code: Optional[str]) -> bool:
-        return (code or "").lower() in {"auth_error", "session_busy"}
+        normalized = (code or "").lower()
+        return normalized in _AUTH_ERROR_CODES or normalized in _NON_RETRIABLE_PROVIDER_CODES
+
+    @staticmethod
+    def _details_http_status(details: Dict[str, Any]) -> Optional[int]:
+        status = details.get("http_status")
+        if status is None:
+            status = details.get("status")
+        if status is None:
+            raw_event = details.get("raw_event")
+            if isinstance(raw_event, dict):
+                status = raw_event.get("status")
+        try:
+            return int(status) if status is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    @classmethod
+    def _provider_error_is_retriable(cls, code: Optional[str], details: Dict[str, Any]) -> bool:
+        """Classify provider/API errors without coupling retry policy to one caller.
+
+        Transport errors are classified where they are raised. This method only
+        handles provider-shaped errors from SDK API exceptions and streamed
+        ``error`` / ``response.failed`` events.
+        """
+        normalized = (code or "").lower()
+        provider_type = (details.get("provider_type") or "").lower()
+        http_status = cls._details_http_status(details)
+
+        if normalized == "previous_response_not_found":
+            return True
+        if normalized in _RETRYABLE_PROVIDER_CODES:
+            return True
+        if http_status is not None and (http_status in _RETRYABLE_HTTP_STATUSES or http_status >= 500):
+            return True
+        if (
+            normalized in _AUTH_ERROR_CODES
+            or normalized in _NON_RETRIABLE_PROVIDER_CODES
+            or provider_type in _NON_RETRIABLE_PROVIDER_TYPES
+            or (http_status is not None and 400 <= http_status < 500)
+        ):
+            return False
+        return False
+
+    def _transport_error_with_request_summary(
+        self,
+        exc: ResponsesWebSocketTransportError,
+        request_kwargs: Dict[str, Any],
+    ) -> ResponsesWebSocketTransportError:
+        """Attach safe request metadata to transport failures at request time."""
+        details = dict(exc.details or {})
+        details.setdefault("request_summary", self._request_summary(request_kwargs))
+        return ResponsesWebSocketTransportError(
+            str(exc),
+            code=exc.code,
+            retriable=exc.retriable,
+            details=details,
+        )
 
     def _retry_delay_seconds(self, retry_number: int) -> float:
         """Return exponential retry delay with bounded jitter."""
@@ -339,6 +455,10 @@ class ResponsesWebSocketAdapter(ResponsesNormalizationMixin):
             and retries_used < self.max_transport_retries
             and code != "previous_response_not_found"
             and not self._is_non_retriable_retry_code(code)
+            and not (
+                (error_dict.get("details") or {}).get("provider_code")
+                and not self._provider_error_is_retriable(code, error_dict.get("details") or {})
+            )
         )
 
     @classmethod
@@ -431,6 +551,9 @@ class ResponsesWebSocketAdapter(ResponsesNormalizationMixin):
                 or getattr(event, "message", None)
                 or code
             )
+            status = event_d.get("status") or getattr(event, "status", None)
+            if status is not None:
+                details["http_status"] = status
             details["provider_code"] = code
             details["provider_message"] = message
             for key in ("param", "type"):
@@ -545,7 +668,10 @@ class ResponsesWebSocketAdapter(ResponsesNormalizationMixin):
         """Send a request over the sync SDK connection and yield runtime events."""
         request_kwargs = self._request_with_session(messages, kwargs, include_prev=include_prev)
         create_kw = self._create_kwargs(request_kwargs)
-        connection = self._connect_sync()
+        try:
+            connection = self._connect_sync()
+        except ResponsesWebSocketTransportError as exc:
+            raise self._transport_error_with_request_summary(exc, request_kwargs) from exc
         self._debug_responses_payload("Responses WS response.create payload", create_kw)
 
         try:
@@ -567,7 +693,14 @@ class ResponsesWebSocketAdapter(ResponsesNormalizationMixin):
                 code = provider_code or "api_error"
                 raise ResponsesWebSocketTransportError(
                     human_msg, code=code,
-                    retriable=not self._is_auth_error_code(code),
+                    retriable=self._provider_error_is_retriable(code, details),
+                    details=details,
+                ) from exc
+            if details.get("http_status") is not None:
+                raise ResponsesWebSocketTransportError(
+                    str(exc) or "api_error",
+                    code="api_error",
+                    retriable=self._provider_error_is_retriable("api_error", details),
                     details=details,
                 ) from exc
             # Generic transport-level failure.
@@ -640,10 +773,11 @@ class ResponsesWebSocketAdapter(ResponsesNormalizationMixin):
                     message = error_details.get("provider_message", code)
                     if code == "previous_response_not_found":
                         raise RuntimeError(code)
+                    transport_code = "auth_error" if self._is_auth_error_code(code) else code
                     raise ResponsesWebSocketTransportError(
                         message,
-                        code=("auth_error" if self._is_auth_error_code(code) else code),
-                        retriable=not self._is_auth_error_code(code),
+                        code=transport_code,
+                        retriable=self._provider_error_is_retriable(transport_code, error_details),
                         details=error_details,
                     )
                 # Safely ignore all other lifecycle events (response.created,
@@ -677,7 +811,10 @@ class ResponsesWebSocketAdapter(ResponsesNormalizationMixin):
         """Send a request over the async SDK connection and yield runtime events."""
         request_kwargs = self._request_with_session(messages, kwargs, include_prev=include_prev)
         create_kw = self._create_kwargs(request_kwargs)
-        connection = await self._connect_async()
+        try:
+            connection = await self._connect_async()
+        except ResponsesWebSocketTransportError as exc:
+            raise self._transport_error_with_request_summary(exc, request_kwargs) from exc
         self._debug_responses_payload("Responses WS response.create payload", create_kw)
 
         try:
@@ -697,7 +834,14 @@ class ResponsesWebSocketAdapter(ResponsesNormalizationMixin):
                 code = provider_code or "api_error"
                 raise ResponsesWebSocketTransportError(
                     human_msg, code=code,
-                    retriable=not self._is_auth_error_code(code),
+                    retriable=self._provider_error_is_retriable(code, details),
+                    details=details,
+                ) from exc
+            if details.get("http_status") is not None:
+                raise ResponsesWebSocketTransportError(
+                    str(exc) or "api_error",
+                    code="api_error",
+                    retriable=self._provider_error_is_retriable("api_error", details),
                     details=details,
                 ) from exc
             raise ResponsesWebSocketTransportError(
@@ -769,10 +913,11 @@ class ResponsesWebSocketAdapter(ResponsesNormalizationMixin):
                     message = error_details.get("provider_message", code)
                     if code == "previous_response_not_found":
                         raise RuntimeError(code)
+                    transport_code = "auth_error" if self._is_auth_error_code(code) else code
                     raise ResponsesWebSocketTransportError(
                         message,
-                        code=("auth_error" if self._is_auth_error_code(code) else code),
-                        retriable=not self._is_auth_error_code(code),
+                        code=transport_code,
+                        retriable=self._provider_error_is_retriable(transport_code, error_details),
                         details=error_details,
                     )
         except RuntimeError:

--- a/docs/projects/phase-2-responses-websocket-checklist.md
+++ b/docs/projects/phase-2-responses-websocket-checklist.md
@@ -119,6 +119,13 @@ Drop a note into `## Progress Notes` whenever something meaningfully changes.
 
 Add short dated entries here as work lands.
 
+### 2026-07-02 - WebSocket retry policy hardening
+- Status: done
+- RFC sections: `Error and retry policy`; `How continuation should work -> On reconnect`
+- What works for users: WebSocket retries now cover sync and async connection-open failures, including opening-handshake timeouts, under the same pre-output retry guard used for send and receive failures. Documented `websocket_connection_limit_reached` errors trigger a reconnect before output, provider validation errors fail fast, and package metadata advances to `0.6.2`.
+- Caveats: Retries remain conservative: unknown provider failures are not retried unless classified as transient by code or HTTP status, and any observable output still suppresses automatic replay.
+- How we checked it: Focused WebSocket adapter regressions exercise fake SDK connection managers, provider error classification, reconnect behavior, and replay-guard coverage.
+
 ### 2026-07-02 - Non-streaming WebSocket retry hardening
 - Status: done
 - RFC sections: `Error and retry policy`; `How ask(), chat(), listen(), and listen_a() should work`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chatsnack"
-version = "0.6.1"
+version = "0.6.2"
 description = "chatsnack is the easiest Python library for rapid development with OpenAI's ChatGPT API. It provides an intuitive interface for creating and managing chat-based prompts and responses, making it convenient to build complex, interactive conversations with AI."
 authors = ["Mattie Casper"]
 license = "MIT"

--- a/tests/runtime/test_responses_websocket_adapter.py
+++ b/tests/runtime/test_responses_websocket_adapter.py
@@ -29,6 +29,161 @@ def _capture_loguru():
         logger.remove(sink_id)
 
 
+class _FakeCompletedResponse:
+    def __init__(self, text="ok", response_id="resp_ok", model="gpt-4.1"):
+        self.output_text = text
+        self._response_id = response_id
+        self._model = model
+
+    def model_dump(self):
+        return {
+            "id": self._response_id,
+            "status": "completed",
+            "model": self._model,
+            "usage": {"total_tokens": 4},
+            "output_text": self.output_text,
+        }
+
+
+class _FakeCompletedEvent:
+    type = "response.completed"
+
+    def __init__(self, text="ok", response_id="resp_ok", model="gpt-4.1"):
+        self.response = _FakeCompletedResponse(text=text, response_id=response_id, model=model)
+
+
+class _FakeTopLevelErrorEvent:
+    type = "error"
+
+    def __init__(self, code, message=None, *, status=None, provider_type=None):
+        self.code = code
+        self.message = message or code
+        self.status = status
+        self.provider_type = provider_type
+
+    def model_dump(self):
+        error = {"code": self.code, "message": self.message}
+        if self.provider_type is not None:
+            error["type"] = self.provider_type
+        payload = {"type": "error", "error": error}
+        if self.status is not None:
+            payload["status"] = self.status
+        return payload
+
+
+class _FakeResponseFailedEvent:
+    type = "response.failed"
+
+    def __init__(self, code, message=None, *, provider_type=None):
+        self.response = SimpleNamespace(
+            id="resp_failed",
+            status="failed",
+            error=SimpleNamespace(
+                code=code,
+                message=message or code,
+                type=provider_type,
+            ),
+        )
+
+
+class _FakeSyncConnection:
+    def __init__(self, events=None, *, create_error=None):
+        self.response = SimpleNamespace(create=self.create)
+        self._events = list(events or [])
+        self.create_error = create_error
+        self.create_calls = []
+        self.closed = False
+
+    def create(self, **kwargs):
+        self.create_calls.append(kwargs)
+        if self.create_error is not None:
+            raise self.create_error
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._events:
+            return self._events.pop(0)
+        raise StopIteration
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeAsyncConnection:
+    def __init__(self, events=None, *, create_error=None):
+        async def create(**kwargs):
+            self.create_calls.append(kwargs)
+            if self.create_error is not None:
+                raise self.create_error
+
+        self.response = SimpleNamespace(create=create)
+        self._events = list(events or [])
+        self.create_error = create_error
+        self.create_calls = []
+        self.closed = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._events:
+            return self._events.pop(0)
+        raise StopAsyncIteration
+
+    async def close(self):
+        self.closed = True
+
+
+class _SequencedSyncResponses:
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.connect_calls = 0
+
+    def connect(self):
+        return self
+
+    def enter(self):
+        self.connect_calls += 1
+        if not self.outcomes:
+            raise AssertionError("unexpected sync connect attempt")
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+class _SequencedAsyncResponses:
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.connect_calls = 0
+
+    def connect(self):
+        return self
+
+    async def enter(self):
+        self.connect_calls += 1
+        if not self.outcomes:
+            raise AssertionError("unexpected async connect attempt")
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def _fake_sdk_error(status, code, message=None, provider_type=None):
+    exc = Exception(message or code)
+    exc.status_code = status
+    exc.request_id = "req_test"
+    exc.body = {
+        "code": code,
+        "message": message or code,
+        "type": provider_type,
+    }
+    return exc
+
+
 def test_session_busy_raises_fail_fast(monkeypatch):
     ai = SimpleNamespace(api_key="x", base_url=None, client=None, aclient=None)
     adapter = ResponsesWebSocketAdapter(ai, session=ResponsesWebSocketSession(mode="inherit"))
@@ -209,6 +364,177 @@ async def test_create_completion_a_retries_transport_error_before_output_and_suc
     assert result.message.content == "recovered"
     assert len(calls) == 2
     assert dropped["count"] == 1
+
+
+def test_create_completion_retries_sync_connect_open_failure_and_succeeds():
+    responses = _SequencedSyncResponses(
+        [
+            TimeoutError("timed out during opening handshake"),
+            _FakeSyncConnection([_FakeCompletedEvent(text="recovered", response_id="resp_sync_connect")]),
+        ]
+    )
+    ai = SimpleNamespace(client=SimpleNamespace(responses=responses), aclient=None)
+    adapter = ResponsesWebSocketAdapter(
+        ai,
+        session=ResponsesWebSocketSession(mode="inherit"),
+        retry_initial_delay=0,
+    )
+
+    result = adapter.create_completion(messages=[{"role": "user", "content": "hi"}], model="gpt-4.1")
+
+    assert result.message.content == "recovered"
+    assert responses.connect_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_create_completion_a_retries_async_connect_open_failure_and_succeeds():
+    responses = _SequencedAsyncResponses(
+        [
+            TimeoutError("timed out during opening handshake"),
+            _FakeAsyncConnection([_FakeCompletedEvent(text="recovered", response_id="resp_async_connect")]),
+        ]
+    )
+    ai = SimpleNamespace(client=None, aclient=SimpleNamespace(responses=responses))
+    adapter = ResponsesWebSocketAdapter(
+        ai,
+        session=ResponsesWebSocketSession(mode="inherit"),
+        retry_initial_delay=0,
+    )
+
+    result = await adapter.create_completion_a(messages=[{"role": "user", "content": "hi"}], model="gpt-4.1")
+
+    assert result.message.content == "recovered"
+    assert responses.connect_calls == 2
+
+
+def test_create_completion_exhausts_connect_open_failures_with_socket_connect_metadata():
+    responses = _SequencedSyncResponses(
+        [
+            TimeoutError("timed out during opening handshake"),
+            TimeoutError("timed out during opening handshake"),
+            TimeoutError("timed out during opening handshake"),
+        ]
+    )
+    ai = SimpleNamespace(client=SimpleNamespace(responses=responses), aclient=None)
+    adapter = ResponsesWebSocketAdapter(
+        ai,
+        session=ResponsesWebSocketSession(mode="inherit"),
+        max_transport_retries=2,
+        retry_initial_delay=0,
+    )
+
+    with pytest.raises(ResponsesWebSocketTransportError, match="timed out during opening handshake") as exc_info:
+        adapter.create_completion(messages=[{"role": "user", "content": "hi"}], model="gpt-4.1")
+
+    assert responses.connect_calls == 3
+    assert exc_info.value.code == "socket_connect_failed"
+    assert exc_info.value.retriable is True
+    assert exc_info.value.details["phase"] == "opening_handshake"
+    assert exc_info.value.details["request_summary"]["model"] == "gpt-4.1"
+
+
+def test_websocket_connection_limit_reached_reconnects_before_output():
+    first_connection = _FakeSyncConnection(
+        [
+            _FakeTopLevelErrorEvent(
+                "websocket_connection_limit_reached",
+                "Responses websocket connection limit reached (60 minutes).",
+                status=400,
+                provider_type="invalid_request_error",
+            )
+        ]
+    )
+    second_connection = _FakeSyncConnection([_FakeCompletedEvent(text="continued", response_id="resp_limit_retry")])
+    responses = _SequencedSyncResponses([first_connection, second_connection])
+    ai = SimpleNamespace(client=SimpleNamespace(responses=responses), aclient=None)
+    adapter = ResponsesWebSocketAdapter(
+        ai,
+        session=ResponsesWebSocketSession(mode="inherit"),
+        retry_initial_delay=0,
+    )
+
+    result = adapter.create_completion(messages=[{"role": "user", "content": "hi"}], model="gpt-4.1")
+
+    assert result.message.content == "continued"
+    assert responses.connect_calls == 2
+    assert first_connection.closed is True
+
+
+def test_response_create_validation_error_fails_fast_without_retry():
+    validation_error = _fake_sdk_error(
+        400,
+        "invalid_value",
+        "Invalid value: 'namespace'.",
+        "invalid_request_error",
+    )
+    connection = _FakeSyncConnection(create_error=validation_error)
+    responses = _SequencedSyncResponses([connection])
+    ai = SimpleNamespace(client=SimpleNamespace(responses=responses), aclient=None)
+    adapter = ResponsesWebSocketAdapter(
+        ai,
+        session=ResponsesWebSocketSession(mode="inherit"),
+        max_transport_retries=2,
+        retry_initial_delay=0,
+    )
+
+    with pytest.raises(ResponsesWebSocketTransportError, match="Invalid value") as exc_info:
+        adapter.create_completion(messages=[{"role": "user", "content": "hi"}], model="gpt-4.1")
+
+    assert responses.connect_calls == 1
+    assert len(connection.create_calls) == 1
+    assert exc_info.value.code == "invalid_value"
+    assert exc_info.value.retriable is False
+
+
+def test_streamed_validation_failure_fails_fast_without_retry():
+    connection = _FakeSyncConnection(
+        [_FakeResponseFailedEvent("invalid_tools", "Tool schema is invalid", provider_type="invalid_request_error")]
+    )
+    responses = _SequencedSyncResponses([connection])
+    ai = SimpleNamespace(client=SimpleNamespace(responses=responses), aclient=None)
+    adapter = ResponsesWebSocketAdapter(
+        ai,
+        session=ResponsesWebSocketSession(mode="inherit"),
+        max_transport_retries=2,
+        retry_initial_delay=0,
+    )
+
+    with pytest.raises(ResponsesWebSocketTransportError, match="Tool schema is invalid") as exc_info:
+        adapter.create_completion(messages=[{"role": "user", "content": "hi"}], model="gpt-4.1")
+
+    assert responses.connect_calls == 1
+    assert exc_info.value.code == "invalid_tools"
+    assert exc_info.value.retriable is False
+
+
+@pytest.mark.parametrize(
+    ("status", "code"),
+    [
+        (429, "rate_limit_exceeded"),
+        (500, "server_error"),
+    ],
+)
+def test_response_create_transient_provider_errors_retry_before_output(status, code):
+    first_connection = _FakeSyncConnection(create_error=_fake_sdk_error(status, code, code))
+    second_connection = _FakeSyncConnection([_FakeCompletedEvent(text="recovered", response_id=f"resp_{code}")])
+    responses = _SequencedSyncResponses([first_connection, second_connection])
+    ai = SimpleNamespace(client=SimpleNamespace(responses=responses), aclient=None)
+    adapter = ResponsesWebSocketAdapter(
+        ai,
+        session=ResponsesWebSocketSession(mode="inherit"),
+        retry_initial_delay=0,
+    )
+
+    result = adapter.create_completion(messages=[{"role": "user", "content": "hi"}], model="gpt-4.1")
+
+    assert result.message.content == "recovered"
+    assert responses.connect_calls == 2
+    assert first_connection.closed is True
+
+
+@pytest.mark.parametrize("event_type", ["text_delta", "tool_call_delta", "completed"])
+def test_retry_guard_consumes_observable_output_events(event_type):
+    assert ResponsesWebSocketAdapter._event_consumes_retry_guard(SimpleNamespace(type=event_type)) is True
 
 
 def test_create_completion_retries_structured_stream_error_before_output(monkeypatch):
@@ -751,8 +1077,11 @@ def test_sdk_version_check_raises_clear_message():
     adapter = ResponsesWebSocketAdapter(ai, session=ResponsesWebSocketSession(mode="inherit"))
 
     # Try to connect - should raise the version guidance message
-    with pytest.raises(RuntimeError, match="openai>=2.29.0"):
+    with pytest.raises(ResponsesWebSocketTransportError, match="openai>=2.29.0") as exc_info:
         adapter._connect_sync()
+
+    assert exc_info.value.code == "sdk_unsupported"
+    assert exc_info.value.retriable is False
 
 
 def test_create_kwargs_strips_transport_fields():

--- a/tests/runtime/test_responses_websocket_adapter.py
+++ b/tests/runtime/test_responses_websocket_adapter.py
@@ -184,6 +184,12 @@ def _fake_sdk_error(status, code, message=None, provider_type=None):
     return exc
 
 
+def _fake_sdk_status_error(status, message):
+    exc = Exception(message)
+    exc.status_code = status
+    return exc
+
+
 def test_session_busy_raises_fail_fast(monkeypatch):
     ai = SimpleNamespace(api_key="x", base_url=None, client=None, aclient=None)
     adapter = ResponsesWebSocketAdapter(ai, session=ResponsesWebSocketSession(mode="inherit"))
@@ -405,6 +411,89 @@ async def test_create_completion_a_retries_async_connect_open_failure_and_succee
 
     assert result.message.content == "recovered"
     assert responses.connect_calls == 2
+
+
+def test_create_completion_connect_open_validation_error_fails_fast_without_retry():
+    responses = _SequencedSyncResponses(
+        [
+            _fake_sdk_error(
+                400,
+                "invalid_value",
+                "Invalid value: 'namespace'.",
+                "invalid_request_error",
+            )
+        ]
+    )
+    ai = SimpleNamespace(client=SimpleNamespace(responses=responses), aclient=None)
+    adapter = ResponsesWebSocketAdapter(
+        ai,
+        session=ResponsesWebSocketSession(mode="inherit"),
+        max_transport_retries=2,
+        retry_initial_delay=0,
+    )
+
+    with pytest.raises(ResponsesWebSocketTransportError, match="Invalid value") as exc_info:
+        adapter.create_completion(messages=[{"role": "user", "content": "hi"}], model="gpt-4.1")
+
+    assert responses.connect_calls == 1
+    assert exc_info.value.code == "invalid_value"
+    assert exc_info.value.retriable is False
+    assert exc_info.value.details["phase"] == "opening_handshake"
+    assert exc_info.value.details["transport_code"] == "socket_connect_failed"
+    assert exc_info.value.details["request_summary"]["model"] == "gpt-4.1"
+
+
+def test_create_completion_connect_open_http_4xx_without_body_fails_fast_without_retry():
+    responses = _SequencedSyncResponses([_fake_sdk_status_error(403, "Forbidden")])
+    ai = SimpleNamespace(client=SimpleNamespace(responses=responses), aclient=None)
+    adapter = ResponsesWebSocketAdapter(
+        ai,
+        session=ResponsesWebSocketSession(mode="inherit"),
+        max_transport_retries=2,
+        retry_initial_delay=0,
+    )
+
+    with pytest.raises(ResponsesWebSocketTransportError, match="Forbidden") as exc_info:
+        adapter.create_completion(messages=[{"role": "user", "content": "hi"}], model="gpt-4.1")
+
+    assert responses.connect_calls == 1
+    assert exc_info.value.code == "api_error"
+    assert exc_info.value.retriable is False
+    assert exc_info.value.details["http_status"] == 403
+    assert exc_info.value.details["phase"] == "opening_handshake"
+    assert exc_info.value.details["transport_code"] == "socket_connect_failed"
+    assert exc_info.value.details["request_summary"]["model"] == "gpt-4.1"
+
+
+@pytest.mark.asyncio
+async def test_create_completion_a_connect_open_auth_error_fails_fast_without_retry():
+    responses = _SequencedAsyncResponses(
+        [
+            _fake_sdk_error(
+                401,
+                "invalid_api_key",
+                "Invalid API key.",
+                "authentication_error",
+            )
+        ]
+    )
+    ai = SimpleNamespace(client=None, aclient=SimpleNamespace(responses=responses))
+    adapter = ResponsesWebSocketAdapter(
+        ai,
+        session=ResponsesWebSocketSession(mode="inherit"),
+        max_transport_retries=2,
+        retry_initial_delay=0,
+    )
+
+    with pytest.raises(ResponsesWebSocketTransportError, match="Invalid API key") as exc_info:
+        await adapter.create_completion_a(messages=[{"role": "user", "content": "hi"}], model="gpt-4.1")
+
+    assert responses.connect_calls == 1
+    assert exc_info.value.code == "invalid_api_key"
+    assert exc_info.value.retriable is False
+    assert exc_info.value.details["phase"] == "opening_handshake"
+    assert exc_info.value.details["transport_code"] == "socket_connect_failed"
+    assert exc_info.value.details["request_summary"]["model"] == "gpt-4.1"
 
 
 def test_create_completion_exhausts_connect_open_failures_with_socket_connect_metadata():


### PR DESCRIPTION
## Summary

Harden the Responses WebSocket retry policy around connection-open failures and provider error classification.

## What changed

- Wrap sync and async SDK WebSocket `responses.connect().enter()` failures as retryable `socket_connect_failed` transport errors before output is consumed.
- Add centralized provider/API retry classification so transient 429/5xx and `websocket_connection_limit_reached` can retry, while validation/auth/configuration failures fail fast.
- Surface SDK support failures as non-retryable `sdk_unsupported` metadata.
- Add fake-SDK regression coverage for connection-open retries, retry exhaustion metadata, reconnect limits, validation fail-fast behavior, transient provider retries, and replay-guard events.
- Bump package metadata from `0.6.1` to `0.6.2` and update the Phase 2 WebSocket checklist.

## Root cause

Opening-handshake failures happened during connection acquisition before the request attempt entered the same retry-aware send/receive boundary, so `create_completion_a()` could surface the timeout without retrying.

## Validation

- `python -m pytest tests/runtime/test_responses_websocket_adapter.py tests/runtime/test_responses_websocket_previous_response_retry.py -q` -> 48 passed
- `python -m pytest tests/test_phase2_sessions.py -q` -> 24 passed
- `python -m pytest tests/test_runtime_defaults.py -q` -> 17 passed
- `python -m pytest tests/test_responses_tool_normalization.py -q` -> 30 passed
- `python -m pytest tests/mixins/test_query.py -q -k "not live"` -> 52 passed, 20 deselected, existing async close warnings

Full `python -m pytest -q -k "not live"` exceeded the 10-minute local timeout without a failure summary.