### PR TITLE
Raise snapclass minimum to 0.1.3

### DIFF
--- a/chatsnack/chat/mixin_serialization.py
+++ b/chatsnack/chat/mixin_serialization.py
@@ -54,7 +54,7 @@ def refresh_snapclass_config_stash(cls):
     config = getattr(cls, "__snapclass_config__", None)
     stash = getattr(config, "stash", None)
     if stash is not None:
-        # snapclass 0.1.2 rejects lifecycle hooks that change snapshot paths.
+        # snapclass rejects lifecycle hooks that change snapshot paths.
         # Refresh env/cwd-sensitive stashes before object construction or
         # explicit save/load instead of doing it inside ready/loaded hooks.
         config.stash = stash.refresh()
@@ -140,7 +140,7 @@ class DatafileMixin:
         _refresh_after_snapshot_load(self)
 
     def _install_snapshot_compat_hooks(self):
-        # snapclass 0.1.2 owns snapshot lifecycle hooks. This method remains so
+        # snapclass owns snapshot lifecycle hooks. This method remains so
         # older chatsnack internals can call it without reintroducing monkey
         # patching around snapshot.load().
         return None

--- a/docs/projects/snapclass-migration-checklist.md
+++ b/docs/projects/snapclass-migration-checklist.md
@@ -13,8 +13,8 @@
 
 Notes:
 
-- Deterministic migration/YAML coverage passed against PyPI `snapclass==0.1.2`: `tests/test_file_snack_fillings.py`, `tests/test_chatsnack_yaml_peeves.py`, `tests/test_compact_tools_yaml.py`, `tests/test_phase3_yaml.py`, and `tests/test_snapclass_persistence_compat.py` with the three live OpenAI filling tests deselected.
-- New snapclass compatibility tests passed against PyPI `snapclass==0.1.2`.
+- Deterministic migration/YAML coverage passed against PyPI `snapclass==0.1.3`: `tests/test_file_snack_fillings.py`, `tests/test_chatsnack_yaml_peeves.py`, `tests/test_compact_tools_yaml.py`, `tests/test_phase3_yaml.py`, and `tests/test_snapclass_persistence_compat.py` with the three live OpenAI filling tests deselected.
+- New snapclass compatibility tests passed against PyPI `snapclass==0.1.3`.
 - Runtime and Responses-family regression tests passed, including the tool-followup request handling added during the port.
 - Live model coverage passed after the Responses-family tool-followup fix: `172 passed, 1 skipped` across live-relevant Python tests and `43 passed, 2 skipped` across notebook examples.
 - Full-suite verification remains open only because a single monolithic `pytest -q` run has not been repeated after the targeted local and live suites.

--- a/poetry.lock
+++ b/poetry.lock
@@ -909,14 +909,14 @@ oldlibyaml = ["ruamel.yaml.clib ; platform_python_implementation == \"CPython\""
 
 [[package]]
 name = "snapclass"
-version = "0.1.2"
+version = "0.1.3"
 description = "Human-readable file persistence for Python dataclasses."
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
 files = [
-    {file = "snapclass-0.1.2-py3-none-any.whl", hash = "sha256:352914d394da6399c8455ce2cea553b0968acd5d200c54e8da26a67e3068f081"},
-    {file = "snapclass-0.1.2.tar.gz", hash = "sha256:3a1051c920b25f47524f8701448ab7abc2596746bcb5eb6a9f835474bc8b31a3"},
+    {file = "snapclass-0.1.3-py3-none-any.whl", hash = "sha256:320f46c1d2a3daf53211402cc3ddf77dacde46c9366a02d48b4089db56d5d351"},
+    {file = "snapclass-0.1.3.tar.gz", hash = "sha256:f97c5999db1137b4851f93a4bdabc68d84f53148667cf604467a8e073ccd055b"},
 ]
 
 [package.dependencies]
@@ -1129,4 +1129,4 @@ rich = ["rich"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "601ad28518af0783609984219fc020d297494f2e40fb74d71b9b25910f9915f1"
+content-hash = "908fc25d02d3c1674479764ec6b1c19ec11e916a9ca29f4bfd9fae268b9493f9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.11"
-snapclass = "^0.1.2"
+snapclass = "^0.1.3"
 python-dotenv = "^1.0.0"
 loguru = "^0.6.0"
 nest-asyncio = "^1.5.6"


### PR DESCRIPTION
## Summary

- raise the minimum supported `snapclass` version to `0.1.3`
- refresh `poetry.lock` for the new snapclass release
- update stale snapclass-version-specific comments and migration checklist notes

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests\test_snapclass_persistence_compat.py`
- `.\.venv\Scripts\python.exe -m pytest tests\test_file_snack_fillings.py tests\test_chatsnack_yaml_peeves.py tests\test_compact_tools_yaml.py tests\test_phase3_yaml.py tests\test_snapclass_persistence_compat.py -k 'not test_text_expansion and not test_text_nested_expansion and not test_text_chat_expansion'`
- `.\.venv\Scripts\poetry.exe check`

Notes: `poetry check` passed with existing Poetry metadata deprecation warnings. The broader deterministic suite passed with 88 selected tests and 3 live OpenAI filling tests deselected.