### PR TITLE
Make auto_feed limits configurable and release 0.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ chat.reasoning.summary = "auto"
 The `sources=True` on `web_search` automatically populates `params.responses["include"]`
 without manual dict mutation.
 
+For unusually long local-utensil workflows, `auto_feed` controls the automatic
+execute-and-follow-up loop. Leave it unset (or use `True` / `None`) for the legacy
+five-cycle limit. A positive integer allows that many cycles; `False` or `0` still
+executes the first pending batch, but does not feed its results back to the model.
+Parallel calls requested in one assistant response count as one cycle.
+
 ### Tasty Features
 
 There's many other tidbits covered in the notebooks, examples, and videos. Here are some of the highlights:

--- a/chatsnack/chat/mixin_params.py
+++ b/chatsnack/chat/mixin_params.py
@@ -7,6 +7,28 @@ from snapclass import snapclass
 
 
 DEFAULT_MODEL_FALLBACK = "gpt-5-chat-latest"
+_LEGACY_AUTO_FEED_LIMIT = 5
+
+
+def _resolve_auto_feed_limit(value: bool | int | None) -> int:
+    """Resolve authored auto-feed settings to a safe continuation limit.
+
+    ``True`` and ``None`` preserve the original five-cycle behavior, while
+    ``False`` and ``0`` disable follow-up submissions after the pending tool
+    batch executes. Booleans must be handled before integers because ``bool``
+    is an ``int`` subclass in Python.
+    """
+    if value is None or value is True:
+        return _LEGACY_AUTO_FEED_LIMIT
+    if value is False:
+        return 0
+    if isinstance(value, int):
+        if value < 0:
+            raise ValueError("auto_feed must be a non-negative integer")
+        return value
+    raise TypeError(
+        "auto_feed must be True, False, None, or a non-negative integer"
+    )
 
 
 _REASONING_SUMMARY_OPTIONS = frozenset({"auto", "concise", "detailed"})
@@ -376,7 +398,7 @@ class ChatParams:
     native_tools: Optional[List[dict]] = None  # Phase 3: provider-native tool dicts (web_search, code_interpreter, etc.)
     tool_choice: Optional[str] = None
     auto_execute: Optional[bool] = None  
-    auto_feed: Optional[bool] = True  # Whether to automatically feed tool results back to the model
+    auto_feed: bool | int | None = True  # True keeps the legacy five-cycle tool-result feed limit
 
     # Azure-specific parameters
     deployment: Optional[str] = None
@@ -390,6 +412,10 @@ class ChatParams:
     session: Optional[str] = None  # responses transport selector: None | inherit | new
     profile: Optional[dict] = None  # runtime profile/options; forwarded to adapters, stripped before provider API
     responses: Optional[dict] = None  # Phase 3: Responses API nested config (text, reasoning, include, store, export_state, etc.)
+
+    def __post_init__(self):
+        """Reject invalid automatic tool-result feed settings at construction."""
+        _resolve_auto_feed_limit(self.auto_feed)
 
 
     """
@@ -762,13 +788,14 @@ class ChatParamsMixin:
             self.params.tool_choice = value
 
     @property
-    def auto_feed(self) -> Optional[bool]:
+    def auto_feed(self) -> bool | int | None:
         if self.params is None:
             return None
         return self.params.auto_feed
 
     @auto_feed.setter
-    def auto_feed(self, value: bool):
+    def auto_feed(self, value: bool | int | None):
+        _resolve_auto_feed_limit(value)
         if self.params is None and value is not None:
             self.params = ChatParams()
         if self.params is not None:

--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -12,7 +12,24 @@ from ..runtime import EVENT_SCHEMA_VERSION
 from ..runtime.attachment_inputs import normalize_attachment_inputs
 
 from .mixin_messages import ChatMessagesMixin
-from .mixin_params import ChatParamsMixin, DEFAULT_MODEL_FALLBACK
+from .mixin_params import (
+    ChatParamsMixin,
+    DEFAULT_MODEL_FALLBACK,
+    _resolve_auto_feed_limit,
+)
+
+
+def _tool_call_name(tool_call) -> str:
+    """Return a useful name for an unexecuted tool-call diagnostic."""
+    if isinstance(tool_call, dict):
+        function = tool_call.get("function", {}) or {}
+        return function.get("name") or tool_call.get("type") or "unknown"
+    function = getattr(tool_call, "function", None)
+    return (
+        getattr(function, "name", None)
+        or getattr(tool_call, "type", None)
+        or "unknown"
+    )
 
 
 class ChatStreamListener:
@@ -811,17 +828,31 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
 
             # Check if we should auto-execute tools, default is we will
             if has_tool_calls and (self.params.auto_execute is None or self.params.auto_execute):
-                # Recursive tool call handling with max depth
-                max_tool_recursion = 5
-                current_recursion = 0
+                max_auto_feed_cycles = _resolve_auto_feed_limit(self.params.auto_feed)
+                auto_feed_cycles = 0
                 current_chat = new_chatprompt
 
                 # trace call that we got here and begin recursion
-                logger.trace("Tool call recursion, max depth: {max_depth}", max_depth=max_tool_recursion)
+                logger.trace(
+                    "Tool call recursion, auto-feed limit: {max_depth}",
+                    max_depth=max_auto_feed_cycles,
+                )
 
-                while has_tool_calls and current_recursion < max_tool_recursion:
-                    current_recursion += 1
-                    logger.debug(f"Tool recursion {current_recursion}/{max_tool_recursion}")
+                # A zero limit still executes the already-requested batch. It
+                # only suppresses the automatic follow-up submission.
+                while has_tool_calls and (
+                    auto_feed_cycles < max_auto_feed_cycles
+                    or max_auto_feed_cycles == 0
+                ):
+                    if max_auto_feed_cycles > 0:
+                        auto_feed_cycles += 1
+                        logger.debug(
+                            "Tool recursion {current}/{maximum}",
+                            current=auto_feed_cycles,
+                            maximum=max_auto_feed_cycles,
+                        )
+                    else:
+                        logger.debug("Executing pending tool calls without auto-feed")
                    
                     for tool_call in message.tool_calls:
                         tool_output = await self._execute_model_tool_call(tool_call)
@@ -831,7 +862,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
                         logger.debug(f"Current chat messages: {current_chat.get_messages()}")
                     
                     # Check if we should feed tool results back to the model
-                    if self.params.auto_feed is None or self.params.auto_feed:
+                    if max_auto_feed_cycles > 0:
                         # Use _submit_for_response_and_prompt for the follow-up call
                         # Since we want to use the current conversation as context, we create a temporary chat object
                         temp_chat = current_chat.copy()
@@ -869,14 +900,26 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
                                     current_chat = current_chat.assistant(assistant_turn)
                                 current_chat._set_runtime_metadata_from_response(follow_up)
                     else:
-                        # If auto_feed is False, break the tool call recursion loop
-                        # The assistant's tool calls are recorded but not fed back to the model
+                        # The pending tool batch executed, but its results are
+                        # not submitted for another model response.
                         has_tool_calls = False
-                        logger.debug("Not feeding tool results back to model due to auto_feed=False")
+                        logger.debug("Not feeding tool results back because auto_feed is disabled")
                 
-                # Log warning if we hit max recursion
-                if current_recursion >= max_tool_recursion and has_tool_calls:
-                    logger.warning(f"Reached maximum tool recursion depth ({max_tool_recursion})")
+                if (
+                    max_auto_feed_cycles > 0
+                    and auto_feed_cycles >= max_auto_feed_cycles
+                    and has_tool_calls
+                ):
+                    pending_names = ", ".join(
+                        _tool_call_name(tool_call)
+                        for tool_call in message.tool_calls
+                    )
+                    logger.warning(
+                        "Reached auto_feed limit ({maximum}); pending tool calls "
+                        "were recorded but not executed: {tool_names}",
+                        maximum=max_auto_feed_cycles,
+                        tool_names=pending_names,
+                    )
                     
                 # Return the chat with all tool interactions
                 return current_chat

--- a/chatsnack/skills/chatsnack-fluency/SKILL.md
+++ b/chatsnack/skills/chatsnack-fluency/SKILL.md
@@ -97,6 +97,13 @@ def save_note(title: str, body: str):
 chat = Chat("Use save_note when a note should persist.", utensils=[save_note])
 ```
 
+For an unusually long local-utensil chain, a positive integer `auto_feed=N`
+allows up to `N` automatic execution/result-feed cycles. Omitted, `None`, or
+`True` keeps the legacy five-cycle behavior. `False` or `0` executes the first
+pending batch without feeding its results back for another model response.
+Parallel calls in one assistant response count as one cycle. Keep this numeric
+knob in advanced examples; the common path should continue to omit it.
+
 ## Good Patterns
 
 Agentic coding prompt builder:

--- a/chatsnack/skills/chatsnack-fluency/references/pattern-atlas.md
+++ b/chatsnack/skills/chatsnack-fluency/references/pattern-atlas.md
@@ -246,7 +246,34 @@ chat = Chat(
 
 The YAML can say when issue creation is appropriate; Python provides the callable.
 
-## Tip 10: Add Custom Filling Namespaces Only For Real Catalogs
+## Tip 10: Budget Only The Long Utensil Chains
+
+Most chats should omit `auto_feed` and keep the legacy five-cycle automatic
+tool-result loop. When a known workflow needs more steps, put the larger budget
+on the `Chat` instead of adding orchestration around it:
+
+```python
+curator = Chat(
+    "Research the topic fully, then submit one curator plan.",
+    utensils=[resolve_names, search_articles, search_claims, read_articles, submit_curator_plan],
+    auto_feed=8,
+)
+```
+
+The same setting stays readable in saved YAML:
+
+```yaml
+params:
+  auto_feed: 8
+```
+
+A batch of parallel calls requested by one assistant response counts as one
+cycle. Omitted, `None`, or `True` means five cycles; `False` or `0` executes the
+first pending batch without sending its results back for another response. If a
+positive limit is exhausted, the next requested call stays in chat history but
+is not executed.
+
+## Tip 11: Add Custom Filling Namespaces Only For Real Catalogs
 
 Custom filling namespaces are useful when a project has a real external fragment catalog. They should feel like a narrow extension of fillings, not a replacement for saved `Text` and saved `Chat` assets.
 

--- a/chatsnack/yamlformat.py
+++ b/chatsnack/yamlformat.py
@@ -22,6 +22,7 @@ from loguru import logger
 from snapclass import formatters
 from ruamel.yaml import YAML as _YAML
 
+from .chat.mixin_params import _resolve_auto_feed_limit
 from .chat.turns import (
     CANONICAL_FIELD_ORDER,
     CANONICAL_SYSTEM_ROLE,
@@ -230,6 +231,15 @@ def _normalize_data_on_load(data):
         data["messages"] = [_normalize_message_on_load(m) for m in messages]
 
     params = data.get("params")
+    if isinstance(params, dict) and "auto_feed" in params:
+        # Validate the authored scalar before snapclass can coerce a float or
+        # string into one of the bool/int union members.
+        authored_auto_feed = params["auto_feed"]
+        _resolve_auto_feed_limit(authored_auto_feed)
+        if isinstance(authored_auto_feed, int) and not isinstance(authored_auto_feed, bool):
+            # Ruamel uses integer subclasses; normalize them so snapclass's
+            # bool-first union matching does not turn YAML ``0`` into False.
+            params["auto_feed"] = int(authored_auto_feed)
     if isinstance(params, dict) and isinstance(params.get("tools"), list):
         # Phase 4: compile compact authoring syntax under params.tools into
         # provider-shaped dicts, then split back to the current internal

--- a/docs/rfcs/phase-0-chat-compatibility-rfc.md
+++ b/docs/rfcs/phase-0-chat-compatibility-rfc.md
@@ -60,9 +60,11 @@ The compatibility behaviors in this RFC are frozen as the authoritative baseline
 
 ### Tool recursion
 - `auto_execute=None` behaves as enabled.
-- Max recursion depth is `5`.
-- `auto_feed=None` behaves as enabled, feeding tool output back for follow-up completion.
-- `auto_feed=False` records assistant/tool interactions and stops recursion.
+- The legacy recursion depth is `5` when `auto_feed` is omitted, `None`, or `True`.
+- A positive integer `auto_feed=N` allows up to `N` tool-result feed cycles.
+- `auto_feed=False` or `0` executes the first pending tool-call batch, records the assistant/tool interaction, and makes no follow-up completion.
+- Parallel tool calls from one assistant response count as one cycle.
+- When the limit is exhausted, the next assistant-requested tool call remains in history but is not executed, and the warning names the pending tool.
 - Tool-call metadata and tool messages are preserved in returned chat history.
 
 ### Return shape

--- a/notebooks/GettingStartedWithChatsnack.ipynb
+++ b/notebooks/GettingStartedWithChatsnack.ipynb
@@ -936,6 +936,29 @@
     "\n",
     "print(demo.ask(\"What is a Python decorator and how do I use it?\"))\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Longer utensil chains\n",
+    "\n",
+    "`auto_feed` controls ChatSnack's automatic local-utensil loop. Leave it unset (or use `True` / `None`) for the original five-cycle limit. A positive number allows that many tool-execution/feed cycles; `False` or `0` executes the first pending batch without asking the model to continue. Parallel calls in one assistant response count as one cycle.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "deep_research = Chat(\n",
+    "    \"Search until the documentation question is fully resolved.\",\n",
+    "    utensils=[docs_search],\n",
+    "    auto_feed=8,\n",
+    ")\n",
+    "print(deep_research.yaml)\n"
+   ]
   }
  ],
  "metadata": {

--- a/poetry.lock
+++ b/poetry.lock
@@ -909,14 +909,14 @@ oldlibyaml = ["ruamel.yaml.clib ; platform_python_implementation == \"CPython\""
 
 [[package]]
 name = "snapclass"
-version = "0.1.3"
+version = "0.2.0"
 description = "Human-readable file persistence for Python dataclasses."
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
 files = [
-    {file = "snapclass-0.1.3-py3-none-any.whl", hash = "sha256:320f46c1d2a3daf53211402cc3ddf77dacde46c9366a02d48b4089db56d5d351"},
-    {file = "snapclass-0.1.3.tar.gz", hash = "sha256:f97c5999db1137b4851f93a4bdabc68d84f53148667cf604467a8e073ccd055b"},
+    {file = "snapclass-0.2.0-py3-none-any.whl", hash = "sha256:681fd876e438df923c5813e77b33ed5d3be2dfbd8486256bca1d44d081dd1d8d"},
+    {file = "snapclass-0.2.0.tar.gz", hash = "sha256:d9de4271e385e0b6a5b44aa80255bf5da0ff36d5a593bf8b18c2049f8bd1ab93"},
 ]
 
 [package.dependencies]
@@ -925,8 +925,10 @@ json5 = ">=0.9,<1"
 tomlkit = ">=0.10,<0.16"
 
 [package.extras]
+benchmark = ["tiktoken (>=0.7,<1)"]
 test = ["pytest (>=8)"]
 typing = ["mypy (>=1.11,<3)"]
+yaml-fast = ["ruamel.yaml.clib (>=0.2.15,<0.3)", "tree-sitter (>=0.25,<0.27)", "tree-sitter-yaml (>=0.7.2,<0.8)"]
 
 [[package]]
 name = "sniffio"
@@ -1129,4 +1131,4 @@ rich = ["rich"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "908fc25d02d3c1674479764ec6b1c19ec11e916a9ca29f4bfd9fae268b9493f9"
+content-hash = "c34b7d9bcfd9444e73b8a3089c95e029febf1a49bc1996db39cc53cfea87476f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chatsnack"
-version = "0.6.2"
+version = "0.6.3"
 description = "chatsnack is the easiest Python library for rapid development with OpenAI's ChatGPT API. It provides an intuitive interface for creating and managing chat-based prompts and responses, making it convenient to build complex, interactive conversations with AI."
 authors = ["Mattie Casper"]
 license = "MIT"
@@ -11,7 +11,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.11"
-snapclass = "^0.1.3"
+snapclass = "^0.2.0"
 python-dotenv = "^1.0.0"
 loguru = "^0.6.0"
 nest-asyncio = "^1.5.6"

--- a/tests/test_auto_feed_limits.py
+++ b/tests/test_auto_feed_limits.py
@@ -1,0 +1,263 @@
+from types import SimpleNamespace
+
+import pytest
+from loguru import logger
+from snapclass import SnapclassError
+
+from chatsnack import Chat, ChatParams
+
+
+_OMITTED = object()
+
+
+class _FakeAiClient:
+    client = SimpleNamespace()
+    aclient = SimpleNamespace()
+
+    def ensure_responses_support(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _use_lightweight_ai_client(monkeypatch):
+    """Keep tool-loop tests local and avoid opening real SDK clients."""
+    monkeypatch.setattr("chatsnack.chat.AiClient", _FakeAiClient)
+
+
+class _ToolCall:
+    def __init__(self, name: str, index: int):
+        self.id = f"call_{index}"
+        self.type = "function"
+        self.function = SimpleNamespace(name=name, arguments="{}")
+
+
+class _ToolMessage:
+    content = None
+
+    def __init__(self, *names: str, offset: int = 0):
+        self.tool_calls = [
+            _ToolCall(name, offset + index)
+            for index, name in enumerate(names)
+        ]
+
+
+async def _run_tool_chain(chat, monkeypatch, tool_batches, auto_feed=_OMITTED):
+    batches = iter(tool_batches)
+    first_batch = next(batches)
+    follow_ups = []
+    executed = []
+
+    async def fake_submit(**kwargs):
+        return "[]", _ToolMessage(*first_batch)
+
+    async def fake_follow_up(self, prompt, **kwargs):
+        follow_ups.append(prompt)
+        try:
+            names = next(batches)
+        except StopIteration:
+            return "done"
+        return _ToolMessage(*names, offset=len(follow_ups) * 10)
+
+    def fake_execute(tool_call):
+        executed.append(tool_call["function"]["name"])
+        return {"accepted": True}
+
+    monkeypatch.setattr(chat, "_submit_for_response_and_prompt", fake_submit)
+    monkeypatch.setattr(Chat, "_cleaned_chat_completion", fake_follow_up)
+    monkeypatch.setattr(chat, "execute_tool_call", fake_execute)
+
+    chat.auto_execute = True
+    if auto_feed is not _OMITTED:
+        chat.auto_feed = auto_feed
+    output = await chat.chat_a()
+    return output, executed, follow_ups
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("runtime", ["responses", "chat_completions"])
+async def test_auto_feed_six_executes_sixth_terminal_tool(runtime, monkeypatch):
+    """Goal: a longer curator chain can execute its sixth terminal utensil."""
+    chat = Chat(runtime=runtime)
+    batches = [
+        ["resolve_names"],
+        ["search_articles"],
+        ["search_claims"],
+        ["search_claims"],
+        ["read_articles"],
+        ["submit_curator_plan"],
+    ]
+
+    output, executed, follow_ups = await _run_tool_chain(
+        chat,
+        monkeypatch,
+        batches,
+        auto_feed=6,
+    )
+
+    assert executed == [batch[0] for batch in batches]
+    assert len(follow_ups) == 6
+    assert output.last == "done"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auto_feed",
+    [_OMITTED, True, None],
+    ids=["omitted", "true", "none"],
+)
+async def test_legacy_auto_feed_limit_retains_sixth_pending_call(
+    auto_feed,
+    monkeypatch,
+):
+    """Companion Goal: legacy settings still allow exactly five feed cycles."""
+    chat = Chat()
+    batches = [[f"tool_{index}"] for index in range(1, 6)]
+    batches.append(["submit_curator_plan"])
+
+    output, executed, follow_ups = await _run_tool_chain(
+        chat,
+        monkeypatch,
+        batches,
+        auto_feed=auto_feed,
+    )
+
+    assert executed == [f"tool_{index}" for index in range(1, 6)]
+    assert len(follow_ups) == 5
+    assert output.get_messages()[-1]["tool_calls"][0]["function"]["name"] == "submit_curator_plan"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("auto_feed", [False, 0])
+async def test_zero_and_false_execute_pending_batch_without_follow_up(
+    auto_feed,
+    monkeypatch,
+):
+    chat = Chat()
+
+    output, executed, follow_ups = await _run_tool_chain(
+        chat,
+        monkeypatch,
+        [["resolve_names"], ["unused_follow_up"]],
+        auto_feed=auto_feed,
+    )
+
+    assert executed == ["resolve_names"]
+    assert follow_ups == []
+    assert output.get_messages()[-1]["content"] == '{"accepted": true}'
+
+
+@pytest.mark.asyncio
+async def test_one_feed_cycle_counts_parallel_calls_as_one_batch(monkeypatch):
+    chat = Chat()
+
+    output, executed, follow_ups = await _run_tool_chain(
+        chat,
+        monkeypatch,
+        [["search_articles", "search_claims"], ["submit_curator_plan"]],
+        auto_feed=1,
+    )
+
+    assert executed == ["search_articles", "search_claims"]
+    assert len(follow_ups) == 1
+    assert output.get_messages()[-1]["tool_calls"][0]["function"]["name"] == "submit_curator_plan"
+
+
+@pytest.mark.asyncio
+async def test_exhaustion_warning_names_unexecuted_tool(monkeypatch):
+    chat = Chat()
+    warnings = []
+    sink = logger.add(warnings.append, level="WARNING", format="{message}")
+    try:
+        await _run_tool_chain(
+            chat,
+            monkeypatch,
+            [["resolve_names"], ["submit_curator_plan"]],
+            auto_feed=1,
+        )
+    finally:
+        logger.remove(sink)
+
+    warning = "\n".join(str(message) for message in warnings)
+    assert "auto_feed limit (1)" in warning
+    assert "recorded but not executed" in warning
+    assert "submit_curator_plan" in warning
+
+
+def test_auto_feed_default_and_invalid_values():
+    assert ChatParams().auto_feed is True
+
+    with pytest.raises(ValueError, match="non-negative"):
+        ChatParams(auto_feed=-1)
+
+    with pytest.raises(TypeError, match="True, False, None"):
+        ChatParams(auto_feed=1.5)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_type"),
+    [
+        (True, bool),
+        (False, bool),
+        (0, int),
+        (1, int),
+        (12, int),
+    ],
+)
+def test_auto_feed_values_round_trip_through_chat_yaml(
+    tmp_path,
+    value,
+    expected_type,
+):
+    path = tmp_path / f"AutoFeed{value!s}.yml"
+    chat = Chat(
+        name=path.stem,
+        params=ChatParams(auto_feed=value),
+    )
+
+    chat.save(path)
+    loaded = Chat(name=path.stem)
+    loaded.load(path)
+
+    assert loaded.params.auto_feed == value
+    assert type(loaded.params.auto_feed) is expected_type
+
+
+def test_legacy_yaml_without_auto_feed_loads_true(tmp_path):
+    path = tmp_path / "LegacyAutoFeed.yml"
+    path.write_text(
+        "params:\n"
+        "  model: gpt-4-turbo\n"
+        "messages: []\n",
+        encoding="utf-8",
+    )
+
+    loaded = Chat(name=path.stem)
+    loaded.load(path)
+
+    assert loaded.params.auto_feed is True
+
+
+@pytest.mark.parametrize(
+    ("yaml_value", "message"),
+    [
+        ("-1", "non-negative"),
+        ("1.5", "True, False, None"),
+        ("many", "True, False, None"),
+    ],
+)
+def test_invalid_auto_feed_yaml_is_rejected_before_coercion(
+    tmp_path,
+    yaml_value,
+    message,
+):
+    path = tmp_path / "InvalidAutoFeed.yml"
+    path.write_text(
+        "params:\n"
+        f"  auto_feed: {yaml_value}\n"
+        "messages: []\n",
+        encoding="utf-8",
+    )
+
+    loaded = Chat(name=path.stem)
+    with pytest.raises(SnapclassError, match=message):
+        loaded.load(path)


### PR DESCRIPTION
## Summary

- allow `auto_feed` to accept non-negative integer cycle limits while preserving the legacy boolean and null behavior
- keep omitted, `true`, and `null` at the existing five-cycle limit
- execute the pending tool batch without another model turn for `false` and `0`
- retain and name unexecuted pending tool calls when the cycle budget is exhausted
- document longer utensil chains in the README, Getting Started notebook, RFC, and packaged fluency guidance
- release ChatSnack `0.6.3` with published `snapclass ^0.2.0`

## Root cause

The query loop hardcoded a maximum of five tool-execution/feed cycles. If the model requested the correct terminal tool on its sixth response, ChatSnack recorded that assistant tool call but stopped before executing it. Downstream code then reported that no submission was received, obscuring that the real failure was exhaustion of ChatSnack's internal tool-call budget.

## Compatibility

Existing supported configurations retain their behavior:

- omitted, `true`, and `null`: five automatic cycles
- `false` and `0`: execute the first pending batch without feeding results back
- positive integer `N`: allow at most `N` execution/feed cycles

Parallel tool calls in one assistant response count as one cycle.

## Validation

- 108 persistence, YAML, serialization, compact-tool, and `auto_feed` tests passed
- 241 runtime and session tests passed
- 139 query/utensil tests passed; 21 live tests skipped
- 52 core Chat/Text/package tests passed
- notebook metadata pass: 1 passed, 2 skipped, 44 live/non-selected cells deselected
- built the `0.6.3` wheel and installed it in a fresh Python 3.11 virtual environment
- fresh-wheel smoke test confirmed `chatsnack==0.6.3`, `snapclass==0.2.0`, and exact YAML preservation of numeric `auto_feed: 0`
- `poetry check` and `pip check` completed without errors

Live OpenAI calls were explicitly disabled during regression testing.