### PR TITLE
Add aggregate runtime usage tracking

### DIFF
--- a/chatsnack/__init__.py
+++ b/chatsnack/__init__.py
@@ -94,6 +94,7 @@ from .asynchelpers import aformatter
 from .chat import Chat, Text, ChatParams
 from . import packs
 from .utensil import utensil, get_all_utensils, get_openai_tools, UtensilGroup, HostedUtensil
+from .runtime import CallUsage, ResponseUsage, UsageCounts
 
 from .fillings import active_filling_stash, snack_catalog, filling_machine
 

--- a/chatsnack/chat/__init__.py
+++ b/chatsnack/chat/__init__.py
@@ -11,6 +11,7 @@ from snapclass import snapclass
 from ..aiclient import AiClient
 from ..defaults import CHATSNACK_PROMPTS
 from ..runtime import (
+    CallUsage,
     ChatCompletionsAdapter,
     ResponsesAdapter,
     ResponsesWebSocketAdapter,
@@ -267,6 +268,7 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
             session_mode = self.session
         self.runtime = self._select_runtime(runtime=runtime, runtime_selector=runtime_selector, profile=profile, session_mode=session_mode)
         self._last_runtime_metadata = _empty_runtime_metadata()
+        self._last_call_usage = None
 
 
    
@@ -328,6 +330,11 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
         """Close every tracked shared Responses WebSocket session."""
         ResponsesWebSocketAdapter.close_all_sessions()
 
+    @property
+    def last_call_usage(self) -> Optional[CallUsage]:
+        """Usage snapshot from the most recently finished ``chat()`` call."""
+        return self._last_call_usage
+
     def reset(self) -> object:
         """Restore the chat to the state captured immediately after initialization."""
         self.name = self._initial_name
@@ -342,6 +349,7 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
             # Re-load tools from the initial registry
             self._load_tools_from_params()
         self._last_runtime_metadata = _empty_runtime_metadata()
+        self._last_call_usage = None
         return self
     
     def _load_tools_from_params(self):
@@ -561,6 +569,8 @@ def _ensure_chat_live_state(self):
         )
     if not hasattr(self, "_last_runtime_metadata"):
         self._last_runtime_metadata = _empty_runtime_metadata()
+    if not hasattr(self, "_last_call_usage"):
+        self._last_call_usage = None
     if not hasattr(self, "_initial_name"):
         _capture_chat_reset_state(self)
 
@@ -581,6 +591,7 @@ def _refresh_chat_after_snapshot_load(self):
         session_mode=session_mode,
     )
     self._last_runtime_metadata = _empty_runtime_metadata()
+    self._last_call_usage = None
     _capture_chat_reset_state(self)
 
 

--- a/chatsnack/chat/__init__.py
+++ b/chatsnack/chat/__init__.py
@@ -332,7 +332,7 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
 
     @property
     def last_call_usage(self) -> Optional[CallUsage]:
-        """Usage snapshot from the most recently finished ``chat()`` call."""
+        """Usage from the latest completed or failed ``chat()``/``chat_a()`` call."""
         return self._last_call_usage
 
     def reset(self) -> object:

--- a/chatsnack/chat/mixin_params.py
+++ b/chatsnack/chat/mixin_params.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass, field
 from snapclass import snapclass
 
 
-DEFAULT_MODEL_FALLBACK = "gpt-5-chat-latest"
+# Favor a stable cross-runtime/tool baseline over a rolling chat-only alias.
+DEFAULT_MODEL_FALLBACK = "gpt-5.4"
 _LEGACY_AUTO_FEED_LIMIT = 5
 
 

--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -443,7 +443,12 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
             kwargs.pop("tool_choice", None)
         return kwargs
 
-    async def _submit_for_response_and_prompt(self, track_continuation: bool = False, **additional_vars):
+    async def _submit_for_response_and_prompt(
+        self,
+        track_continuation: bool = False,
+        _call_usage_ledger=None,
+        **additional_vars,
+    ):
         """ Executes the query as-is and returns a tuple of the final prompt and the response"""
         prompter = self
         # if the user in additional_vars, we're going to instead deepcopy this prompt into a new prompt and add the .user() to it
@@ -467,6 +472,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
             return prompt, await prompter._cleaned_chat_completion(
                 prompt,
                 track_continuation=track_continuation,
+                _call_usage_ledger=_call_usage_ledger,
                 **kwargs,
             )
 
@@ -575,7 +581,13 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         meta = self._normalize_runtime_metadata(response)
         self._set_last_runtime_metadata(meta)
 
-    async def _cleaned_chat_completion(self, prompt, track_continuation: bool = False, **kwargs):
+    async def _cleaned_chat_completion(
+        self,
+        prompt,
+        track_continuation: bool = False,
+        _call_usage_ledger=None,
+        **kwargs,
+    ):
         # if there's no model specified, use the default
         if "model" not in kwargs:
             # if there's an engine in the kwargs, use that as the model
@@ -606,6 +618,8 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
                 if last_response_id:
                     request_kwargs["previous_response_id"] = last_response_id
             normalized = await adapter.create_completion_a(messages=messages, **request_kwargs)
+            if _call_usage_ledger is not None:
+                _call_usage_ledger.record(normalized)
             response = normalized
             if track_continuation:
                 self._set_last_runtime_metadata(self._normalize_runtime_metadata(normalized))
@@ -769,13 +783,42 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         return self._run_sync(self.chat_a(**additional_vars), "chat")
         
     async def chat_a(self, usermsg=None, files=None, images=None, **additional_vars) -> object:
-        """Async form of `chat()`."""
+        """Return a continued chat with call-scoped provider usage attached."""
+        from ..runtime.usage import _CallUsageLedger
+
         additional_vars = self._prepare_query_vars(usermsg, files=files, images=images, **additional_vars)
-            
+
+        ledger = _CallUsageLedger()
+        self._last_call_usage = None
+        try:
+            completed = await self._chat_a_with_usage(
+                _call_usage_ledger=ledger,
+                **additional_vars,
+            )
+        except BaseException as exc:
+            snapshot = ledger.snapshot()
+            self._last_call_usage = snapshot
+            try:
+                setattr(exc, "last_call_usage", snapshot)
+            except Exception:
+                pass
+            raise
+
+        snapshot = ledger.snapshot()
+        self._last_call_usage = snapshot
+        completed._last_call_usage = snapshot
+        return completed
+
+    async def _chat_a_with_usage(self, _call_usage_ledger, **additional_vars) -> object:
+        """Run one chat orchestration while sharing its private response ledger."""
         if self.stream:
             raise Exception("Cannot use chat() with a stream")
         
-        prompt, response = await self._submit_for_response_and_prompt(track_continuation=True, **additional_vars)
+        prompt, response = await self._submit_for_response_and_prompt(
+            track_continuation=True,
+            _call_usage_ledger=_call_usage_ledger,
+            **additional_vars,
+        )
         
         # create a new chatprompt with the new name, copy it from this one
         new_chatprompt = self.__class__(
@@ -872,6 +915,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
                         follow_up = await temp_chat._cleaned_chat_completion(
                             new_prompt,
                             track_continuation=True,
+                            _call_usage_ledger=_call_usage_ledger,
                             **temp_chat._build_tool_followup_request_kwargs(),
                         )
                         

--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -789,7 +789,6 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         additional_vars = self._prepare_query_vars(usermsg, files=files, images=images, **additional_vars)
 
         ledger = _CallUsageLedger()
-        self._last_call_usage = None
         try:
             completed = await self._chat_a_with_usage(
                 _call_usage_ledger=ledger,

--- a/chatsnack/chat/mixin_utensil.py
+++ b/chatsnack/chat/mixin_utensil.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Union, Any
 from loguru import logger
 
 from ..utensil import get_openai_tools, handle_tool_call, UtensilFunction, UtensilGroup, HostedUtensil
-from .mixin_params import ChatParams  # Changed to import from mixin_params instead
+from .mixin_params import ChatParams, DEFAULT_MODEL_FALLBACK
 
 
 class ChatUtensilMixin:
@@ -305,7 +305,7 @@ class ChatUtensilMixin:
                     # remove engine for newest models as of Nov 13 2023
                     del out["engine"]
                 else:
-                    out["model"] = "gpt-5-chat-latest"
+                    out["model"] = DEFAULT_MODEL_FALLBACK
             self.kwargs = out
 
         async def start_a(self):

--- a/chatsnack/runtime/__init__.py
+++ b/chatsnack/runtime/__init__.py
@@ -11,6 +11,7 @@ from .types import (
     RuntimeTerminalMetadata,
 )
 from .attachment_resolver import AttachmentResolver
+from .usage import CallUsage, ResponseUsage, UsageCounts
 from .chat_completions_adapter import ChatCompletionsAdapter
 from .responses_adapter import ResponsesAdapter
 from .responses_websocket_adapter import (
@@ -32,6 +33,9 @@ __all__ = [
     "RuntimeTerminalMetadata",
     "RuntimeErrorPayload",
     "AttachmentResolver",
+    "UsageCounts",
+    "ResponseUsage",
+    "CallUsage",
     "ChatCompletionsAdapter",
     "ResponsesAdapter",
     "ResponsesWebSocketAdapter",

--- a/chatsnack/runtime/chat_completions_adapter.py
+++ b/chatsnack/runtime/chat_completions_adapter.py
@@ -100,6 +100,7 @@ class ChatCompletionsAdapter:
             finish_reason=choice.get("finish_reason"),
             model=response_dict.get("model"),
             usage=response_dict.get("usage"),
+            metadata={"response_id": response_dict.get("id")},
         )
 
     def create_completion(self, messages: List[Dict[str, Any]], **kwargs: Any) -> NormalizedCompletionResult:

--- a/chatsnack/runtime/responses_common.py
+++ b/chatsnack/runtime/responses_common.py
@@ -427,7 +427,8 @@ class ResponsesNormalizationMixin:
 
         metadata = {
             "response_id": response_dict.get("id"),
-            "previous_response_id": request_kwargs.get("previous_response_id"),
+            "previous_response_id": response_dict.get("previous_response_id")
+            or request_kwargs.get("previous_response_id"),
             "assistant_phase": assistant_phase,
             "provider_extras": {
                 "status": response_dict.get("status"),

--- a/chatsnack/runtime/usage.py
+++ b/chatsnack/runtime/usage.py
@@ -104,12 +104,13 @@ def _known_count(
     usage: Mapping[str, Any],
     *paths: Tuple[str, ...],
 ) -> Optional[int]:
+    """Return the first integer found across compatible provider aliases."""
     for path in paths:
         value = _value_at(usage, path)
         if value is _MISSING:
             continue
         if isinstance(value, bool) or not isinstance(value, int):
-            return None
+            continue
         return value
     return None
 

--- a/chatsnack/runtime/usage.py
+++ b/chatsnack/runtime/usage.py
@@ -1,0 +1,200 @@
+"""Provider-neutral usage snapshots for one Chatsnack call."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
+
+from .types import NormalizedCompletionResult
+
+
+@dataclass(frozen=True)
+class UsageCounts:
+    """Known token counts, preserving absence separately from reported zero."""
+
+    input_tokens: Optional[int] = None
+    cached_input_tokens: Optional[int] = None
+    output_tokens: Optional[int] = None
+    reasoning_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class ResponseUsage:
+    """Usage and provider identity captured from one completed response."""
+
+    sequence: int
+    response_id: Optional[str]
+    previous_response_id: Optional[str]
+    model: Optional[str]
+    input_tokens: Optional[int]
+    cached_input_tokens: Optional[int]
+    output_tokens: Optional[int]
+    reasoning_tokens: Optional[int]
+    total_tokens: Optional[int]
+    usage_reported: bool
+    provider_usage: Optional[Dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class CallUsage:
+    """Immutable ordered usage snapshot for one ``chat()`` or ``chat_a()`` call."""
+
+    responses: Tuple[ResponseUsage, ...] = ()
+
+    @property
+    def total(self) -> UsageCounts:
+        """Sum every reported value while leaving wholly absent fields unknown."""
+        return UsageCounts(
+            input_tokens=_sum_known(self.responses, "input_tokens"),
+            cached_input_tokens=_sum_known(self.responses, "cached_input_tokens"),
+            output_tokens=_sum_known(self.responses, "output_tokens"),
+            reasoning_tokens=_sum_known(self.responses, "reasoning_tokens"),
+            total_tokens=_sum_known(self.responses, "total_tokens"),
+        )
+
+    @property
+    def response_count(self) -> int:
+        """Number of normalized provider responses observed during the call."""
+        return len(self.responses)
+
+    @property
+    def usage_response_count(self) -> int:
+        """Number of responses that supplied a non-null usage payload."""
+        return sum(response.usage_reported for response in self.responses)
+
+    @property
+    def is_complete(self) -> bool:
+        """Whether every observed response supplied a usage payload."""
+        return bool(self.responses) and self.usage_response_count == self.response_count
+
+    @property
+    def missing_usage_sequences(self) -> Tuple[int, ...]:
+        """One-based response positions whose provider usage payload was absent."""
+        return tuple(
+            response.sequence
+            for response in self.responses
+            if not response.usage_reported
+        )
+
+
+def _sum_known(responses: Sequence[ResponseUsage], field_name: str) -> Optional[int]:
+    values = [
+        value
+        for response in responses
+        if (value := getattr(response, field_name)) is not None
+    ]
+    return sum(values) if values else None
+
+
+_MISSING = object()
+
+
+def _value_at(mapping: Mapping[str, Any], path: Tuple[str, ...]):
+    current: Any = mapping
+    for key in path:
+        if not isinstance(current, Mapping) or key not in current:
+            return _MISSING
+        current = current[key]
+    return current
+
+
+def _known_count(
+    usage: Mapping[str, Any],
+    *paths: Tuple[str, ...],
+) -> Optional[int]:
+    for path in paths:
+        value = _value_at(usage, path)
+        if value is _MISSING:
+            continue
+        if isinstance(value, bool) or not isinstance(value, int):
+            return None
+        return value
+    return None
+
+
+def _plain_usage_mapping(usage: Any) -> Dict[str, Any]:
+    """Detach an SDK/provider usage object into ordinary nested Python data."""
+    if isinstance(usage, Mapping):
+        value = dict(usage)
+    elif hasattr(usage, "model_dump"):
+        value = usage.model_dump()
+    elif hasattr(usage, "__dict__"):
+        value = vars(usage)
+    else:
+        try:
+            value = dict(usage)
+        except (TypeError, ValueError):
+            value = {}
+    return deepcopy(value) if isinstance(value, dict) else {}
+
+
+def _response_usage_from_completion(
+    completion: NormalizedCompletionResult,
+    sequence: int,
+) -> ResponseUsage:
+    usage_reported = getattr(completion, "usage", None) is not None
+    provider_usage = (
+        _plain_usage_mapping(completion.usage)
+        if usage_reported
+        else None
+    )
+    usage = provider_usage or {}
+    metadata = getattr(completion, "metadata", None) or {}
+
+    return ResponseUsage(
+        sequence=sequence,
+        response_id=metadata.get("response_id"),
+        previous_response_id=metadata.get("previous_response_id"),
+        model=getattr(completion, "model", None),
+        input_tokens=_known_count(
+            usage,
+            ("input_tokens",),
+            ("prompt_tokens",),
+        ),
+        cached_input_tokens=_known_count(
+            usage,
+            ("input_tokens_details", "cached_tokens"),
+            ("prompt_tokens_details", "cached_tokens"),
+            ("cached_input_tokens",),
+            ("input_cached_tokens",),
+        ),
+        output_tokens=_known_count(
+            usage,
+            ("output_tokens",),
+            ("completion_tokens",),
+        ),
+        reasoning_tokens=_known_count(
+            usage,
+            ("output_tokens_details", "reasoning_tokens"),
+            ("completion_tokens_details", "reasoning_tokens"),
+            ("reasoning_tokens",),
+        ),
+        total_tokens=_known_count(usage, ("total_tokens",)),
+        usage_reported=usage_reported,
+        provider_usage=provider_usage,
+    )
+
+
+class _CallUsageLedger:
+    """Mutable call-local collector that freezes into a public ``CallUsage``."""
+
+    def __init__(self):
+        self._responses: list[ResponseUsage] = []
+
+    def record(self, completion: NormalizedCompletionResult) -> None:
+        """Record the normalized result at the adapter-return boundary once."""
+        self._responses.append(
+            _response_usage_from_completion(
+                completion,
+                sequence=len(self._responses) + 1,
+            )
+        )
+
+    def snapshot(self) -> CallUsage:
+        """Freeze the current order of already-detached response values."""
+        return CallUsage(responses=tuple(self._responses))
+
+
+__all__ = ["UsageCounts", "ResponseUsage", "CallUsage"]

--- a/docs/guides/yaml-and-assets.md
+++ b/docs/guides/yaml-and-assets.md
@@ -59,7 +59,7 @@ from chatsnack import Chat
 
 wisechat = Chat("Respond with professional writing based on the user query.")
 wisechat.user("Author an alliterative poem about good snacks to eat with coffee.")
-wisechat.model = "gpt-5-chat-latest"
+wisechat.model = "gpt-5.4"
 ```
 
 That keeps a prompt asset close to the exact runtime configuration we meant to use.

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -38,7 +38,7 @@ Chats serialize cleanly to YAML, which means our prompts can be readable, editab
 
 ```yaml
 params:
-  model: gpt-5-chat-latest
+  model: gpt-5.4
 messages:
   - system: Respond with professional writing based on the user query.
   - user: Author an alliterative poem about good snacks to eat with coffee.

--- a/docs/projects/aggregate-runtime-usage-checklist.md
+++ b/docs/projects/aggregate-runtime-usage-checklist.md
@@ -1,0 +1,61 @@
+# Aggregate Runtime Usage Checklist
+
+> Tracks implementation of the [aggregate runtime usage RFC](../rfcs/aggregate-runtime-usage-rfc.md).
+
+## Public usage values
+
+- [x] Add provider-neutral `UsageCounts`, `ResponseUsage`, and `CallUsage` values
+  _Available from the `chatsnack` package root with intent-focused docstrings._
+- [x] Preserve missing counts as `None` and reported zero as `0`
+  _Covered for Responses and Chat Completions field shapes._
+- [x] Retain a detached plain-data copy of each provider usage mapping
+  _Nested provider values are deep-copied when recorded; freezing reuses those
+  detached response values in an ordered tuple._
+- [x] Expose response count, usage coverage, completeness, and missing sequences
+  _All response positions are one-based and ordered._
+
+## Call orchestration
+
+- [x] Start an independent ledger for each `chat()` or `chat_a()` call
+  _The sync surface delegates to the async call owner._
+- [x] Record once where a normalized adapter completion first returns
+  _Temporary-chat metadata propagation does not record ledger entries._
+- [x] Share the ledger through utensil auto-feed follow-ups
+  _A two-response utensil Goal test proves two entries and two provider requests._
+- [x] Preserve partial usage on failure without wrapping the exception
+  _The source chat and assignable exception expose the frozen partial call._
+- [x] Keep `_last_runtime_metadata["usage"]` scoped to the latest response
+  _Existing continuation behavior remains available beside aggregate usage._
+
+## Model and persistence safety
+
+- [x] Keep `_last_call_usage` private, unannotated, and transient
+  _The public surface is the read-only `Chat.last_call_usage` property._
+- [x] Clear usage on construction, copy, reset, and load
+  _Lifecycle tests cover each operation._
+- [x] Keep ordinary and `export_state` YAML free of the ledger
+  _Runtime usage remains outside authored prompt assets._
+
+## Adapter fidelity and compatibility
+
+- [x] Preserve Chat Completions response IDs
+  _Normalized metadata now carries the provider response ID._
+- [x] Prefer the Responses payload's previous response ID
+  _Request metadata remains the fallback._
+- [x] Cover Responses HTTP, Responses WebSocket, and Chat Completions shapes
+  _Existing adapter fixtures plus usage contract fixtures cover all current adapters._
+- [x] Cover OpenRouter-compatible and Azure-compatible response shapes
+  _Azure coverage is fixture-based and best-effort; live Azure remains unverified._
+
+## Documentation and verification
+
+- [x] Add a compact API reference example
+  _The Chat reference shows totals, coverage, and per-response inspection._
+- [x] Add an exploratory notebook cell
+  _The artifact utensil workflow shows aggregate totals, coverage, missing usage
+  sequences, and ordered per-response details after its auto-feed call._
+- [ ] Run the complete test suite
+  _Repository run: 555 passed, 1 skipped, and 8 existing provider-backed tests
+  failed because `gpt-5-chat-latest` is deprecated in the configured live environment.
+  The implicit fallback is now `gpt-5.4`, and focused offline default, listener,
+  query-submission, and usage suites pass; the live full suite has not been rerun._

--- a/docs/reference/api/chat.md
+++ b/docs/reference/api/chat.md
@@ -3,3 +3,38 @@
 `Chat` is the primary unit of work in chatsnack.
 
 ::: chatsnack.Chat
+
+## Runtime usage
+
+Every completed `chat()` or `chat_a()` call leaves an in-memory usage snapshot
+on both the source chat and the returned chat:
+
+```python
+completed = chat.chat("Make the snack plan.")
+usage = completed.last_call_usage
+
+print(usage.response_count)
+print(usage.total)
+
+for response in usage.responses:
+    print(response.sequence, response.model, response.total_tokens)
+```
+
+`usage.responses` includes every provider response created during that call,
+including automatic utensil follow-ups. Each `response.provider_usage` keeps a
+detached copy of that provider's usage mapping for fields outside the normalized
+counts.
+
+Providers may omit usage. Those calls still complete, the corresponding
+response remains in order, and `usage.is_complete` is `False`. Reported zeroes
+remain `0`; missing counts remain `None`. Totals from an incomplete call are
+known lower bounds.
+
+The snapshot is call-scoped runtime data. It is cleared by copy, reset, and
+load operations and does not appear in saved YAML.
+
+::: chatsnack.UsageCounts
+
+::: chatsnack.ResponseUsage
+
+::: chatsnack.CallUsage

--- a/docs/rfcs/aggregate-runtime-usage-rfc.md
+++ b/docs/rfcs/aggregate-runtime-usage-rfc.md
@@ -1,0 +1,58 @@
+# RFC: Aggregate Runtime Usage Across One Chat Call
+
+## Status
+
+Accepted and implemented.
+
+## Decision
+
+Chatsnack records one provider-neutral usage item for every normalized provider
+completion returned during a public `chat()` or `chat_a()` call. The ordered,
+frozen result is exposed as `Chat.last_call_usage` on the source chat and the
+returned chat.
+
+Collection happens at the adapter-return boundary. Metadata setters and
+temporary chats may propagate the latest response state without creating more
+usage entries.
+
+## Public contract
+
+`CallUsage.responses` contains one-based `ResponseUsage` values. Each response
+includes provider IDs, model, normalized counts, coverage, and a deep-copied
+plain mapping of the original usage payload.
+
+Responses and Chat Completions usage names share these normalized fields:
+
+| Normalized field | Responses | Chat Completions |
+| --- | --- | --- |
+| `input_tokens` | `input_tokens` | `prompt_tokens` |
+| `cached_input_tokens` | `input_tokens_details.cached_tokens` | `prompt_tokens_details.cached_tokens` |
+| `output_tokens` | `output_tokens` | `completion_tokens` |
+| `reasoning_tokens` | `output_tokens_details.reasoning_tokens` | `completion_tokens_details.reasoning_tokens` |
+| `total_tokens` | `total_tokens` | `total_tokens` |
+
+Every aggregate field sums reported values and remains `None` when no response
+reported that field. A non-null empty usage object counts as reported usage.
+An absent usage payload creates a response item with `usage_reported=False` and
+makes the call incomplete.
+
+## Lifecycle
+
+Each public call owns an independent private ledger. Success freezes one
+snapshot for the source and returned chats. Failure freezes the partial ledger
+on the source chat and attaches it to the original exception when that exception
+accepts attributes.
+
+`_last_call_usage` is unannotated live state. Construction, manual copy, reset,
+and load begin with `None`, and YAML serialization stays unchanged.
+
+## Provider and transport coverage
+
+Normalization follows response shape. It covers Chatsnack's existing Responses
+HTTP, Responses WebSocket, and Chat Completions adapters, including compatible
+OpenRouter response shapes. Azure OpenAI uses the same fixture-backed paths and
+is best-effort because no live Azure environment was available for this change.
+
+Provider work without a completed payload reaching Chatsnack cannot appear in
+the ledger. This RFC adds no provider request, local token estimate, pricing,
+budget, session total, or new transport.

--- a/notebooks/ExperimentingWithChatsnack.ipynb
+++ b/notebooks/ExperimentingWithChatsnack.ipynb
@@ -543,6 +543,36 @@
     "print(turn2.last)\n",
     "print(turn2.yaml)\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Inspect Call Usage\n",
+    "A utensil call may need more than one provider response. The returned `Chat` keeps the whole call's usage together."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "usage = turn1.last_call_usage\n",
+    "print(f\"usage coverage: {usage.usage_response_count}/{usage.response_count} responses\")\n",
+    "print(\"totals:\", usage.total)\n",
+    "\n",
+    "if not usage.is_complete:\n",
+    "    print(\"missing usage from responses:\", usage.missing_usage_sequences)\n",
+    "\n",
+    "for response in usage.responses:\n",
+    "    print({\n",
+    "        \"response\": response.sequence,\n",
+    "        \"model\": response.model,\n",
+    "        \"tokens\": response.total_tokens,\n",
+    "        \"usage_reported\": response.usage_reported,\n",
+    "    })\n"
+   ]
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chatsnack"
-version = "0.6.3"
+version = "0.6.4"
 description = "chatsnack is the easiest Python library for rapid development with OpenAI's ChatGPT API. It provides an intuitive interface for creating and managing chat-based prompts and responses, making it convenient to build complex, interactive conversations with AI."
 authors = ["Mattie Casper"]
 license = "MIT"

--- a/tests/mixins/test_chatparams.py
+++ b/tests/mixins/test_chatparams.py
@@ -74,7 +74,7 @@ def test_set_tool_choice_creates_params(chat_params_mixin):
 
 
 # Existing engine tests for various models; you can skip these if needed.
-@pytest.mark.parametrize("engine", ["gpt-3.5-turbo", "gpt-4", "gpt-4o", "o1", "o3-mini", "gpt-4o-mini", "gpt-4-turbo", "gpt-5-chat-latest", "gpt-5-nano", "gpt-5-mini", "gpt-5.3-chat-latest", "gpt-5.4"])
+@pytest.mark.parametrize("engine", ["gpt-3.5-turbo", "gpt-4", "gpt-4o", "o1", "o3-mini", "gpt-4o-mini", "gpt-4-turbo", "gpt-5-nano", "gpt-5-mini", "gpt-5.3-chat-latest", "gpt-5.4"])
 @pytest.mark.skipif(os.environ.get("OPENAI_API_KEY") is None, reason="OPENAI_API_KEY is not set in environment or .env")
 def test_engines(engine):
     SENTENCE = "A short sentence about the difference between green and blue."
@@ -102,7 +102,8 @@ def test_engines(engine):
 def test_get_non_none_params_default_model_fallback(chat_params):
     chat_params.model = ""
     out = chat_params._get_non_none_params()
-    assert out["model"] == DEFAULT_MODEL_FALLBACK
+    assert DEFAULT_MODEL_FALLBACK == "gpt-5.4"
+    assert out["model"] == "gpt-5.4"
 
 
 def test_get_non_none_params_preserves_profile(chat_params):

--- a/tests/mixins/test_query.py
+++ b/tests/mixins/test_query.py
@@ -669,7 +669,8 @@ async def test_cleaned_chat_completion_model_fallback(chat):
     )
     chat.system("system")
     await chat._cleaned_chat_completion(chat.json)
-    assert fake_completions.last_kwargs["model"] == DEFAULT_MODEL_FALLBACK
+    assert DEFAULT_MODEL_FALLBACK == "gpt-5.4"
+    assert fake_completions.last_kwargs["model"] == "gpt-5.4"
 
 
 @pytest.mark.asyncio

--- a/tests/mixins/test_query_listen.py
+++ b/tests/mixins/test_query_listen.py
@@ -5,6 +5,7 @@ from chatsnack import Chat, Text, CHATSNACK_BASE_DIR
 import pytest
 import asyncio
 from chatsnack.chat.mixin_query import ChatStreamListener
+from chatsnack.chat.mixin_utensil import ChatUtensilMixin
 from chatsnack.aiclient import AiClient
 
 
@@ -177,6 +178,14 @@ def test_listener_default_legacy_text_mode():
     chunks = list(listener)
     assert chunks == ["A", "B", ""]
     assert "".join(chunks) == "AB"
+
+
+def test_stream_listeners_share_the_cross_runtime_model_fallback():
+    assert ChatStreamListener(ai=None, prompt="[]").kwargs["model"] == "gpt-5.4"
+    assert (
+        ChatUtensilMixin.ChatStreamListener(ai=None, prompt="[]").kwargs["model"]
+        == "gpt-5.4"
+    )
 
 
 @pytest.mark.parametrize("use_runtime_adapter", [True, False])

--- a/tests/runtime/test_chat_completions_adapter.py
+++ b/tests/runtime/test_chat_completions_adapter.py
@@ -31,6 +31,7 @@ def test_reserved_event_types_are_defined():
 def test_normalizes_non_stream_completion_with_tool_calls():
     response = _FakeObj(
         {
+            "id": "chatcmpl_abc",
             "model": "gpt-test",
             "usage": {"total_tokens": 4},
             "choices": [
@@ -62,8 +63,72 @@ def test_normalizes_non_stream_completion_with_tool_calls():
     assert result.model == "gpt-test"
     assert result.finish_reason == "tool_calls"
     assert result.usage == {"total_tokens": 4}
+    assert result.metadata["response_id"] == "chatcmpl_abc"
     assert result.message.tool_calls[0].id == "call_1"
     assert result.message.tool_calls[0].function.name == "get_weather"
+
+
+def test_chat_completions_response_id_is_preserved_when_usage_is_missing():
+    response = _FakeObj(
+        {
+            "id": "chatcmpl_openrouter",
+            "model": "openrouter/model",
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "hi"},
+                }
+            ],
+        }
+    )
+    ai = SimpleNamespace(
+        client=SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=lambda **kwargs: response)
+            )
+        )
+    )
+
+    result = ChatCompletionsAdapter(ai).create_completion(messages=[])
+
+    assert result.metadata["response_id"] == "chatcmpl_openrouter"
+    assert result.usage is None
+
+
+@pytest.mark.parametrize("model", ["openrouter/model", "azure-deployment"])
+def test_compatible_chat_completions_usage_payload_is_preserved(model):
+    usage = {
+        "prompt_tokens": 6,
+        "prompt_tokens_details": {"cached_tokens": 2},
+        "completion_tokens": 4,
+        "completion_tokens_details": {"reasoning_tokens": 1},
+        "total_tokens": 10,
+    }
+    response = _FakeObj(
+        {
+            "id": "chatcmpl_provider",
+            "model": model,
+            "usage": usage,
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "hi"},
+                }
+            ],
+        }
+    )
+    ai = SimpleNamespace(
+        client=SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=lambda **kwargs: response)
+            )
+        )
+    )
+
+    result = ChatCompletionsAdapter(ai).create_completion(messages=[])
+
+    assert result.usage == usage
+    assert result.metadata["response_id"] == "chatcmpl_provider"
 
 
 def test_normalizes_sync_stream_events_with_completed_terminal():

--- a/tests/runtime/test_responses_adapter.py
+++ b/tests/runtime/test_responses_adapter.py
@@ -157,6 +157,28 @@ def test_continuation_previous_response_id_passthrough_and_metadata_mirror():
     assert result.metadata["previous_response_id"] == "resp_prev"
 
 
+def test_response_payload_previous_response_id_wins_over_request_fallback():
+    response = _FakeObj(
+        {
+            "id": "resp_current",
+            "previous_response_id": "resp_provider_previous",
+            "status": "completed",
+            "model": "gpt-4.1",
+            "output": [],
+        }
+    )
+    ai = SimpleNamespace(
+        client=SimpleNamespace(responses=SimpleNamespace(create=lambda **kwargs: response))
+    )
+
+    result = ResponsesAdapter(ai).create_completion(
+        messages=[],
+        previous_response_id="resp_request_fallback",
+    )
+
+    assert result.metadata["previous_response_id"] == "resp_provider_previous"
+
+
 def test_normalizes_assistant_text_tool_calls_usage_model_status_and_metadata():
     response = _FakeObj(
         {
@@ -194,6 +216,34 @@ def test_normalizes_assistant_text_tool_calls_usage_model_status_and_metadata():
     assert result.metadata["response_id"] == "resp_abc"
     assert result.metadata["assistant_phase"] == "completed"
     assert result.metadata["provider_extras"]["status"] == "completed"
+
+
+@pytest.mark.parametrize("model", ["openrouter/model", "azure-deployment"])
+def test_compatible_responses_usage_payload_is_preserved(model):
+    usage = {
+        "input_tokens": 6,
+        "input_tokens_details": {"cached_tokens": 2},
+        "output_tokens": 4,
+        "output_tokens_details": {"reasoning_tokens": 1},
+        "total_tokens": 10,
+    }
+    response = _FakeObj(
+        {
+            "id": "resp_provider",
+            "status": "completed",
+            "model": model,
+            "usage": usage,
+            "output": [],
+        }
+    )
+    ai = SimpleNamespace(
+        client=SimpleNamespace(responses=SimpleNamespace(create=lambda **kwargs: response))
+    )
+
+    result = ResponsesAdapter(ai).create_completion(messages=[])
+
+    assert result.usage == usage
+    assert result.metadata["response_id"] == "resp_provider"
 
 
 def test_normalizes_rich_assistant_parts_into_message_fields():

--- a/tests/runtime/test_responses_websocket_adapter.py
+++ b/tests/runtime/test_responses_websocket_adapter.py
@@ -863,6 +863,7 @@ def test_create_completion_consumes_stream_to_normalized_result(monkeypatch):
 
     assert result.message.content == "hello"
     assert result.metadata["response_id"] == "resp_1"
+    assert result.usage == {"total_tokens": 5}
 
 
 def test_create_completion_uses_terminal_response_payload_for_rich_output(monkeypatch):

--- a/tests/runtime/test_usage.py
+++ b/tests/runtime/test_usage.py
@@ -160,6 +160,30 @@ def test_missing_zero_and_empty_usage_payloads_remain_distinct():
     )
 
 
+def test_malformed_preferred_alias_falls_back_to_valid_compatible_alias():
+    ledger = _CallUsageLedger()
+    ledger.record(
+        _completion(
+            {
+                "input_tokens": "unknown",
+                "prompt_tokens": 11,
+                "input_tokens_details": {"cached_tokens": False},
+                "prompt_tokens_details": {"cached_tokens": 4},
+                "output_tokens": None,
+                "completion_tokens": 7,
+                "output_tokens_details": {"reasoning_tokens": "unknown"},
+                "completion_tokens_details": {"reasoning_tokens": 3},
+            }
+        )
+    )
+
+    response = ledger.snapshot().responses[0]
+    assert response.input_tokens == 11
+    assert response.cached_input_tokens == 4
+    assert response.output_tokens == 7
+    assert response.reasoning_tokens == 3
+
+
 def test_ledger_sequences_responses_and_detaches_raw_provider_usage():
     usage = {
         "input_tokens": 2,

--- a/tests/runtime/test_usage.py
+++ b/tests/runtime/test_usage.py
@@ -1,0 +1,199 @@
+from copy import deepcopy
+
+import pytest
+
+from chatsnack import CallUsage, ResponseUsage, UsageCounts
+from chatsnack.runtime import (
+    NormalizedAssistantMessage,
+    NormalizedCompletionResult,
+)
+from chatsnack.runtime.usage import _CallUsageLedger
+
+
+def _completion(usage, *, response_id="resp_1", model="gpt-test"):
+    return NormalizedCompletionResult(
+        message=NormalizedAssistantMessage(content="done"),
+        model=model,
+        usage=usage,
+        metadata={
+            "response_id": response_id,
+            "previous_response_id": "resp_previous",
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider_shape", "usage"),
+    [
+        (
+            "openai_responses_http",
+            {
+                "input_tokens": 11,
+                "input_tokens_details": {"cached_tokens": 4},
+                "output_tokens": 7,
+                "output_tokens_details": {"reasoning_tokens": 3},
+                "total_tokens": 18,
+            },
+        ),
+        (
+            "openai_responses_websocket",
+            {
+                "input_tokens": 11,
+                "input_tokens_details": {"cached_tokens": 4},
+                "output_tokens": 7,
+                "output_tokens_details": {"reasoning_tokens": 3},
+                "total_tokens": 18,
+            },
+        ),
+        (
+            "openrouter_responses_http",
+            {
+                "input_tokens": 11,
+                "input_tokens_details": {"cached_tokens": 4},
+                "output_tokens": 7,
+                "output_tokens_details": {"reasoning_tokens": 3},
+                "total_tokens": 18,
+            },
+        ),
+        (
+            "azure_responses_http",
+            {
+                "input_tokens": 11,
+                "input_tokens_details": {"cached_tokens": 4},
+                "output_tokens": 7,
+                "output_tokens_details": {"reasoning_tokens": 3},
+                "total_tokens": 18,
+            },
+        ),
+        (
+            "azure_responses_websocket",
+            {
+                "input_tokens": 11,
+                "input_tokens_details": {"cached_tokens": 4},
+                "output_tokens": 7,
+                "output_tokens_details": {"reasoning_tokens": 3},
+                "total_tokens": 18,
+            },
+        ),
+        (
+            "openai_chat_completions",
+            {
+                "prompt_tokens": 11,
+                "prompt_tokens_details": {"cached_tokens": 4},
+                "completion_tokens": 7,
+                "completion_tokens_details": {"reasoning_tokens": 3},
+                "total_tokens": 18,
+            },
+        ),
+        (
+            "openrouter_chat_completions",
+            {
+                "prompt_tokens": 11,
+                "prompt_tokens_details": {"cached_tokens": 4},
+                "completion_tokens": 7,
+                "completion_tokens_details": {"reasoning_tokens": 3},
+                "total_tokens": 18,
+            },
+        ),
+        (
+            "azure_chat_completions",
+            {
+                "prompt_tokens": 11,
+                "prompt_tokens_details": {"cached_tokens": 4},
+                "completion_tokens": 7,
+                "completion_tokens_details": {"reasoning_tokens": 3},
+                "total_tokens": 18,
+            },
+        ),
+    ],
+)
+def test_normalizes_usage_by_response_shape(provider_shape, usage):
+    ledger = _CallUsageLedger()
+
+    ledger.record(_completion(usage, response_id=f"resp_{provider_shape}"))
+
+    response = ledger.snapshot().responses[0]
+    assert response.input_tokens == 11
+    assert response.cached_input_tokens == 4
+    assert response.output_tokens == 7
+    assert response.reasoning_tokens == 3
+    assert response.total_tokens == 18
+    assert response.model == "gpt-test"
+    assert response.provider_usage == usage
+
+
+def test_missing_zero_and_empty_usage_payloads_remain_distinct():
+    ledger = _CallUsageLedger()
+    ledger.record(_completion(None, response_id="resp_missing"))
+    ledger.record(
+        _completion(
+            {
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "total_tokens": 0,
+            },
+            response_id="resp_zero",
+        )
+    )
+    ledger.record(_completion({}, response_id="resp_empty"))
+
+    call = ledger.snapshot()
+
+    assert call.response_count == 3
+    assert call.usage_response_count == 2
+    assert call.is_complete is False
+    assert call.missing_usage_sequences == (1,)
+    assert call.responses[0].usage_reported is False
+    assert call.responses[0].provider_usage is None
+    assert call.responses[1].usage_reported is True
+    assert call.responses[1].input_tokens == 0
+    assert call.responses[1].output_tokens == 0
+    assert call.responses[1].total_tokens == 0
+    assert call.responses[2].usage_reported is True
+    assert call.responses[2].provider_usage == {}
+    assert call.total == UsageCounts(
+        input_tokens=0,
+        cached_input_tokens=None,
+        output_tokens=0,
+        reasoning_tokens=None,
+        total_tokens=0,
+    )
+
+
+def test_ledger_sequences_responses_and_detaches_raw_provider_usage():
+    usage = {
+        "input_tokens": 2,
+        "output_tokens": 3,
+        "total_tokens": 5,
+        "vendor": {"credits": ["one"]},
+    }
+    original = deepcopy(usage)
+    ledger = _CallUsageLedger()
+
+    ledger.record(_completion(usage, response_id="resp_one"))
+    ledger.record(_completion({"total_tokens": 7}, response_id="resp_two"))
+    usage["vendor"]["credits"].append("mutated")
+
+    call = ledger.snapshot()
+    assert isinstance(call, CallUsage)
+    assert isinstance(call.responses[0], ResponseUsage)
+    assert call.responses[0].sequence == 1
+    assert call.responses[1].sequence == 2
+    assert call.responses[0].provider_usage == original
+    assert call.total.input_tokens == 2
+    assert call.total.output_tokens == 3
+    assert call.total.total_tokens == 12
+
+
+def test_empty_call_snapshot_is_incomplete_and_immutable():
+    call = _CallUsageLedger().snapshot()
+
+    assert call.responses == ()
+    assert call.response_count == 0
+    assert call.usage_response_count == 0
+    assert call.is_complete is False
+    assert call.missing_usage_sequences == ()
+    assert call.total == UsageCounts()
+
+    with pytest.raises(AttributeError):
+        call.responses = ()

--- a/tests/test_call_usage.py
+++ b/tests/test_call_usage.py
@@ -243,6 +243,42 @@ async def test_next_call_replaces_source_usage_and_leaves_prior_result_intact():
     assert source.last_call_usage.total.total_tokens == 8
 
 
+@pytest.mark.asyncio
+async def test_in_flight_call_preserves_most_recently_finished_source_usage():
+    first_runtime = _SequenceRuntime(
+        [_completion("First.", {"total_tokens": 5}, response_id="resp_first")]
+    )
+    source = Chat("Answer briefly.", runtime=first_runtime)
+    first = await source.chat_a("First?")
+    first_call = first.last_call_usage
+
+    class _BlockingRuntime:
+        def __init__(self):
+            self.started = asyncio.Event()
+            self.release = asyncio.Event()
+
+        async def create_completion_a(self, messages, **kwargs):
+            self.started.set()
+            await self.release.wait()
+            return _completion(
+                "Second.",
+                {"total_tokens": 8},
+                response_id="resp_second",
+            )
+
+    runtime = _BlockingRuntime()
+    source.runtime = runtime
+    pending = asyncio.create_task(source.chat_a("Second?"))
+    await runtime.started.wait()
+
+    assert source.last_call_usage is first_call
+
+    runtime.release.set()
+    second = await pending
+    assert source.last_call_usage is second.last_call_usage
+    assert source.last_call_usage.total.total_tokens == 8
+
+
 def test_call_usage_is_transient_across_yaml_copy_reset_and_load(tmp_path):
     runtime = _SequenceRuntime(
         [

--- a/tests/test_call_usage.py
+++ b/tests/test_call_usage.py
@@ -1,0 +1,319 @@
+import asyncio
+
+import pytest
+
+from chatsnack import (
+    CallUsage,
+    Chat,
+    ChatParams,
+    ResponseUsage,
+    UsageCounts,
+    utensil,
+)
+from chatsnack.runtime import (
+    NormalizedAssistantMessage,
+    NormalizedCompletionResult,
+    NormalizedToolCall,
+    NormalizedToolFunction,
+)
+
+
+class _SequenceRuntime:
+    """Small adapter double that returns normalized provider responses in order."""
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    async def create_completion_a(self, messages, **kwargs):
+        self.requests.append({"messages": messages, "kwargs": kwargs})
+        response = self.responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response
+
+
+def _completion(
+    content,
+    usage,
+    *,
+    response_id,
+    previous_response_id=None,
+    tool_call=None,
+    model="gpt-test",
+):
+    return NormalizedCompletionResult(
+        message=NormalizedAssistantMessage(
+            content=content,
+            tool_calls=[tool_call] if tool_call is not None else [],
+        ),
+        model=model,
+        usage=usage,
+        metadata={
+            "response_id": response_id,
+            "previous_response_id": previous_response_id,
+            "assistant_phase": "incomplete" if tool_call else "completed",
+            "provider_extras": {
+                "status": "in_progress" if tool_call else "completed"
+            },
+        },
+    )
+
+
+def _tool_call(name):
+    return NormalizedToolCall(
+        id="call_snack",
+        function=NormalizedToolFunction(
+            name=name,
+            arguments='{"name":"popcorn"}',
+        ),
+    )
+
+
+@utensil
+def aggregate_usage_snack_lookup(name: str) -> str:
+    """Look up a snack for the aggregate-usage acceptance story."""
+    return f"{name} is crunchy"
+
+
+@pytest.mark.asyncio
+async def test_chat_a_aggregates_every_auto_feed_provider_response_once():
+    first_usage = {
+        "input_tokens": 10,
+        "input_tokens_details": {"cached_tokens": 3},
+        "output_tokens": 2,
+        "output_tokens_details": {"reasoning_tokens": 1},
+        "total_tokens": 12,
+    }
+    second_usage = {
+        "prompt_tokens": 5,
+        "prompt_tokens_details": {"cached_tokens": 0},
+        "completion_tokens": 7,
+        "completion_tokens_details": {"reasoning_tokens": 2},
+        "total_tokens": 12,
+    }
+    runtime = _SequenceRuntime(
+        [
+            _completion(
+                None,
+                first_usage,
+                response_id="resp_tool",
+                tool_call=_tool_call("aggregate_usage_snack_lookup"),
+            ),
+            _completion(
+                "Popcorn is crunchy.",
+                second_usage,
+                response_id="resp_final",
+                previous_response_id="resp_tool",
+            ),
+        ]
+    )
+    source = Chat(
+        "Use the snack tool.",
+        runtime=runtime,
+        utensils=[aggregate_usage_snack_lookup],
+        auto_feed=True,
+    )
+
+    completed = await source.chat_a("Tell me about popcorn.")
+
+    assert isinstance(completed, Chat)
+    assert completed.response == "Popcorn is crunchy."
+    assert len(runtime.requests) == 2
+    call = completed.last_call_usage
+    assert source.last_call_usage is call
+    assert call.response_count == 2
+    assert call.usage_response_count == 2
+    assert call.is_complete is True
+    assert [item.response_id for item in call.responses] == [
+        "resp_tool",
+        "resp_final",
+    ]
+    assert call.responses[1].previous_response_id == "resp_tool"
+    assert call.total == UsageCounts(
+        input_tokens=15,
+        cached_input_tokens=3,
+        output_tokens=9,
+        reasoning_tokens=3,
+        total_tokens=24,
+    )
+    assert call.responses[0].provider_usage == first_usage
+    assert call.responses[1].provider_usage == second_usage
+    assert completed._last_runtime_metadata["usage"] == second_usage
+
+
+def test_chat_preserves_mixed_usage_coverage_and_reported_zero():
+    runtime = _SequenceRuntime(
+        [
+            _completion(
+                None,
+                None,
+                response_id="resp_missing",
+                tool_call=_tool_call("aggregate_usage_snack_lookup"),
+            ),
+            _completion(
+                "Done.",
+                {
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "total_tokens": 0,
+                },
+                response_id="resp_zero",
+                previous_response_id="resp_missing",
+            ),
+        ]
+    )
+    source = Chat(
+        "Use the snack tool.",
+        runtime=runtime,
+        utensils=[aggregate_usage_snack_lookup],
+        auto_feed=True,
+    )
+
+    completed = source.chat("Tell me about popcorn.")
+
+    call = completed.last_call_usage
+    assert call.response_count == 2
+    assert call.usage_response_count == 1
+    assert call.is_complete is False
+    assert call.missing_usage_sequences == (1,)
+    assert call.responses[0].provider_usage is None
+    assert call.responses[1].input_tokens == 0
+    assert call.responses[1].output_tokens == 0
+    assert call.responses[1].total_tokens == 0
+    assert call.total == UsageCounts(
+        input_tokens=0,
+        output_tokens=0,
+        total_tokens=0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_chat_a_failure_exposes_partial_usage_without_wrapping_exception():
+    failure = RuntimeError("follow-up failed")
+    runtime = _SequenceRuntime(
+        [
+            _completion(
+                None,
+                {"input_tokens": 4, "output_tokens": 1, "total_tokens": 5},
+                response_id="resp_tool",
+                tool_call=_tool_call("aggregate_usage_snack_lookup"),
+            ),
+            failure,
+        ]
+    )
+    source = Chat(
+        "Use the snack tool.",
+        runtime=runtime,
+        utensils=[aggregate_usage_snack_lookup],
+        auto_feed=True,
+    )
+
+    with pytest.raises(RuntimeError) as raised:
+        await source.chat_a("Tell me about popcorn.")
+
+    assert raised.value is failure
+    assert len(runtime.requests) == 2
+    partial = source.last_call_usage
+    assert partial.response_count == 1
+    assert partial.responses[0].response_id == "resp_tool"
+    assert partial.total.total_tokens == 5
+    assert failure.last_call_usage is partial
+
+
+@pytest.mark.asyncio
+async def test_next_call_replaces_source_usage_and_leaves_prior_result_intact():
+    first_runtime = _SequenceRuntime(
+        [_completion("First.", {"total_tokens": 5}, response_id="resp_first")]
+    )
+    source = Chat("Answer briefly.", runtime=first_runtime)
+    first = await source.chat_a("First?")
+    first_call = first.last_call_usage
+
+    second_runtime = _SequenceRuntime(
+        [_completion("Second.", {"total_tokens": 8}, response_id="resp_second")]
+    )
+    source.runtime = second_runtime
+    second = await source.chat_a("Second?")
+
+    assert first.last_call_usage is first_call
+    assert first.last_call_usage.total.total_tokens == 5
+    assert source.last_call_usage is second.last_call_usage
+    assert source.last_call_usage.response_count == 1
+    assert source.last_call_usage.total.total_tokens == 8
+
+
+def test_call_usage_is_transient_across_yaml_copy_reset_and_load(tmp_path):
+    runtime = _SequenceRuntime(
+        [
+            _completion(
+                "Saved answer.",
+                {"input_tokens": 2, "output_tokens": 3, "total_tokens": 5},
+                response_id="resp_saved",
+            )
+        ]
+    )
+    source = Chat(
+        name="UsageTransient",
+        params=ChatParams(
+            runtime="chat_completions",
+            responses={"export_state": True},
+        ),
+        runtime=runtime,
+    )
+    result = source.chat("Save this.")
+    call = result.last_call_usage
+
+    assert "last_call_usage" not in result.yaml
+    assert "provider_usage" not in result.yaml
+    with pytest.raises(AttributeError):
+        result.last_call_usage = call
+    assert result.copy().last_call_usage is None
+
+    result.reset()
+    assert result.last_call_usage is None
+
+    result._last_call_usage = call
+    path = tmp_path / "UsageTransient.yml"
+    result.save(path)
+    result.load(path)
+    assert result.last_call_usage is None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_calls_keep_independent_ledgers_and_source_tracks_last_finish():
+    class _ConcurrentRuntime:
+        async def create_completion_a(self, messages, **kwargs):
+            prompt = messages[-1]["content"]
+            if prompt == "slow":
+                await asyncio.sleep(0.02)
+                return _completion(
+                    "Slow.",
+                    {"total_tokens": 20},
+                    response_id="resp_slow",
+                )
+            await asyncio.sleep(0)
+            return _completion(
+                "Fast.",
+                {"total_tokens": 5},
+                response_id="resp_fast",
+            )
+
+    source = Chat("Answer briefly.", runtime=_ConcurrentRuntime())
+
+    slow, fast = await asyncio.gather(
+        source.chat_a("slow"),
+        source.chat_a("fast"),
+    )
+
+    assert slow.last_call_usage.responses[0].response_id == "resp_slow"
+    assert slow.last_call_usage.total.total_tokens == 20
+    assert fast.last_call_usage.responses[0].response_id == "resp_fast"
+    assert fast.last_call_usage.total.total_tokens == 5
+    assert source.last_call_usage is slow.last_call_usage
+
+
+def test_public_usage_types_are_available_from_package_root():
+    assert CallUsage.__name__ == "CallUsage"
+    assert ResponseUsage.__name__ == "ResponseUsage"
+    assert UsageCounts.__name__ == "UsageCounts"


### PR DESCRIPTION
## Summary

- expose call-scoped usage through `Chat.last_call_usage`
- record every provider response, including utensil auto-feed follow-ups
- normalize Responses and Chat Completions token fields while retaining raw provider usage
- report incomplete coverage without estimating missing usage
- keep the usage ledger transient and outside saved YAML
- use `gpt-5.4` as the implicit cross-runtime fallback
- bump the package patch version from `0.6.3` to `0.6.4`
- add API documentation and an exploratory notebook usage example

## Why

Lorebubble needs the cost and token footprint of the entire `chat()` call rather than only the final auto-feed response. Some compatible providers omit usage, so the public result records coverage and preserves missing values instead of failing the call or inventing counts.

The previous implicit `gpt-5-chat-latest` fallback is unavailable in the configured live environment. `gpt-5.4` provides the broad Responses, Chat Completions, streaming, and tool compatibility Chatsnack currently needs.

## Compatibility

- `chat()` and `chat_a()` still return `Chat`
- existing provider requests and continuation behavior are unchanged
- existing YAML remains unchanged
- OpenRouter- and Azure-shaped payloads are covered by fixtures
- Azure support is best-effort; no live Azure environment was used

## Validation

- `poetry check`
- 132 focused offline tests passed
- strict MkDocs build passed
- Python compile check passed
- staged diff whitespace check passed

The full live provider suite was not rerun.