### PR TITLE
Fix vulnerable Flask and docs dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 mkdocs>=1.6,<2.0
 mkdocs-material>=9.6,<10.0
 mkdocstrings[python]>=0.30,<1.0
-pymdown-extensions>=10.0,<11.0
+pymdown-extensions>=11.0.1,<12.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -99,23 +99,24 @@ files = [
 
 [[package]]
 name = "flask"
-version = "2.3.3"
+version = "3.1.3"
 description = "A simple framework for building complex web applications."
 optional = true
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"flask\" or extra == \"examples\""
 files = [
-    {file = "flask-2.3.3-py3-none-any.whl", hash = "sha256:f69fcd559dc907ed196ab9df0e48471709175e696d6e698dd4dbe940f96ce66b"},
-    {file = "flask-2.3.3.tar.gz", hash = "sha256:09c347a92aa7ff4a8e7f3206795f30d826654baf38b873d0744cd571ca609efc"},
+    {file = "flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c"},
+    {file = "flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb"},
 ]
 
 [package.dependencies]
-blinker = ">=1.6.2"
+blinker = ">=1.9.0"
 click = ">=8.1.3"
-itsdangerous = ">=2.1.2"
-Jinja2 = ">=3.1.2"
-Werkzeug = ">=2.3.7"
+itsdangerous = ">=2.2.0"
+jinja2 = ">=3.1.2"
+markupsafe = ">=2.1.1"
+werkzeug = ">=3.1.0"
 
 [package.extras]
 async = ["asgiref (>=3.2)"]
@@ -1131,4 +1132,4 @@ rich = ["rich"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "c34b7d9bcfd9444e73b8a3089c95e029febf1a49bc1996db39cc53cfea87476f"
+content-hash = "91823a882ebce216feab3e8125cf08786e3d3cbc5a7156d71caad3f481a9b476"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ loguru = "^0.6.0"
 nest-asyncio = "^1.5.6"
 openai = ">=2.29.0"
 websockets = ">=13.0"
-Flask = {version = "^2.1", optional = true}
+Flask = {version = "^3.1.3", optional = true}
 questionary = {version = "^1.10.0", optional = true}
 rich = {version = "^13.3.2", optional = true}
 


### PR DESCRIPTION
## Summary
- require `pymdown-extensions>=11.0.1,<12.0` to resolve the high-severity ReDoS alert in the docs dependencies
- require Flask `^3.1.3` and refresh `poetry.lock` to resolve the Flask session-cache alerts
- keep the upcoming package version at `0.7.0`

## Dependabot alerts
- https://github.com/Mattie/chatsnack/security/dependabot/45
- https://github.com/Mattie/chatsnack/security/dependabot/44
- https://github.com/Mattie/chatsnack/security/dependabot/38

## Validation
- `poetry check --lock` with Poetry 2.4.1
- 41 focused project tests passed
- Flask 3.1.3 smoke check confirmed `Vary: Cookie` for session membership access
- `mkdocs build --strict` passed with pymdown-extensions 11.0.2