### PR TITLE
Update GPT reasoning capability profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,20 @@ When working on a bug fix or feature, review `3HTDD.md` and prefer its Three-Hor
 
 Use TDD, but worry less about forcing every step into a low-level red-green loop. Aim a little higher with top-level Goal tests that prove acceptance criteria and serve as user-facing examples, use Steer tests to bridge toward implementation, and drop to Unit tests only when a tighter loop is helpful.
 
+## Model capability tables
+
+When changing `chatsnack/chat/mixin_params.py` or validating support for a new model, review every model default and capability table in that file, including `DEFAULT_MODEL_FALLBACK` and `_KNOWN_REASONING_MODELS`.
+
+For each new or changed capability entry:
+
+- Verify support against current official provider documentation.
+- Record the verification date and direct official reference URL or URLs beside the entry.
+- Put specific variants before broader family prefixes because the first matching pattern wins.
+- Cover the common model ID, dated snapshots, and variants whose capabilities differ.
+- Test accepted values for warning-free pass-through and known unsupported values for advisory pass-through warnings.
+
+Keep capability validation advisory. An incomplete local table must not strip or rewrite provider options authored by the caller.
+
 ## Project checklists
 
 When working on a major feature or change, use the relevant checklist in `docs/projects/` to track progress and ensure alignment with the RFC. Check things off, leave short notes, and say what somebody can actually do now. The goal is to keep the implementation work easy to follow (for the team and the follow-on developers) without making anyone dig through the full RFC every time.

--- a/chatsnack/chat/mixin_params.py
+++ b/chatsnack/chat/mixin_params.py
@@ -33,7 +33,48 @@ def _resolve_auto_feed_limit(value: bool | int | None) -> int:
 
 
 _REASONING_SUMMARY_OPTIONS = frozenset({"auto", "concise", "detailed"})
+# Keep a verification date and official reference URL(s) beside each table update.
 _KNOWN_REASONING_MODELS: Tuple[Tuple[str, Dict[str, frozenset]], ...] = (
+    # Verified 2026-08-06. GPT-5.6 family effort values:
+    # https://developers.openai.com/api/docs/guides/deployment-checklist#set-up-reasoningeffort
+    # gpt-5.6-sol xhigh support:
+    # https://learn.chatgpt.com/docs/security/cli#choose-a-model-and-reasoning-effort
+    (
+        "gpt-5.6",
+        {
+            "effort": frozenset({"none", "low", "medium", "high", "xhigh", "max"}),
+            "summary": _REASONING_SUMMARY_OPTIONS,
+        },
+    ),
+    # Verified 2026-08-06:
+    # https://developers.openai.com/api/docs/models/gpt-5.5-pro
+    (
+        "gpt-5.5-pro",
+        {
+            "effort": frozenset({"medium", "high", "xhigh"}),
+            "summary": _REASONING_SUMMARY_OPTIONS,
+        },
+    ),
+    # Verified 2026-08-06:
+    # https://developers.openai.com/api/docs/models/gpt-5.5
+    (
+        "gpt-5.5",
+        {
+            "effort": frozenset({"none", "low", "medium", "high", "xhigh"}),
+            "summary": _REASONING_SUMMARY_OPTIONS,
+        },
+    ),
+    # Verified 2026-08-06:
+    # https://developers.openai.com/api/docs/models/gpt-5.4-pro
+    (
+        "gpt-5.4-pro",
+        {
+            "effort": frozenset({"medium", "high", "xhigh"}),
+            "summary": _REASONING_SUMMARY_OPTIONS,
+        },
+    ),
+    # Verified 2026-08-06:
+    # https://developers.openai.com/api/docs/models/gpt-5.4
     (
         "gpt-5.4",
         {

--- a/tests/test_runtime_defaults.py
+++ b/tests/test_runtime_defaults.py
@@ -81,6 +81,95 @@ def test_reasoning_known_model_warns_for_known_unsupported_effort():
     assert any("known supported set" in str(w.message) and "gpt-5.4" in str(w.message) for w in caught)
 
 
+def test_gpt_5_6_sol_xhigh_passes_without_capability_warning():
+    params = ChatParams(
+        model="gpt-5.6-sol",
+        runtime="responses",
+        responses={"reasoning": {"effort": "xhigh"}},
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        opts = params._get_responses_api_options()
+
+    assert opts["reasoning"]["effort"] == "xhigh"
+    assert not any("known supported set" in str(w.message) for w in caught)
+
+
+def test_gpt_5_6_terra_max_passes_without_capability_warning():
+    params = ChatParams(
+        model="gpt-5.6-terra",
+        runtime="responses",
+        responses={"reasoning": {"effort": "max"}},
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        opts = params._get_responses_api_options()
+
+    assert opts["reasoning"]["effort"] == "max"
+    assert not any("reasoning effort" in str(w.message).lower() for w in caught)
+
+
+def test_gpt_5_5_xhigh_passes_without_capability_warning():
+    params = ChatParams(
+        model="gpt-5.5",
+        runtime="responses",
+        responses={"reasoning": {"effort": "xhigh"}},
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        opts = params._get_responses_api_options()
+
+    assert opts["reasoning"]["effort"] == "xhigh"
+    assert not any("reasoning effort" in str(w.message).lower() for w in caught)
+
+
+def test_gpt_5_5_snapshot_uses_family_capabilities():
+    params = ChatParams(
+        model="gpt-5.5-2026-04-23",
+        runtime="responses",
+        responses={"reasoning": {"effort": "none"}},
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        opts = params._get_responses_api_options()
+
+    assert opts["reasoning"]["effort"] == "none"
+    assert not any("reasoning effort" in str(w.message).lower() for w in caught)
+
+
+def test_gpt_5_5_and_5_4_pro_profiles_reject_low_effort():
+    for model in ("gpt-5.5-pro", "gpt-5.4-pro"):
+        params = ChatParams(
+            model=model,
+            runtime="responses",
+            responses={"reasoning": {"effort": "low"}},
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            params._get_responses_api_options()
+
+        assert any("known supported set" in str(w.message) and model in str(w.message) for w in caught)
+
+
+def test_generic_gpt_5_still_warns_for_xhigh():
+    params = ChatParams(
+        model="gpt-5",
+        runtime="responses",
+        responses={"reasoning": {"effort": "xhigh"}},
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        params._get_responses_api_options()
+
+    assert any("known supported set" in str(w.message) and "gpt-5" in str(w.message) for w in caught)
+
+
 def test_reasoning_known_model_warns_for_known_unsupported_summary():
     params = ChatParams(model="o3-mini", runtime="responses", responses={"reasoning": {"summary": "verbose"}})
     with warnings.catch_warnings(record=True) as caught:

--- a/tests/test_runtime_defaults.py
+++ b/tests/test_runtime_defaults.py
@@ -1,5 +1,7 @@
 import warnings
 
+import pytest
+
 from chatsnack import Chat
 from chatsnack.chat.mixin_params import ChatParams
 from chatsnack.runtime import ChatCompletionsAdapter, ResponsesAdapter, ResponsesWebSocketAdapter
@@ -81,79 +83,66 @@ def test_reasoning_known_model_warns_for_known_unsupported_effort():
     assert any("known supported set" in str(w.message) and "gpt-5.4" in str(w.message) for w in caught)
 
 
-def test_gpt_5_6_sol_xhigh_passes_without_capability_warning():
+@pytest.mark.parametrize(
+    ("model", "effort"),
+    (
+        ("gpt-5.6-sol", "xhigh"),
+        ("gpt-5.6-terra", "max"),
+        ("gpt-5.5", "xhigh"),
+        ("gpt-5.5-2026-04-23", "none"),
+        ("gpt-5.5-pro", "xhigh"),
+        ("gpt-5.4", "xhigh"),
+        ("gpt-5.4-2026-03-05", "none"),
+        ("gpt-5.4-pro", "xhigh"),
+    ),
+)
+def test_current_gpt_models_pass_supported_effort_without_warning(model, effort):
+    params = ChatParams(
+        model=model,
+        runtime="responses",
+        responses={"reasoning": {"effort": effort}},
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        opts = params._get_responses_api_options()
+
+    assert opts["reasoning"]["effort"] == effort
+    assert not caught
+
+
+@pytest.mark.parametrize("model", ("gpt-5.5-pro", "gpt-5.4-pro"))
+def test_current_gpt_pro_profiles_warn_for_low_effort(model):
+    params = ChatParams(
+        model=model,
+        runtime="responses",
+        responses={"reasoning": {"effort": "low"}},
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        opts = params._get_responses_api_options()
+
+    assert opts["reasoning"]["effort"] == "low"
+    assert len(caught) == 1
+    assert "known supported set" in str(caught[0].message)
+    assert model in str(caught[0].message)
+
+
+def test_codex_ultra_mode_warns_as_unknown_api_effort_and_passes_through():
     params = ChatParams(
         model="gpt-5.6-sol",
         runtime="responses",
-        responses={"reasoning": {"effort": "xhigh"}},
+        responses={"reasoning": {"effort": "ultra"}},
     )
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         opts = params._get_responses_api_options()
 
-    assert opts["reasoning"]["effort"] == "xhigh"
-    assert not any("known supported set" in str(w.message) for w in caught)
-
-
-def test_gpt_5_6_terra_max_passes_without_capability_warning():
-    params = ChatParams(
-        model="gpt-5.6-terra",
-        runtime="responses",
-        responses={"reasoning": {"effort": "max"}},
-    )
-
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        opts = params._get_responses_api_options()
-
-    assert opts["reasoning"]["effort"] == "max"
-    assert not any("reasoning effort" in str(w.message).lower() for w in caught)
-
-
-def test_gpt_5_5_xhigh_passes_without_capability_warning():
-    params = ChatParams(
-        model="gpt-5.5",
-        runtime="responses",
-        responses={"reasoning": {"effort": "xhigh"}},
-    )
-
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        opts = params._get_responses_api_options()
-
-    assert opts["reasoning"]["effort"] == "xhigh"
-    assert not any("reasoning effort" in str(w.message).lower() for w in caught)
-
-
-def test_gpt_5_5_snapshot_uses_family_capabilities():
-    params = ChatParams(
-        model="gpt-5.5-2026-04-23",
-        runtime="responses",
-        responses={"reasoning": {"effort": "none"}},
-    )
-
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        opts = params._get_responses_api_options()
-
-    assert opts["reasoning"]["effort"] == "none"
-    assert not any("reasoning effort" in str(w.message).lower() for w in caught)
-
-
-def test_gpt_5_5_and_5_4_pro_profiles_reject_low_effort():
-    for model in ("gpt-5.5-pro", "gpt-5.4-pro"):
-        params = ChatParams(
-            model=model,
-            runtime="responses",
-            responses={"reasoning": {"effort": "low"}},
-        )
-
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            params._get_responses_api_options()
-
-        assert any("known supported set" in str(w.message) and model in str(w.message) for w in caught)
+    assert opts["reasoning"]["effort"] == "ultra"
+    assert len(caught) == 1
+    assert "Unknown reasoning effort 'ultra'" in str(caught[0].message)
 
 
 def test_generic_gpt_5_still_warns_for_xhigh():
@@ -165,9 +154,12 @@ def test_generic_gpt_5_still_warns_for_xhigh():
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        params._get_responses_api_options()
+        opts = params._get_responses_api_options()
 
-    assert any("known supported set" in str(w.message) and "gpt-5" in str(w.message) for w in caught)
+    assert opts["reasoning"]["effort"] == "xhigh"
+    assert len(caught) == 1
+    assert "known supported set" in str(caught[0].message)
+    assert "gpt-5" in str(caught[0].message)
 
 
 def test_reasoning_known_model_warns_for_known_unsupported_summary():


### PR DESCRIPTION
## Summary

- add dated, source-backed reasoning profiles for GPT-5.6 and GPT-5.5
- add explicit GPT-5.5 Pro and GPT-5.4 Pro profiles before their broader family prefixes
- record official references for the existing GPT-5.4 profile
- document capability-table maintenance requirements in `AGENTS.md`
- add regression coverage for aliases, dated snapshots, variant ordering, warnings, and pass-through behavior

## Why

`gpt-5.6-sol` fell through to the generic `gpt-5` capability profile. That profile does not include `xhigh`, so chatsnack emitted a false advisory warning even though it still forwarded the authored value unchanged.

## Impact

Supported effort values for the new model families no longer produce false capability warnings. Provider options remain advisory and pass through unchanged. The narrower Pro profiles keep unsupported-value warnings accurate.

## References

- https://developers.openai.com/api/docs/guides/deployment-checklist#set-up-reasoningeffort
- https://learn.chatgpt.com/docs/security/cli#choose-a-model-and-reasoning-effort
- https://developers.openai.com/api/docs/models/gpt-5.5
- https://developers.openai.com/api/docs/models/gpt-5.5-pro
- https://developers.openai.com/api/docs/models/gpt-5.4
- https://developers.openai.com/api/docs/models/gpt-5.4-pro

## Validation

`python -m pytest tests/test_runtime_defaults.py tests/test_runtime_boundary_isolation.py tests/runtime/test_responses_adapter.py -q`

52 passed. The run retains one pre-existing `AsyncClient.aclose` cleanup warning.