### PR TITLE
Add native OpenRouter and Azure v1 client configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,44 @@ Read more below, watch the [intro video](https://www.youtube.com/watch?v=Yjwi54r
 ### Responses API Support
 `Chat()` now defaults to the Responses family over WebSocket with `session="inherit"`.
 If you stay on that default path--or explicitly choose another Responses transport--
-chatsnack requires the OpenAI Python client to be `openai>=2.29.0` (or newer).
+chatsnack requires the OpenAI Python client to be `openai>=3.5.0,<4.0.0`.
 For explicit WebSocket support outside chatsnack's packaged dependencies, install
-`openai[realtime]>=2.29.0`.
+`openai[realtime]>=3.5.0,<4.0.0`.
+
+### OpenRouter and Azure v1
+
+A Chat can name its own OpenAI-compatible endpoint and the environment variable
+that holds its key. The two fields travel together, and the key value never goes
+into YAML:
+
+```python
+from chatsnack import Chat
+
+openrouter = Chat(
+    "Answer tersely.",
+    model="openai/gpt-oss-20b",
+    base_url="https://openrouter.ai/api/v1",
+    api_key_env="OPENROUTER_API_KEY",
+)
+
+azure = Chat(
+    "Answer tersely.",
+    model="my-deployment",
+    base_url="https://my-resource.openai.azure.com/openai/v1/",
+    api_key_env="AZURE_OPENAI_API_KEY",
+)
+```
+
+Custom endpoints use Responses HTTP (including SSE streaming) unless a runtime
+is selected explicitly. Chats without these fields keep the normal OpenAI SDK
+environment and Chatsnack's Responses WebSocket default. Legacy Azure fields
+(`api_base`, `api_type`, `api_version`, and `deployment`) are no longer accepted;
+use the complete Azure v1 URL and put the deployment name in `model`.
+
+Client settings are bound when a Chat is created or first loaded. Continued and
+copied Chats keep that binding, and `reset()` does not re-read the credential
+environment variable. Create a new Chat to use a different endpoint, credential,
+or transport.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -32,33 +32,66 @@ For explicit WebSocket support outside chatsnack's packaged dependencies, instal
 
 ### OpenRouter and Azure v1
 
-A Chat can name its own OpenAI-compatible endpoint and the environment variable
-that holds its key. The two fields travel together, and the key value never goes
-into YAML:
+A saved Chat can name its OpenAI-compatible endpoint and the environment variable
+that holds its key. The key value stays in the environment. For example, save
+this as `datafiles/chatsnack/OpenRouterSnack.yml` (or under the directory named
+by `CHATSNACK_BASE_DIR`):
+
+```yaml
+params:
+  model: z-ai/glm-5.3-flash
+  base_url: https://openrouter.ai/api/v1
+  api_key_env: OPENROUTER_API_KEY
+messages:
+  - system: Answer tersely and recommend excellent snacks.
+```
+
+Load it and use it like any other named Chat:
 
 ```python
 from chatsnack import Chat
 
-openrouter = Chat(
-    "Answer tersely.",
-    model="openai/gpt-oss-20b",
+openrouter = Chat(name="OpenRouterSnack")
+print(openrouter.ask("Name one movie-night snack."))
+
+thread = openrouter.chat("Name one salty snack.")
+thread = thread.chat("What drink pairs with it?")
+print(thread.last)
+```
+
+Dynamic applications can use the same fields directly:
+
+```python
+dynamic = Chat(
+    "Answer tersely and recommend excellent snacks.",
+    model="z-ai/glm-5.3-flash",
     base_url="https://openrouter.ai/api/v1",
     api_key_env="OPENROUTER_API_KEY",
 )
-
-azure = Chat(
-    "Answer tersely.",
-    model="my-deployment",
-    base_url="https://my-resource.openai.azure.com/openai/v1/",
-    api_key_env="AZURE_OPENAI_API_KEY",
-)
 ```
 
-Custom endpoints use Responses HTTP (including SSE streaming) unless a runtime
-is selected explicitly. Chats without these fields keep the normal OpenAI SDK
-environment and Chatsnack's Responses WebSocket default. Legacy Azure fields
-(`api_base`, `api_type`, `api_version`, and `deployment`) are no longer accepted;
-use the complete Azure v1 URL and put the deployment name in `model`.
+Azure v1 uses the same saved-Chat shape with its complete v1 URL and the
+deployment name in `model`:
+
+```yaml
+params:
+  model: my-deployment
+  base_url: https://my-resource.openai.azure.com/openai/v1/
+  api_key_env: AZURE_OPENAI_API_KEY
+messages:
+  - system: Answer tersely.
+```
+
+Custom endpoints use Responses HTTP, including SSE streaming, unless a runtime
+is selected explicitly. Chats without these fields keep the standard
+`OPENAI_API_KEY` / `OPENAI_BASE_URL` SDK behavior and Chatsnack's Responses
+WebSocket default.
+
+Legacy Azure fields (`api_base`, `api_type`, `api_version`, and `deployment`) are
+no longer accepted. The legacy endpoint variables `OPENAI_AZURE_ENDPOINT` and
+`OPENAI_API_BASE` also raise a migration error when no new endpoint is authored.
+Move the complete endpoint and credential-variable name to `base_url` and
+`api_key_env`; put the Azure deployment name in `model`.
 
 Client settings are bound when a Chat is created or first loaded. Continued and
 copied Chats keep that binding, and `reset()` does not re-read the credential

--- a/README.md
+++ b/README.md
@@ -30,73 +30,8 @@ chatsnack requires the OpenAI Python client to be `openai>=3.5.0,<4.0.0`.
 For explicit WebSocket support outside chatsnack's packaged dependencies, install
 `openai[realtime]>=3.5.0,<4.0.0`.
 
-### OpenRouter and Azure v1
-
-A saved Chat can name its OpenAI-compatible endpoint and the environment variable
-that holds its key. The key value stays in the environment. For example, save
-this as `datafiles/chatsnack/OpenRouterSnack.yml` (or under the directory named
-by `CHATSNACK_BASE_DIR`):
-
-```yaml
-params:
-  model: z-ai/glm-5.3-flash
-  base_url: https://openrouter.ai/api/v1
-  api_key_env: OPENROUTER_API_KEY
-messages:
-  - system: Answer tersely and recommend excellent snacks.
-```
-
-Load it and use it like any other named Chat:
-
-```python
-from chatsnack import Chat
-
-openrouter = Chat(name="OpenRouterSnack")
-print(openrouter.ask("Name one movie-night snack."))
-
-thread = openrouter.chat("Name one salty snack.")
-thread = thread.chat("What drink pairs with it?")
-print(thread.last)
-```
-
-Dynamic applications can use the same fields directly:
-
-```python
-dynamic = Chat(
-    "Answer tersely and recommend excellent snacks.",
-    model="z-ai/glm-5.3-flash",
-    base_url="https://openrouter.ai/api/v1",
-    api_key_env="OPENROUTER_API_KEY",
-)
-```
-
-Azure v1 uses the same saved-Chat shape with its complete v1 URL and the
-deployment name in `model`:
-
-```yaml
-params:
-  model: my-deployment
-  base_url: https://my-resource.openai.azure.com/openai/v1/
-  api_key_env: AZURE_OPENAI_API_KEY
-messages:
-  - system: Answer tersely.
-```
-
-Custom endpoints use Responses HTTP, including SSE streaming, unless a runtime
-is selected explicitly. Chats without these fields keep the standard
-`OPENAI_API_KEY` / `OPENAI_BASE_URL` SDK behavior and Chatsnack's Responses
-WebSocket default.
-
-Legacy Azure fields (`api_base`, `api_type`, `api_version`, and `deployment`) are
-no longer accepted. The legacy endpoint variables `OPENAI_AZURE_ENDPOINT` and
-`OPENAI_API_BASE` also raise a migration error when no new endpoint is authored.
-Move the complete endpoint and credential-variable name to `base_url` and
-`api_key_env`; put the Azure deployment name in `model`.
-
-Client settings are bound when a Chat is created or first loaded. Continued and
-copied Chats keep that binding, and `reset()` does not re-read the credential
-environment variable. Create a new Chat to use a different endpoint, credential,
-or transport.
+Using OpenRouter, Azure v1, or another OpenAI-compatible endpoint? See the
+[OpenAI-compatible providers guide](docs/guides/providers.md).
 
 ## Usage
 

--- a/chatsnack/aiclient.py
+++ b/chatsnack/aiclient.py
@@ -1,79 +1,113 @@
 import asyncio
-import openai
-import os
-import json
 import inspect
-from loguru import logger
+import os
+from typing import Any, Optional
 
-# class that wraps the OpenAI client and Azure clients
+import openai
+
+
 class AiClient:
-    def __init__(self, api_key = None, base_url = None, azure_endpoint = None, api_version = None, azure_ad_token = None, azure_ad_token_provider = None):
-        # check environment variables and use those if explicit values are not passed in
-        # API key
-        if api_key is None:
-            api_key = os.getenv("OPENAI_API_KEY")
+    """Own lazy sync and async OpenAI clients for one Chat endpoint."""
 
-        # base_url
-        if base_url is None:
-            base_url = os.getenv("OPENAI_API_BASE")
-
-        # Azure specific        
-        if azure_endpoint is None:
-            azure_endpoint = os.getenv("OPENAI_AZURE_ENDPOINT")
-
-        # api_version
-        if api_version is None:
-            api_version = os.getenv("OPENAI_API_VERSION")
-
-        # azure_ad_token
-        if azure_ad_token is None:
-            azure_ad_token = os.getenv("OPENAI_AZURE_AD_TOKEN")
-
-        # azure_ad_token_provider
-        if azure_ad_token_provider is None:
-            azure_ad_token_provider = os.getenv("OPENAI_AZURE_AD_TOKEN_PROVIDER")
-
-        # keep track of the values we're using
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        api_key_env: Optional[str] = None,
+    ):
+        if api_key is None and api_key_env:
+            api_key = os.getenv(api_key_env)
+            if api_key is None or not api_key.strip():
+                raise ValueError(
+                    f"Credential environment variable '{api_key_env}' is not set or is blank."
+                )
         self._api_key = api_key
-        self.azure_endpoint = azure_endpoint
-        self.api_version = api_version
-        self.azure_ad_token = azure_ad_token
-        self.azure_ad_token_provider = azure_ad_token_provider
         self.base_url = base_url
+        self.api_key_env = api_key_env
+        self._client: Any = None
+        self._aclient: Any = None
 
-        # if the azure_endpoint is set, we're an azure client
-        if self.azure_endpoint is not None:
-            self.is_azure = True
-            self.aclient = openai.AsyncAzureOpenAI(api_key=api_key, azure_endpoint=self.azure_endpoint, api_version=self.api_version, azure_ad_token=self.azure_ad_token, azure_ad_token_provider=self.azure_ad_token_provider)
-            self.client = openai.AzureOpenAI(api_key=api_key, azure_endpoint=self.azure_endpoint, api_version=self.api_version, azure_ad_token=self.azure_ad_token, azure_ad_token_provider=self.azure_ad_token_provider)
-        else:
-            self.is_azure = False
+    def _client_kwargs(self, client_class) -> dict:
+        """Build ordinary SDK options without ambient OpenAI tenant headers."""
+        kwargs = {}
+        if self._api_key is not None:
+            kwargs["api_key"] = self._api_key
+        if self.base_url is not None:
+            kwargs["base_url"] = self.base_url
+            supported = inspect.signature(client_class).parameters
+            for name in ("organization", "project"):
+                if name in supported:
+                    kwargs[name] = openai.Omit()
+            if "default_headers" in supported:
+                # OpenAI 3.x merges OPENAI_CUSTOM_HEADERS into every ordinary
+                # client. A per-Chat custom endpoint must not inherit headers
+                # intended for another provider; its named key stays explicit.
+                headers = {}
+                for line in os.getenv("OPENAI_CUSTOM_HEADERS", "").splitlines():
+                    name, separator, _ = line.partition(":")
+                    if separator and name.strip():
+                        headers[name.strip()] = openai.Omit()
+                if self._api_key is not None:
+                    headers["Authorization"] = f"Bearer {self._api_key}"
+                kwargs["default_headers"] = headers
+        return kwargs
 
-            # if we have base_url, we're a custom OpenAI client
-            if self.base_url is None:
-                self.aclient = openai.AsyncOpenAI(api_key=api_key)
-                self.client = openai.OpenAI(api_key=api_key)
-            else:
-                self.aclient = openai.AsyncOpenAI(api_key=api_key, base_url=self.base_url)
-                self.client = openai.OpenAI(api_key=api_key, base_url=self.base_url)
-    
     @property
-    def api_key(self):
-        return self._api_key
+    def client(self):
+        """Return the sync SDK client, constructing it on first use."""
+        if self._client is None:
+            self._client = openai.OpenAI(**self._client_kwargs(openai.OpenAI))
+        return self._client
+
+    @client.setter
+    def client(self, value):
+        self._client = value
+
+    @property
+    def aclient(self):
+        """Return the async SDK client, constructing it on first use."""
+        if self._aclient is None:
+            self._aclient = openai.AsyncOpenAI(
+                **self._client_kwargs(openai.AsyncOpenAI)
+            )
+        return self._aclient
+
+    @aclient.setter
+    def aclient(self, value):
+        self._aclient = value
+
+    @property
+    def _has_opened_clients(self) -> bool:
+        """Return whether this binding currently owns an SDK client object."""
+        return self._client is not None or self._aclient is not None
+
+    def _clone_binding(self) -> "AiClient":
+        """Create an independent lazy owner with this binding's resolved key."""
+        return AiClient(
+            api_key=self._api_key,
+            base_url=self.base_url,
+            api_key_env=self.api_key_env,
+        )
+
+    @property
+    def api_key(self) -> Optional[str]:
+        return self._api_key if self._api_key is not None else os.getenv("OPENAI_API_KEY")
 
     @api_key.setter
     def api_key(self, value):
         self._api_key = value
-        self.aclient.api_key = value
-        self.client.api_key = value
+        if self._aclient is not None:
+            self._aclient.api_key = value
+        if self._client is not None:
+            self._client.api_key = value
 
     def upload_file(self, file_path: str, purpose: str = "assistants") -> str:
         """Upload a local file via the OpenAI Files API (synchronous).
 
         Returns the ``file_id`` string from the created file object.
         """
-        with open(file_path, "rb") as f:
-            result = self.client.files.create(file=f, purpose=purpose)
+        with open(file_path, "rb") as file_handle:
+            result = self.client.files.create(file=file_handle, purpose=purpose)
         return result.id
 
     async def upload_file_async(self, file_path: str, purpose: str = "assistants") -> str:
@@ -81,8 +115,8 @@ class AiClient:
 
         Returns the ``file_id`` string from the created file object.
         """
-        with open(file_path, "rb") as f:
-            result = await self.aclient.files.create(file=f, purpose=purpose)
+        with open(file_path, "rb") as file_handle:
+            result = await self.aclient.files.create(file=file_handle, purpose=purpose)
         return result.id
 
     async def download_container_file_async(self, container_id: str, file_id: str) -> bytes:
@@ -104,13 +138,17 @@ class AiClient:
         raise TypeError("Container file download did not return bytes.")
 
     @staticmethod
-    def _supports_responses_endpoint(client) -> bool:
-        responses = getattr(client, "responses", None)
-        return responses is not None and callable(getattr(responses, "create", None))
+    def _supports_responses_endpoint(client_or_class) -> bool:
+        responses = getattr(client_or_class, "responses", None)
+        create = getattr(responses, "create", None) if responses is not None else None
+        return callable(create) or hasattr(responses, "__get__")
 
     def ensure_responses_support(self) -> None:
-        sync_supported = self._supports_responses_endpoint(getattr(self, "client", None))
-        async_supported = self._supports_responses_endpoint(getattr(self, "aclient", None))
+        """Check the Responses SDK surface without opening lazy clients."""
+        sync_target = self._client if self._client is not None else openai.OpenAI
+        async_target = self._aclient if self._aclient is not None else openai.AsyncOpenAI
+        sync_supported = self._supports_responses_endpoint(sync_target)
+        async_supported = self._supports_responses_endpoint(async_target)
         if sync_supported and async_supported:
             return
 
@@ -123,5 +161,34 @@ class AiClient:
         raise RuntimeError(
             "Responses runtime requires OpenAI clients with Responses endpoints. Missing: "
             + ", ".join(missing)
-            + ". Upgrade the `openai` package to >=2.29.0 and/or inject compatible clients."
+            + ". Upgrade the `openai` package to >=3.5.0 and/or inject compatible clients."
         )
+
+    def close(self) -> None:
+        """Close any SDK clients that were opened."""
+        if self._aclient is not None:
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                pass
+            else:
+                raise RuntimeError("Use await close_a() inside an event loop.")
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+        if self._aclient is not None:
+            result = self._aclient.close()
+            if inspect.isawaitable(result):
+                asyncio.run(result)
+            self._aclient = None
+
+    async def close_a(self) -> None:
+        """Close any opened sync and async SDK clients from async code."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+        if self._aclient is not None:
+            result = self._aclient.close()
+            if inspect.isawaitable(result):
+                await result
+            self._aclient = None

--- a/chatsnack/aiclient.py
+++ b/chatsnack/aiclient.py
@@ -30,12 +30,18 @@ class AiClient:
         self._api_key = api_key
         self.base_url = base_url
         self.api_key_env = api_key_env
+        self._resolved_base_url: Optional[str] = None
         self._client: Any = None
         self._aclient: Any = None
 
     def _client_kwargs(self, client_class) -> dict:
-        """Build ordinary SDK options without ambient OpenAI tenant headers."""
-        if self.base_url is None:
+        """Build SDK options while isolating authored custom endpoints."""
+        effective_base_url = (
+            self.base_url
+            if self.base_url is not None
+            else self._resolved_base_url
+        )
+        if effective_base_url is None:
             legacy_endpoint_vars = [
                 name
                 for name in _LEGACY_ENDPOINT_ENV_VARS
@@ -52,8 +58,9 @@ class AiClient:
         kwargs = {}
         if self._api_key is not None:
             kwargs["api_key"] = self._api_key
+        if effective_base_url is not None:
+            kwargs["base_url"] = effective_base_url
         if self.base_url is not None:
-            kwargs["base_url"] = self.base_url
             supported = inspect.signature(client_class).parameters
             for name in ("organization", "project"):
                 if name in supported:
@@ -102,7 +109,7 @@ class AiClient:
         return self._client is not None or self._aclient is not None
 
     def _clone_binding(self) -> "AiClient":
-        """Create an independent lazy owner with this binding's resolved key."""
+        """Clone resolved settings without changing the Chat's authored config."""
         api_key = self._api_key
         if api_key is None:
             for opened_client in (self._client, self._aclient):
@@ -110,11 +117,20 @@ class AiClient:
                 if isinstance(resolved_key, str) and resolved_key:
                     api_key = resolved_key
                     break
-        return AiClient(
+        resolved_base_url = self._resolved_base_url
+        if resolved_base_url is None and self.base_url is None:
+            for opened_client in (self._client, self._aclient):
+                opened_base_url = getattr(opened_client, "base_url", None)
+                if opened_base_url is not None:
+                    resolved_base_url = str(opened_base_url)
+                    break
+        cloned = AiClient(
             api_key=api_key,
             base_url=self.base_url,
             api_key_env=self.api_key_env,
         )
+        cloned._resolved_base_url = resolved_base_url
+        return cloned
 
     @property
     def api_key(self) -> Optional[str]:

--- a/chatsnack/aiclient.py
+++ b/chatsnack/aiclient.py
@@ -103,8 +103,15 @@ class AiClient:
 
     def _clone_binding(self) -> "AiClient":
         """Create an independent lazy owner with this binding's resolved key."""
+        api_key = self._api_key
+        if api_key is None:
+            for opened_client in (self._client, self._aclient):
+                resolved_key = getattr(opened_client, "api_key", None)
+                if isinstance(resolved_key, str) and resolved_key:
+                    api_key = resolved_key
+                    break
         return AiClient(
-            api_key=self._api_key,
+            api_key=api_key,
             base_url=self.base_url,
             api_key_env=self.api_key_env,
         )

--- a/chatsnack/aiclient.py
+++ b/chatsnack/aiclient.py
@@ -6,6 +6,12 @@ from typing import Any, Optional
 import openai
 
 
+_LEGACY_ENDPOINT_ENV_VARS = (
+    "OPENAI_API_BASE",
+    "OPENAI_AZURE_ENDPOINT",
+)
+
+
 class AiClient:
     """Own lazy sync and async OpenAI clients for one Chat endpoint."""
 
@@ -29,6 +35,20 @@ class AiClient:
 
     def _client_kwargs(self, client_class) -> dict:
         """Build ordinary SDK options without ambient OpenAI tenant headers."""
+        if self.base_url is None:
+            legacy_endpoint_vars = [
+                name
+                for name in _LEGACY_ENDPOINT_ENV_VARS
+                if os.getenv(name, "").strip()
+            ]
+            if legacy_endpoint_vars:
+                names = ", ".join(legacy_endpoint_vars)
+                raise ValueError(
+                    f"Legacy endpoint environment settings are no longer supported: {names}. "
+                    "Configure base_url and api_key_env on the Chat or in "
+                    "its YAML. For ordinary global OpenAI SDK configuration, use "
+                    "OPENAI_BASE_URL."
+                )
         kwargs = {}
         if self._api_key is not None:
             kwargs["api_key"] = self._api_key

--- a/chatsnack/chat/__init__.py
+++ b/chatsnack/chat/__init__.py
@@ -63,6 +63,13 @@ def _runtime_policy_from_env() -> tuple[str, Optional[str]]:
     return "responses", "inherit"
 
 
+def _chat_param_value(params: Any, name: str) -> Any:
+    """Read one authored value from ChatParams or its supported dict form."""
+    if isinstance(params, dict):
+        return params.get(name)
+    return getattr(params, name, None) if params is not None else None
+
+
 ########################################################################################################################
 # Core datafile classes of Plunkychat
 # (1) Chat, high-level class that symbolizes a prompt/request/response, can reference other Chat objects to chain
@@ -276,10 +283,10 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
         explicit_session = session is not None
         params_runtime = None
         if hasattr(self, "params") and self.params is not None:
-            profile = getattr(self.params, "profile", None)
-            params_runtime = getattr(self.params, "runtime", None)
+            profile = _chat_param_value(self.params, "profile")
+            params_runtime = _chat_param_value(self.params, "runtime")
             runtime_selector = runtime_selector or params_runtime
-            session_mode = getattr(self.params, "session", None)
+            session_mode = _chat_param_value(self.params, "session")
 
         # Phase 4 runtime resolution order:
         # explicit runtime object -> explicit runtime selector -> params.runtime
@@ -297,7 +304,7 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
         elif session_specified:
             runtime_selector = "responses"
             runtime_source = "explicit_session"
-        elif getattr(self.params, "base_url", None):
+        elif _chat_param_value(self.params, "base_url"):
             runtime_selector = "responses"
             runtime_source = "custom_endpoint"
         else:
@@ -310,6 +317,7 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
         if explicit_session and runtime_source in {"default_policy", "explicit_session"} and runtime_selector == "responses":
             session_mode = self.session
         self.runtime = self._select_runtime(runtime=runtime, runtime_selector=runtime_selector, profile=profile, session_mode=session_mode)
+        self._transport_binding = self._runtime_binding_signature(self.runtime)
         self._provider_binding_error = None
         self._last_runtime_metadata = _empty_runtime_metadata()
         self._last_call_usage = None
@@ -472,6 +480,8 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
         runtime_selector, profile, session_mode = _runtime_config_from_chat_params(self)
         if overrides.get("runtime_selector") is not None:
             runtime_selector = overrides["runtime_selector"]
+            if _chat_param_value(self.params, "session") is None:
+                session_mode = None
         return runtime, runtime_selector, profile, session_mode
 
     def _assert_bound_configuration(self) -> None:
@@ -481,10 +491,24 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
             raise ValueError(error)
         desired_client = self._client_config_from_params()
         current_client = getattr(self, "_client_binding", desired_client)
-        if desired_client != current_client:
+        runtime, runtime_selector, profile, session_mode = (
+            self._requested_runtime_configuration()
+        )
+        desired_runtime = self._selected_runtime_binding_signature(
+            runtime=runtime,
+            runtime_selector=runtime_selector,
+            profile=profile,
+            session_mode=session_mode,
+        )
+        current_runtime = getattr(
+            self,
+            "_transport_binding",
+            self._runtime_binding_signature(self.runtime),
+        )
+        if desired_client != current_client or desired_runtime != current_runtime:
             raise ValueError(
-                "Provider settings are fixed for an active Chat. "
-                "Create a new Chat to use different client parameters."
+                "Provider and transport settings are fixed for an active Chat. "
+                "Create a new Chat to use different provider or transport settings."
             )
 
     def _ai_client_for_copy(self, *, share: bool = False):
@@ -693,8 +717,33 @@ def _install_datafiles_compat(cls, should_autoload):
 
     def __init__(self, *args, **kwargs):
         autoload = should_autoload(args, kwargs)
+        deferred_param_overrides = {}
+        client_pair_is_complete = (
+            kwargs.get("base_url") is None
+        ) == (kwargs.get("api_key_env") is None)
+        if autoload and client_pair_is_complete:
+            # Load the durable ChatParams before applying live constructor
+            # knobs. Prebuilding defaults here would erase saved options.
+            kwargs = dict(kwargs)
+            for name in (
+                "engine",
+                "model",
+                "base_url",
+                "api_key_env",
+                "session",
+                "stream",
+                "auto_execute",
+                "tool_choice",
+                "auto_feed",
+            ):
+                if kwargs.get(name) is not None:
+                    deferred_param_overrides[name] = kwargs.pop(name)
         refresh_snapclass_config_stash(cls)
         original_init(self, *args, **kwargs)
+        if deferred_param_overrides:
+            self._chatsnack_constructor_overrides.update(
+                deferred_param_overrides
+            )
         # snapclass attaches snapshot after the model's custom __init__ returns.
         # Install chatsnack's load/save hooks here so direct chat.snapshot.load()
         # gets the same runtime refresh as Chat.load() and Chat.objects.get().
@@ -713,16 +762,20 @@ def _install_datafiles_compat(cls, should_autoload):
                     after_load = getattr(self, "_after_legacy_autoload", None)
                 if after_load is not None:
                     after_load()
+        elif deferred_param_overrides:
+            # Named new Chats have no asset to load, so finish their deferred
+            # parameter binding against the freshly initialized params.
+            self._refresh_after_snapshot_load()
 
     cls.__init__ = __init__
     cls.objects = _LegacyObjects(cls)
 
 
 def _runtime_config_from_chat_params(chat):
-    profile = getattr(chat.params, "profile", None) if chat.params is not None else None
-    runtime_selector = getattr(chat.params, "runtime", None) if chat.params is not None else None
-    session_mode = getattr(chat.params, "session", None) if chat.params is not None else None
-    base_url = getattr(chat.params, "base_url", None) if chat.params is not None else None
+    profile = _chat_param_value(chat.params, "profile")
+    runtime_selector = _chat_param_value(chat.params, "runtime")
+    session_mode = _chat_param_value(chat.params, "session")
+    base_url = _chat_param_value(chat.params, "base_url")
     if runtime_selector is None and session_mode is None and base_url:
         runtime_selector = "responses"
     elif runtime_selector is None and session_mode is None:
@@ -800,6 +853,8 @@ def _ensure_chat_live_state(self):
             profile=profile,
             session_mode=session_mode,
         )
+    if not hasattr(self, "_transport_binding"):
+        self._transport_binding = self._runtime_binding_signature(self.runtime)
     if not hasattr(self, "_last_runtime_metadata"):
         self._last_runtime_metadata = _empty_runtime_metadata()
     if not hasattr(self, "_last_call_usage"):
@@ -833,7 +888,11 @@ def _refresh_chat_after_snapshot_load(self):
         profile=profile,
         session_mode=session_mode,
     )
-    current_runtime = self._runtime_binding_signature(previous_runtime)
+    current_runtime = getattr(
+        self,
+        "_transport_binding",
+        self._runtime_binding_signature(previous_runtime),
+    )
     active_binding = bool(
         getattr(self, "_provider_binding_locked", False)
         or (
@@ -858,6 +917,7 @@ def _refresh_chat_after_snapshot_load(self):
             profile=profile,
             session_mode=session_mode,
         )
+        self._transport_binding = self._runtime_binding_signature(self.runtime)
     else:
         self._restart_websocket_session()
     self._provider_binding_locked = True

--- a/chatsnack/chat/__init__.py
+++ b/chatsnack/chat/__init__.py
@@ -35,6 +35,7 @@ def _empty_runtime_metadata() -> Dict[str, object]:
 
 
 _RUNTIME_ENV_WARNING_EMITTED = False
+_LEGACY_CLIENT_FIELDS = frozenset({"api_base", "api_type", "api_version", "deployment"})
 
 
 def _runtime_policy_from_env() -> tuple[str, Optional[str]]:
@@ -98,6 +99,12 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
         `Chat("Name", "system message")`, `Chat(name="SavedPrompt")`, and
         `Chat(..., utensils=[...])`.
         """
+        legacy_fields = sorted(_LEGACY_CLIENT_FIELDS.intersection(kwargs))
+        if legacy_fields:
+            raise TypeError(
+                f"Chat.__init__() got an unexpected keyword argument '{legacy_fields[0]}'"
+            )
+
         # Extract utensil-related parameters first
         utensils = kwargs.pop("utensils", None)
         auto_execute = kwargs.pop("auto_execute", None)
@@ -106,10 +113,17 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
         runtime = kwargs.pop("runtime", None)
         runtime_selector = kwargs.pop("runtime_selector", None)
         model = kwargs.pop("model", None)
+        base_url = kwargs.pop("base_url", None)
+        api_key_env = kwargs.pop("api_key_env", None)
+        if (base_url is None) != (api_key_env is None):
+            raise ValueError(
+                "base_url and api_key_env constructor overrides must be provided together."
+            )
         session = kwargs.pop("session", None)
         stream = kwargs.pop("stream", None)
         tool_search_handler = kwargs.pop("tool_search_handler", None)
         runtime_bindings = kwargs.pop("_runtime_bindings", None)
+        inherited_ai_client = kwargs.pop("_ai_client", None)
         if isinstance(runtime, str) and runtime_selector is None:
             runtime_selector = runtime
             runtime = None
@@ -122,6 +136,8 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
             for key, value in {
                 "engine": kwargs.get("engine"),
                 "model": model,
+                "base_url": base_url,
+                "api_key_env": api_key_env,
                 "session": session,
                 "stream": stream,
                 "auto_execute": auto_execute,
@@ -162,6 +178,11 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
             self.engine = kwargs["engine"]
         if model is not None:
             self.model = model
+        if base_url is not None:
+            if self.params is None:
+                self.params = ChatParams()
+            self.params.base_url = base_url
+            self.params.api_key_env = api_key_env
         if session is not None:
             self.session = session
         if stream is not None:
@@ -248,7 +269,7 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
         self._initial_registry = getattr(self, '_local_registry', None)
         self._initial_runtime_bindings = dict(self._runtime_bindings)
 
-        self.ai = AiClient()
+        self._bind_ai_client(inherited_ai_client)
         profile = None
         session_mode = None
         explicit_runtime_selector = runtime_selector
@@ -276,6 +297,9 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
         elif session_specified:
             runtime_selector = "responses"
             runtime_source = "explicit_session"
+        elif getattr(self.params, "base_url", None):
+            runtime_selector = "responses"
+            runtime_source = "custom_endpoint"
         else:
             runtime_selector, default_session = _runtime_policy_from_env()
             runtime_source = "default_policy"
@@ -286,11 +310,80 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
         if explicit_session and runtime_source in {"default_policy", "explicit_session"} and runtime_selector == "responses":
             session_mode = self.session
         self.runtime = self._select_runtime(runtime=runtime, runtime_selector=runtime_selector, profile=profile, session_mode=session_mode)
+        self._provider_binding_error = None
         self._last_runtime_metadata = _empty_runtime_metadata()
         self._last_call_usage = None
 
 
-   
+    def _client_config_from_params(self) -> tuple[Optional[str], Optional[str]]:
+        """Return the normalized nonsecret client configuration authored on this Chat."""
+        params = getattr(self, "params", None)
+        if isinstance(params, dict):
+            raw_base_url = params.get("base_url")
+            raw_api_key_env = params.get("api_key_env")
+        else:
+            raw_base_url = getattr(params, "base_url", None) if params is not None else None
+            raw_api_key_env = getattr(params, "api_key_env", None) if params is not None else None
+        base_url = raw_base_url.strip() if isinstance(raw_base_url, str) else raw_base_url
+        api_key_env = (
+            raw_api_key_env.strip()
+            if isinstance(raw_api_key_env, str)
+            else raw_api_key_env
+        )
+        if bool(base_url) != bool(api_key_env) or (
+            raw_base_url is not None and not base_url
+        ) or (
+            raw_api_key_env is not None and not api_key_env
+        ):
+            raise ValueError(
+                "base_url and api_key_env must be nonblank and configured together."
+            )
+        if isinstance(params, dict):
+            if raw_base_url is not None or raw_api_key_env is not None:
+                params["base_url"] = base_url
+                params["api_key_env"] = api_key_env
+        elif params is not None:
+            params.base_url = base_url
+            params.api_key_env = api_key_env
+        return base_url, api_key_env
+
+    def _bind_ai_client(self, inherited_ai_client=None) -> None:
+        """Bind one lazy SDK client owner when a conversation lineage begins."""
+        base_url, api_key_env = self._client_config_from_params()
+        binding = (base_url, api_key_env)
+        if not hasattr(self, "_provider_binding_locked"):
+            self._provider_binding_locked = bool(base_url) or inherited_ai_client is not None
+        if inherited_ai_client is not None:
+            inherited_binding = (
+                getattr(inherited_ai_client, "base_url", None),
+                getattr(inherited_ai_client, "api_key_env", None),
+            )
+            if inherited_binding != binding:
+                raise ValueError(
+                    "A continued Chat must keep its source provider binding. "
+                    "Create a new Chat to use different client parameters."
+                )
+            self.ai = inherited_ai_client
+            self._client_binding = binding
+            return
+
+        if not base_url:
+            self.ai = AiClient()
+            self._client_binding = binding
+            return
+
+        api_key = os.getenv(api_key_env)
+        if api_key is None or not api_key.strip():
+            raise ValueError(
+                f"Credential environment variable '{api_key_env}' is not set or is blank."
+            )
+        self.ai = AiClient(
+            api_key=api_key,
+            base_url=base_url,
+            api_key_env=api_key_env,
+        )
+        self._client_binding = binding
+
     @staticmethod
     def _is_responses_runtime_selected(runtime_selector) -> bool:
         if runtime_selector is None:
@@ -304,9 +397,9 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
             runtime_selector = runtime_selector or runtime
             runtime = None
         if runtime is not None:
-            # Recreate known adapter types bound to this chat's own ai client so
-            # that cloned/continued chats are fully independent (not sharing the
-            # source chat's ai_client or any adapter state).
+            # Recreate known adapter types around the child Chat's bound client.
+            # Adapter state stays per Chat; a continuation may share the client
+            # that made its request while an ordinary copy owns a lazy clone.
             if isinstance(runtime, ResponsesWebSocketAdapter):
                 if session_mode == "new":
                     child_session = ResponsesWebSocketSession(mode="new")
@@ -338,11 +431,104 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
 
         return ChatCompletionsAdapter(self.ai)
 
+    @staticmethod
+    def _runtime_binding_signature(runtime) -> tuple[object, object]:
+        """Describe the built-in transport state that stays fixed for a lineage."""
+        if isinstance(runtime, ResponsesWebSocketAdapter):
+            return "responses_websocket", getattr(runtime.session, "mode", None)
+        if isinstance(runtime, ResponsesAdapter):
+            return "responses_http", None
+        if isinstance(runtime, ChatCompletionsAdapter):
+            return "chat_completions", None
+        return "custom", id(runtime)
+
+    def _selected_runtime_binding_signature(
+        self,
+        *,
+        runtime=None,
+        runtime_selector=None,
+        profile=None,
+        session_mode=None,
+    ) -> tuple[object, object]:
+        """Describe the transport that the final authored parameters request."""
+        if runtime is not None and not isinstance(runtime, str):
+            if isinstance(runtime, ResponsesWebSocketAdapter):
+                mode = session_mode or getattr(runtime.session, "mode", None)
+                return "responses_websocket", mode
+            return self._runtime_binding_signature(runtime)
+        if self._is_responses_runtime_selected(runtime_selector) or (
+            isinstance(profile, dict)
+            and self._is_responses_runtime_selected(profile.get("runtime"))
+        ):
+            if session_mode in {"inherit", "new"}:
+                return "responses_websocket", session_mode
+            return "responses_http", None
+        return "chat_completions", None
+
+    def _requested_runtime_configuration(self):
+        """Resolve the final runtime inputs without constructing another adapter."""
+        overrides = getattr(self, "_chatsnack_constructor_overrides", {})
+        runtime = overrides.get("runtime")
+        runtime_selector, profile, session_mode = _runtime_config_from_chat_params(self)
+        if overrides.get("runtime_selector") is not None:
+            runtime_selector = overrides["runtime_selector"]
+        return runtime, runtime_selector, profile, session_mode
+
+    def _assert_bound_configuration(self) -> None:
+        """Stop an active Chat before changed client settings can misroute a request."""
+        error = getattr(self, "_provider_binding_error", None)
+        if error:
+            raise ValueError(error)
+        desired_client = self._client_config_from_params()
+        current_client = getattr(self, "_client_binding", desired_client)
+        if desired_client != current_client:
+            raise ValueError(
+                "Provider settings are fixed for an active Chat. "
+                "Create a new Chat to use different client parameters."
+            )
+
+    def _ai_client_for_copy(self, *, share: bool = False):
+        """Share transient request ownership or clone the resolved binding."""
+        if share:
+            return getattr(self, "ai", None)
+        clone = getattr(getattr(self, "ai", None), "_clone_binding", None)
+        return clone() if clone is not None else None
+
+    def _restart_websocket_session(self) -> None:
+        """Detach restored history from any prior provider conversation state."""
+        runtime = getattr(self, "runtime", None)
+        if not isinstance(runtime, ResponsesWebSocketAdapter):
+            return
+        runtime.close_session()
+        self.runtime = ResponsesWebSocketAdapter(
+            self.ai,
+            session=ResponsesWebSocketSession(mode=runtime.session.mode),
+            **runtime._retry_options(),
+        )
+
     def close_session(self):
         """Close the active runtime session if the selected runtime supports it."""
         runtime = getattr(self, "runtime", None)
         if hasattr(runtime, "close_session"):
             runtime.close_session()
+
+    def close(self) -> None:
+        """Close this Chat's built-in runtime session and opened SDK clients."""
+        self.close_session()
+        ai = getattr(self, "ai", None)
+        if hasattr(ai, "close"):
+            ai.close()
+
+    async def close_a(self) -> None:
+        """Asynchronously close this Chat's runtime session and SDK clients."""
+        runtime = getattr(self, "runtime", None)
+        if hasattr(runtime, "close_session_a"):
+            await runtime.close_session_a()
+        elif hasattr(runtime, "close_session"):
+            runtime.close_session()
+        ai = getattr(self, "ai", None)
+        if hasattr(ai, "close_a"):
+            await ai.close_a()
 
     @classmethod
     def close_all_sessions(cls):
@@ -357,8 +543,8 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
     def reset(self) -> object:
         """Restore the chat to the state captured immediately after initialization."""
         self.name = self._initial_name
-        self.params = self._initial_params
-        self.messages = self._initial_messages
+        self.params = copy.copy(self._initial_params)
+        self.messages = copy.copy(self._initial_messages)
         if self._initial_system_message is not None:
             self.system_message = self._initial_system_message
         # Reset tools if initial registry was stored
@@ -370,8 +556,10 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
         self._runtime_bindings = dict(
             getattr(self, "_initial_runtime_bindings", {})
         )
+        self._provider_binding_error = None
         self._last_runtime_metadata = _empty_runtime_metadata()
         self._last_call_usage = None
+        self._restart_websocket_session()
         return self
     
     def _load_tools_from_params(self):
@@ -534,7 +722,10 @@ def _runtime_config_from_chat_params(chat):
     profile = getattr(chat.params, "profile", None) if chat.params is not None else None
     runtime_selector = getattr(chat.params, "runtime", None) if chat.params is not None else None
     session_mode = getattr(chat.params, "session", None) if chat.params is not None else None
-    if runtime_selector is None and session_mode is None:
+    base_url = getattr(chat.params, "base_url", None) if chat.params is not None else None
+    if runtime_selector is None and session_mode is None and base_url:
+        runtime_selector = "responses"
+    elif runtime_selector is None and session_mode is None:
         runtime_selector, session_mode = _runtime_policy_from_env()
     elif runtime_selector is None and session_mode is not None:
         runtime_selector = "responses"
@@ -550,6 +741,13 @@ def _apply_chat_constructor_overrides(chat):
         chat.engine = overrides["engine"]
     if "model" in overrides:
         chat.model = overrides["model"]
+    if "base_url" in overrides or "api_key_env" in overrides:
+        if chat.params is None:
+            chat.params = ChatParams()
+        if "base_url" in overrides:
+            chat.params.base_url = overrides["base_url"]
+        if "api_key_env" in overrides:
+            chat.params.api_key_env = overrides["api_key_env"]
     if "session" in overrides:
         chat.session = overrides["session"]
     if "stream" in overrides:
@@ -583,7 +781,12 @@ def _ensure_chat_live_state(self):
     # authoritative YAML load refresh.
     self._install_snapshot_compat_hooks()
     if not hasattr(self, "ai"):
-        self.ai = AiClient()
+        self._bind_ai_client()
+    elif not hasattr(self, "_client_binding"):
+        self._client_binding = (
+            getattr(self.ai, "base_url", None),
+            getattr(self.ai, "api_key_env", None),
+        )
     if not hasattr(self, "tool_search_handler"):
         self.tool_search_handler = None
     if not hasattr(self, "_runtime_bindings"):
@@ -601,6 +804,12 @@ def _ensure_chat_live_state(self):
         self._last_runtime_metadata = _empty_runtime_metadata()
     if not hasattr(self, "_last_call_usage"):
         self._last_call_usage = None
+    if not hasattr(self, "_provider_binding_error"):
+        self._provider_binding_error = None
+    if not hasattr(self, "_provider_binding_locked"):
+        self._provider_binding_locked = bool(
+            getattr(self, "_client_binding", (None, None))[0]
+        )
     if not hasattr(self, "_initial_name"):
         _capture_chat_reset_state(self)
 
@@ -611,15 +820,48 @@ def _refresh_chat_after_snapshot_load(self):
     _ensure_chat_live_state(self)
     self._load_tools_from_params()
     overrides = _apply_chat_constructor_overrides(self)
-    runtime_selector, profile, session_mode = _runtime_config_from_chat_params(self)
-    if "runtime_selector" in overrides:
-        runtime_selector = overrides["runtime_selector"]
-    self.runtime = self._select_runtime(
-        runtime=overrides.get("runtime"),
+    previous_runtime = getattr(self, "runtime", None)
+    previous_ai = getattr(self, "ai", None)
+    runtime, runtime_selector, profile, session_mode = (
+        self._requested_runtime_configuration()
+    )
+    desired_client = self._client_config_from_params()
+    current_client = getattr(self, "_client_binding", desired_client)
+    desired_runtime = self._selected_runtime_binding_signature(
+        runtime=runtime,
         runtime_selector=runtime_selector,
         profile=profile,
         session_mode=session_mode,
     )
+    current_runtime = self._runtime_binding_signature(previous_runtime)
+    active_binding = bool(
+        getattr(self, "_provider_binding_locked", False)
+        or (
+            previous_ai is not None
+            and getattr(previous_ai, "_has_opened_clients", False)
+        )
+    )
+    if active_binding and (
+        desired_client != current_client or desired_runtime != current_runtime
+    ):
+        self._provider_binding_error = (
+            "Provider and transport settings are fixed for an active Chat. "
+            "Create a new Chat and load the asset there."
+        )
+        raise ValueError(self._provider_binding_error)
+
+    if not active_binding:
+        self._bind_ai_client()
+        self.runtime = self._select_runtime(
+            runtime=runtime,
+            runtime_selector=runtime_selector,
+            profile=profile,
+            session_mode=session_mode,
+        )
+    else:
+        self._restart_websocket_session()
+    self._provider_binding_locked = True
+    self._provider_binding_error = None
     self._last_runtime_metadata = _empty_runtime_metadata()
     self._last_call_usage = None
     _capture_chat_reset_state(self)

--- a/chatsnack/chat/__init__.py
+++ b/chatsnack/chat/__init__.py
@@ -2,6 +2,7 @@ import copy
 import os
 import warnings
 import uuid
+from collections.abc import Mapping
 from dataclasses import field
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
@@ -169,7 +170,12 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
                 self.name = self.__dataclass_fields__["name"].default_factory()
         
         if "params" in kwargs:
-            self.params = kwargs["params"]
+            raw_params = kwargs["params"]
+            self.params = (
+                ChatParams(**dict(raw_params))
+                if isinstance(raw_params, Mapping)
+                else raw_params
+            )
         else:
             # get the default value from the dataclass field, it's optional
             self.params = self.__dataclass_fields__["params"].default
@@ -194,6 +200,10 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
             self.session = session
         if stream is not None:
             self.stream = stream
+        if runtime_selector is not None:
+            if self.params is None:
+                self.params = ChatParams()
+            self.params.runtime = runtime_selector
             
         if "system" in kwargs:
             self.system_message = kwargs["system"]
@@ -317,6 +327,8 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
         if explicit_session and runtime_source in {"default_policy", "explicit_session"} and runtime_selector == "responses":
             session_mode = self.session
         self.runtime = self._select_runtime(runtime=runtime, runtime_selector=runtime_selector, profile=profile, session_mode=session_mode)
+        if runtime is not None:
+            self._chatsnack_constructor_overrides["runtime"] = self.runtime
         self._transport_binding = self._runtime_binding_signature(self.runtime)
         self._provider_binding_error = None
         self._last_runtime_metadata = _empty_runtime_metadata()
@@ -440,15 +452,19 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
         return ChatCompletionsAdapter(self.ai)
 
     @staticmethod
-    def _runtime_binding_signature(runtime) -> tuple[object, object]:
+    def _runtime_binding_signature(runtime) -> tuple[object, object, object]:
         """Describe the built-in transport state that stays fixed for a lineage."""
         if isinstance(runtime, ResponsesWebSocketAdapter):
-            return "responses_websocket", getattr(runtime.session, "mode", None)
+            return (
+                "responses_websocket",
+                getattr(runtime.session, "mode", None),
+                id(runtime.ai_client),
+            )
         if isinstance(runtime, ResponsesAdapter):
-            return "responses_http", None
+            return "responses_http", None, id(runtime.ai_client)
         if isinstance(runtime, ChatCompletionsAdapter):
-            return "chat_completions", None
-        return "custom", id(runtime)
+            return "chat_completions", None, id(runtime.ai_client)
+        return "custom", None, id(runtime)
 
     def _selected_runtime_binding_signature(
         self,
@@ -457,31 +473,27 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
         runtime_selector=None,
         profile=None,
         session_mode=None,
-    ) -> tuple[object, object]:
+    ) -> tuple[object, object, object]:
         """Describe the transport that the final authored parameters request."""
         if runtime is not None and not isinstance(runtime, str):
             if isinstance(runtime, ResponsesWebSocketAdapter):
                 mode = session_mode or getattr(runtime.session, "mode", None)
-                return "responses_websocket", mode
+                return "responses_websocket", mode, id(runtime.ai_client)
             return self._runtime_binding_signature(runtime)
         if self._is_responses_runtime_selected(runtime_selector) or (
             isinstance(profile, dict)
             and self._is_responses_runtime_selected(profile.get("runtime"))
         ):
             if session_mode in {"inherit", "new"}:
-                return "responses_websocket", session_mode
-            return "responses_http", None
-        return "chat_completions", None
+                return "responses_websocket", session_mode, id(self.ai)
+            return "responses_http", None, id(self.ai)
+        return "chat_completions", None, id(self.ai)
 
     def _requested_runtime_configuration(self):
         """Resolve the final runtime inputs without constructing another adapter."""
         overrides = getattr(self, "_chatsnack_constructor_overrides", {})
         runtime = overrides.get("runtime")
         runtime_selector, profile, session_mode = _runtime_config_from_chat_params(self)
-        if overrides.get("runtime_selector") is not None:
-            runtime_selector = overrides["runtime_selector"]
-            if _chat_param_value(self.params, "session") is None:
-                session_mode = None
         return runtime, runtime_selector, profile, session_mode
 
     def _assert_bound_configuration(self) -> None:
@@ -505,7 +517,26 @@ class Chat(ChatQueryMixin, ChatSerializationMixin, ChatUtensilMixin):
             "_transport_binding",
             self._runtime_binding_signature(self.runtime),
         )
-        if desired_client != current_client or desired_runtime != current_runtime:
+        actual_runtime = self._runtime_binding_signature(self.runtime)
+        binding_locked = bool(getattr(self, "_provider_binding_locked", False))
+        if (
+            not binding_locked
+            and desired_client == current_client
+            and desired_runtime == current_runtime
+            and actual_runtime != current_runtime
+        ):
+            # A low-level runtime installed before first use becomes the
+            # Chat's explicit transport. Once a request starts, the same
+            # signature is enforced like any constructor-selected runtime.
+            self._chatsnack_constructor_overrides["runtime"] = self.runtime
+            self._transport_binding = actual_runtime
+            desired_runtime = actual_runtime
+            current_runtime = actual_runtime
+        if (
+            desired_client != current_client
+            or desired_runtime != current_runtime
+            or actual_runtime != current_runtime
+        ):
             raise ValueError(
                 "Provider and transport settings are fixed for an active Chat. "
                 "Create a new Chat to use different provider or transport settings."
@@ -735,9 +766,15 @@ def _install_datafiles_compat(cls, should_autoload):
                 "auto_execute",
                 "tool_choice",
                 "auto_feed",
+                "runtime",
+                "runtime_selector",
             ):
                 if kwargs.get(name) is not None:
-                    deferred_param_overrides[name] = kwargs.pop(name)
+                    value = kwargs.pop(name)
+                    if name == "runtime" and isinstance(value, str):
+                        deferred_param_overrides["runtime_selector"] = value
+                    else:
+                        deferred_param_overrides[name] = value
         refresh_snapclass_config_stash(cls)
         original_init(self, *args, **kwargs)
         if deferred_param_overrides:
@@ -811,6 +848,10 @@ def _apply_chat_constructor_overrides(chat):
         chat.tool_choice = overrides["tool_choice"]
     if "auto_feed" in overrides:
         chat.auto_feed = overrides["auto_feed"]
+    if "runtime_selector" in overrides:
+        if chat.params is None:
+            chat.params = ChatParams()
+        chat.params.runtime = overrides["runtime_selector"]
     if "tool_search_handler" in overrides:
         chat.tool_search_handler = overrides["tool_search_handler"]
         chat._runtime_bindings["tool_search"] = overrides["tool_search_handler"]
@@ -917,6 +958,8 @@ def _refresh_chat_after_snapshot_load(self):
             profile=profile,
             session_mode=session_mode,
         )
+        if runtime is not None:
+            self._chatsnack_constructor_overrides["runtime"] = self.runtime
         self._transport_binding = self._runtime_binding_signature(self.runtime)
     else:
         self._restart_websocket_session()

--- a/chatsnack/chat/mixin_params.py
+++ b/chatsnack/chat/mixin_params.py
@@ -442,11 +442,9 @@ class ChatParams:
     auto_execute: Optional[bool] = None  
     auto_feed: bool | int | None = True  # True keeps the legacy five-cycle tool-result feed limit
 
-    # Azure-specific parameters
-    deployment: Optional[str] = None
-    api_type: Optional[str] = None
-    api_base: Optional[str] = None
-    api_version: Optional[str] = None
+    # Authored client configuration. The environment-variable name is saved;
+    # its secret value is resolved only when a Chat binds its client.
+    base_url: Optional[str] = None
     api_key_env: Optional[str] = None
 
     response_pattern: Optional[str] = None  # internal usage, not passed to the API
@@ -491,15 +489,19 @@ class ChatParams:
         """Returns True if current model supports system messages."""
         return not ("o1" in self.model or "o1-preview" in self.model or "o1-mini" in self.model)
 
-    def _supports_temperature(self) -> bool:
-        """Returns True if current model supports temperature."""
-        return "gpt-4o" in self.model or "gpt-4-turbo" in self.model
+    def _supports_temperature(self) -> Optional[bool]:
+        """Return known support while leaving provider model aliases unknown."""
+        model = (self.model or "").lower()
+        if self._get_reasoning_capabilities() is not None:
+            return False
+        if any(pattern in model for pattern in ("gpt-4o", "gpt-4-turbo")):
+            return True
+        return None
 
     def _get_non_none_params(self) -> dict:
         """
         Returns a dictionary of non-None parameters to send to the ChatCompletion API.
-        Converts old usage (engine, max_tokens) to new fields (model, max_completion_tokens)
-        automatically for reasoning models, so clients don't have to change code.
+        Provider adapters translate cross-family fields after the runtime is known.
         """
         # Gather all fields of the dataclass
         fields = [field.name for field in self.__dataclass_fields__.values()]
@@ -516,19 +518,13 @@ class ChatParams:
         if "engine" in out:
             del out["engine"]
 
-        # max_tokens is deprecated
-        if "max_tokens" in out:
-            out["max_completion_tokens"] = out["max_tokens"]
-            del out["max_tokens"]
-
-        # If model supports temperatures, remove it to avoid breakage
-        if not self._supports_temperature():
-            if "temperature" in out:
-                out["temperature"] = None
-                del out["temperature"]
-        else:
-            # For older GPT-3.5 or GPT-4, we keep max_tokens as-is 
-            pass
+        # Validation remains advisory so provider aliases and deployment names
+        # keep options authored by the caller.
+        if "temperature" in out and self._supports_temperature() is False:
+            warnings.warn(
+                f"Model '{self.model}' may not support temperature; forwarding as authored.",
+                stacklevel=3,
+            )
 
         # Remove tools and tool_choice as they are handled by the utensil_params
         if "tools" in out:
@@ -551,6 +547,10 @@ class ChatParams:
             del out["session"]
         if "responses" in out:
             del out["responses"]
+        if "base_url" in out:
+            del out["base_url"]
+        if "api_key_env" in out:
+            del out["api_key_env"]
 
         # Convert tool definitions to API format
         if "tools" in out and out["tools"]:

--- a/chatsnack/chat/mixin_params.py
+++ b/chatsnack/chat/mixin_params.py
@@ -489,15 +489,6 @@ class ChatParams:
         """Returns True if current model supports system messages."""
         return not ("o1" in self.model or "o1-preview" in self.model or "o1-mini" in self.model)
 
-    def _supports_temperature(self) -> Optional[bool]:
-        """Return known support while leaving provider model aliases unknown."""
-        model = (self.model or "").lower()
-        if self._get_reasoning_capabilities() is not None:
-            return False
-        if any(pattern in model for pattern in ("gpt-4o", "gpt-4-turbo")):
-            return True
-        return None
-
     def _get_non_none_params(self) -> dict:
         """
         Returns a dictionary of non-None parameters to send to the ChatCompletion API.
@@ -517,14 +508,6 @@ class ChatParams:
         # engine is deprecated; remove it from the final dict
         if "engine" in out:
             del out["engine"]
-
-        # Validation remains advisory so provider aliases and deployment names
-        # keep options authored by the caller.
-        if "temperature" in out and self._supports_temperature() is False:
-            warnings.warn(
-                f"Model '{self.model}' may not support temperature; forwarding as authored.",
-                stacklevel=3,
-            )
 
         # Remove tools and tool_choice as they are handled by the utensil_params
         if "tools" in out:

--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -1022,9 +1022,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
             {},
         )
         if "runtime" in source_overrides:
-            child._chatsnack_constructor_overrides["runtime"] = (
-                source_overrides["runtime"]
-            )
+            child._chatsnack_constructor_overrides["runtime"] = child.runtime
         else:
             child._chatsnack_constructor_overrides.pop("runtime", None)
 

--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -11,7 +11,7 @@ from loguru import logger
 from ..assets import capture_asset
 from ..asynchelpers import aformatter
 from ..fillings import active_filling_stash, filling_machine
-from ..runtime import ApplyPatchCall, EVENT_SCHEMA_VERSION
+from ..runtime import ApplyPatchCall, EVENT_SCHEMA_VERSION, ResponsesWebSocketAdapter
 from ..runtime.attachment_inputs import normalize_attachment_inputs
 
 from .mixin_messages import ChatMessagesMixin
@@ -612,17 +612,41 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         self,
         track_continuation: bool = False,
         _call_usage_ledger=None,
+        _submitted_runtime_out=None,
         **additional_vars,
     ):
         """ Executes the query as-is and returns a tuple of the final prompt and the response"""
+        assert_binding = getattr(self, "_assert_bound_configuration", None)
+        if assert_binding is not None:
+            assert_binding()
+        self._provider_binding_locked = True
         prompter = self
         # if the user in additional_vars, we're going to instead deepcopy this prompt into a new prompt and add the .user() to it
         if "__user" in additional_vars:
-            new_chatprompt = self.copy()
+            new_chatprompt = self.copy(_share_ai_client=True)
             new_chatprompt.user(additional_vars["__user"])
             prompter = new_chatprompt
             # remove __user from additional_vars
             del additional_vars["__user"]
+        if (
+            track_continuation
+            and prompter is not self
+            and isinstance(getattr(self, "runtime", None), ResponsesWebSocketAdapter)
+            and isinstance(getattr(prompter, "runtime", None), ResponsesWebSocketAdapter)
+            and prompter.runtime.session is not self.runtime.session
+        ):
+            # An internal first-turn copy gets its own request session. Carry
+            # only provider lineage into it so session="new" can continue.
+            for attribute in (
+                "last_response_id",
+                "last_model",
+                "last_store_value",
+            ):
+                setattr(
+                    prompter.runtime.session,
+                    attribute,
+                    getattr(self.runtime.session, attribute, None),
+                )
         prompt = await prompter._build_final_prompt(additional_vars)
         
         kwargs = self._build_completion_request_kwargs()
@@ -634,12 +658,26 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         else:
             # Route completion through the prompter instance so continuation metadata
             # is written to the chat instance that actually owns this submitted prompt.
-            return prompt, await prompter._cleaned_chat_completion(
-                prompt,
-                track_continuation=track_continuation,
-                _call_usage_ledger=_call_usage_ledger,
-                **kwargs,
+            temporary_websocket_runtime = (
+                prompter is not self
+                and isinstance(getattr(prompter, "runtime", None), ResponsesWebSocketAdapter)
             )
+            try:
+                response = await prompter._cleaned_chat_completion(
+                    prompt,
+                    track_continuation=track_continuation,
+                    _call_usage_ledger=_call_usage_ledger,
+                    **kwargs,
+                )
+            except BaseException:
+                if temporary_websocket_runtime:
+                    await prompter.runtime.close_session_a()
+                raise
+            if _submitted_runtime_out is not None:
+                _submitted_runtime_out.append(getattr(prompter, "runtime", None))
+            if temporary_websocket_runtime and not track_continuation:
+                await prompter.runtime.close_session_a()
+            return prompt, response
 
     def _runtime_supports_continuation(self) -> bool:
         runtime = getattr(self, "runtime", None)
@@ -1014,19 +1052,36 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         if self.stream:
             raise Exception("Cannot use chat() with a stream")
         
+        submitted_runtime = []
         prompt, response = await self._submit_for_response_and_prompt(
             track_continuation=True,
             _call_usage_ledger=_call_usage_ledger,
+            _submitted_runtime_out=submitted_runtime,
             **additional_vars,
+        )
+        response_runtime = (
+            submitted_runtime[0]
+            if submitted_runtime
+            else getattr(self, "runtime", None)
         )
         
         # create a new chatprompt with the new name, copy it from this one
         new_chatprompt = self.__class__(
             params=getattr(self, "params", None),
-            runtime=getattr(self, "runtime", None),
+            runtime=response_runtime,
+            _ai_client=getattr(self, "ai", None),
             tool_search_handler=getattr(self, "tool_search_handler", None),
             _runtime_bindings=getattr(self, "_runtime_bindings", None),
         )
+        if (
+            isinstance(response_runtime, ResponsesWebSocketAdapter)
+            and response_runtime.session.mode == "new"
+            and isinstance(new_chatprompt.runtime, ResponsesWebSocketAdapter)
+            and new_chatprompt.runtime.session is not response_runtime.session
+        ):
+            # session="new" intentionally gives the returned Chat a fresh
+            # connection. The temporary request session is no longer owned.
+            await response_runtime.close_session_a()
 
         logger.trace("Expanded prompt: " + prompt)
         new_chatprompt.add_messages_json(prompt)
@@ -1111,7 +1166,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
                     if max_auto_feed_cycles > 0:
                         # Use _submit_for_response_and_prompt for the follow-up call
                         # Since we want to use the current conversation as context, we create a temporary chat object
-                        temp_chat = current_chat.copy()
+                        temp_chat = current_chat.copy(_share_ai_client=True)
                         current_chat._clone_runtime_metadata_to(temp_chat)
                         new_prompt = json.dumps(temp_chat.get_messages()) 
                         logger.trace(f"Temp chat messagesx: {temp_chat.get_messages()}")
@@ -1176,7 +1231,15 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
             return new_chatprompt
 
     # clone function to create a new chatprompt with the same name and data
-    def copy(self, name: str = None, system = None, expand_includes: bool = False, expand_fillings: bool = False, **additional_vars) -> object:
+    def copy(
+        self,
+        name: str = None,
+        system=None,
+        expand_includes: bool = False,
+        expand_fillings: bool = False,
+        _share_ai_client: bool = False,
+        **additional_vars,
+    ) -> object:
         """ Returns a new ChatPrompt object that is a copy of this one, optionally with a new name ⭐"""
         import copy
         copied_params = copy.copy(self.params)
@@ -1209,6 +1272,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
                 name=name,
                 params=copied_params,
                 runtime=copied_runtime,
+                _ai_client=self._ai_client_for_copy(share=_share_ai_client),
                 runtime_selector=copied_runtime_selector,
                 session=copied_session,
                 tool_search_handler=getattr(self, "tool_search_handler", None),
@@ -1228,6 +1292,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
                 name=name + f"_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}-{uuid.uuid4()}",
                 params=copied_params,
                 runtime=copied_runtime,
+                _ai_client=self._ai_client_for_copy(share=_share_ai_client),
                 runtime_selector=copied_runtime_selector,
                 session=copied_session,
                 tool_search_handler=getattr(self, "tool_search_handler", None),

--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import json
 import uuid
 import warnings
@@ -1012,6 +1013,21 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
             response.event_schema = event_schema
             await response.start_a()
         return response
+
+    def _inherit_authored_runtime_override(self, child) -> None:
+        """Preserve runtime intent without promoting an internal adapter to authoring."""
+        source_overrides = getattr(
+            self,
+            "_chatsnack_constructor_overrides",
+            {},
+        )
+        if "runtime" in source_overrides:
+            child._chatsnack_constructor_overrides["runtime"] = (
+                source_overrides["runtime"]
+            )
+        else:
+            child._chatsnack_constructor_overrides.pop("runtime", None)
+
     def chat(self, usermsg=None, files=None, images=None, **additional_vars) -> object:
         """ 
         Executes the query as-is and returns a new Chat for continuation 
@@ -1067,25 +1083,13 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         
         # create a new chatprompt with the new name, copy it from this one
         new_chatprompt = self.__class__(
-            params=getattr(self, "params", None),
+            params=copy.copy(getattr(self, "params", None)),
             runtime=response_runtime,
             _ai_client=getattr(self, "ai", None),
             tool_search_handler=getattr(self, "tool_search_handler", None),
             _runtime_bindings=getattr(self, "_runtime_bindings", None),
         )
-        source_runtime_overrides = getattr(
-            self,
-            "_chatsnack_constructor_overrides",
-            {},
-        )
-        if "runtime" in source_runtime_overrides:
-            new_chatprompt._chatsnack_constructor_overrides["runtime"] = (
-                source_runtime_overrides["runtime"]
-            )
-        else:
-            # The runtime that submitted this turn preserves request ownership;
-            # it is not a new caller-authored transport override on the child.
-            new_chatprompt._chatsnack_constructor_overrides.pop("runtime", None)
+        self._inherit_authored_runtime_override(new_chatprompt)
         if (
             isinstance(response_runtime, ResponsesWebSocketAdapter)
             and response_runtime.session.mode == "new"
@@ -1254,7 +1258,6 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         **additional_vars,
     ) -> object:
         """ Returns a new ChatPrompt object that is a copy of this one, optionally with a new name ⭐"""
-        import copy
         copied_params = copy.copy(self.params)
         copied_runtime = getattr(self, "runtime", None)
         copied_runtime_selector = None
@@ -1311,6 +1314,8 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
                 tool_search_handler=getattr(self, "tool_search_handler", None),
                 _runtime_bindings=getattr(self, "_runtime_bindings", None),
             )
+
+        self._inherit_authored_runtime_override(new_chat)
 
         # Keep the established local-utensil copy behavior. Caller-executed
         # services retain identity through the separate runtime binding map.

--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -1073,6 +1073,19 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
             tool_search_handler=getattr(self, "tool_search_handler", None),
             _runtime_bindings=getattr(self, "_runtime_bindings", None),
         )
+        source_runtime_overrides = getattr(
+            self,
+            "_chatsnack_constructor_overrides",
+            {},
+        )
+        if "runtime" in source_runtime_overrides:
+            new_chatprompt._chatsnack_constructor_overrides["runtime"] = (
+                source_runtime_overrides["runtime"]
+            )
+        else:
+            # The runtime that submitted this turn preserves request ownership;
+            # it is not a new caller-authored transport override on the child.
+            new_chatprompt._chatsnack_constructor_overrides.pop("runtime", None)
         if (
             isinstance(response_runtime, ResponsesWebSocketAdapter)
             and response_runtime.session.mode == "new"

--- a/chatsnack/runtime/chat_completions_adapter.py
+++ b/chatsnack/runtime/chat_completions_adapter.py
@@ -28,6 +28,14 @@ class ChatCompletionsAdapter:
         "prompt_cache_retention",
         "input",
     })
+    _CLIENT_ONLY_KEYS = frozenset({
+        "base_url",
+        "api_key_env",
+        "api_base",
+        "api_type",
+        "api_version",
+        "deployment",
+    })
 
     def __init__(self, ai_client):
         self.ai_client = ai_client
@@ -35,7 +43,11 @@ class ChatCompletionsAdapter:
     @classmethod
     def _strip_responses_keys(cls, kwargs: Dict[str, Any]) -> Dict[str, Any]:
         """Remove Responses-only keys so they never reach the CC SDK call."""
-        cleaned = {k: v for k, v in kwargs.items() if k not in cls._RESPONSES_ONLY_KEYS}
+        stripped = cls._RESPONSES_ONLY_KEYS | cls._CLIENT_ONLY_KEYS
+        cleaned = {k: v for k, v in kwargs.items() if k not in stripped}
+        if "max_tokens" in cleaned:
+            cleaned.setdefault("max_completion_tokens", cleaned["max_tokens"])
+            cleaned.pop("max_tokens", None)
         # Flatten namespace tools — CC only accepts type="function".
         if "tools" in cleaned and isinstance(cleaned["tools"], list):
             cleaned["tools"] = cls._flatten_namespace_tools(cleaned["tools"])

--- a/chatsnack/runtime/responses_adapter.py
+++ b/chatsnack/runtime/responses_adapter.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import Any, Dict, List
 
 from .attachment_resolver import AttachmentResolver
@@ -23,72 +24,323 @@ class ResponsesAdapter(ResponsesNormalizationMixin):
         endpoint = f"{client_name}.responses.create"
         raise RuntimeError(
             "ResponsesAdapter requires an ai_client exposing "
-            f"`{endpoint}`. Inject a compatible OpenAI client (openai>=2.29.0) "
+            f"`{endpoint}`. Inject a compatible OpenAI client (openai>=3.5.0) "
             "or select the chat_completions runtime."
         )
+
+    @staticmethod
+    def _prepare_sdk_create_kwargs(create, request_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """Route provider extensions through the SDK's ``extra_body`` escape hatch."""
+        try:
+            parameters = inspect.signature(create).parameters
+        except (TypeError, ValueError):
+            return request_kwargs
+        if any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters.values()
+        ):
+            return request_kwargs
+
+        prepared = dict(request_kwargs)
+        extensions = dict(prepared.get("extra_body") or {})
+        for key in list(prepared):
+            if key not in parameters:
+                extensions[key] = prepared.pop(key)
+        if extensions:
+            prepared["extra_body"] = extensions
+        return prepared
 
     def create_completion(self, messages: List[Dict[str, Any]], **kwargs: Any):
         resolved = self.attachment_resolver.resolve_messages(messages)
         request_kwargs = self.build_responses_request(resolved, kwargs)
         self._debug_responses_payload("Responses HTTP create payload", request_kwargs)
-        response = self._get_responses_create(async_mode=False)(**request_kwargs)
+        create = self._get_responses_create(async_mode=False)
+        response = create(**self._prepare_sdk_create_kwargs(create, request_kwargs))
         return self.normalize_completion(response, request_kwargs)
 
     async def create_completion_a(self, messages: List[Dict[str, Any]], **kwargs: Any):
         resolved = await self.attachment_resolver.resolve_messages_async(messages)
         request_kwargs = self.build_responses_request(resolved, kwargs)
         self._debug_responses_payload("Responses HTTP create payload", request_kwargs)
-        response = await self._get_responses_create(async_mode=True)(**request_kwargs)
+        create = self._get_responses_create(async_mode=True)
+        response = await create(**self._prepare_sdk_create_kwargs(create, request_kwargs))
         return self.normalize_completion(response, request_kwargs)
 
-    def stream_completion(self, messages: List[Dict[str, Any]], **kwargs: Any):
-        index = 0
-        try:
-            result = self.create_completion(messages, **kwargs)
-            text = result.message.content or ""
-            if text:
-                yield RuntimeStreamEvent(type="text_delta", index=index, data={"text": text})
+    @staticmethod
+    def _event_type(event: Any) -> str:
+        if isinstance(event, dict):
+            return str(event.get("type") or "")
+        direct = getattr(event, "type", "")
+        if direct:
+            return str(direct)
+        if hasattr(event, "model_dump"):
+            return str((event.model_dump() or {}).get("type") or "")
+        return ""
+
+    def _stream_event_data(self, event: Any) -> Dict[str, Any]:
+        return self._to_dict(event)
+
+    @staticmethod
+    def _stream_error_message(event_data: Dict[str, Any]) -> str:
+        error = event_data.get("error") or {}
+        if not isinstance(error, dict):
+            error = ResponsesAdapter._to_dict(error)
+        response = event_data.get("response") or {}
+        if not isinstance(response, dict):
+            response = ResponsesAdapter._to_dict(response)
+        response_error = response.get("error") or response.get("incomplete_details") or {}
+        if not isinstance(response_error, dict):
+            response_error = ResponsesAdapter._to_dict(response_error)
+        return (
+            event_data.get("message")
+            or error.get("message")
+            or response_error.get("message")
+            or response_error.get("reason")
+            or "Responses stream failed"
+        )
+
+    def _normalize_stream_event(
+        self,
+        sdk_event: Any,
+        *,
+        index: int,
+        request_kwargs: Dict[str, Any],
+        full_text: str,
+        tool_call_state: Dict[str, Dict[str, Any]],
+    ):
+        """Normalize one SDK SSE event and return events plus terminal state."""
+        event_type = self._event_type(sdk_event)
+        event_data = self._stream_event_data(sdk_event)
+        events = []
+        completed = False
+        failed = False
+
+        if event_type in {
+            "response.output_text.delta",
+            "response.content_part.delta",
+        }:
+            part = self._to_dict(event_data.get("part") or {})
+            delta = event_data.get("delta") or part.get("text") or ""
+            if delta:
+                full_text += str(delta)
+                events.append(
+                    RuntimeStreamEvent(type="text_delta", index=index, data={"text": str(delta)})
+                )
                 index += 1
-            for tool_call in result.message.tool_calls:
-                yield RuntimeStreamEvent(type="tool_call_delta", index=index, data={"tool_call": tool_call.__dict__})
+        elif event_type == "response.output_item.added":
+            item = self._to_dict(event_data.get("item") or {})
+            if item.get("type") == "function_call":
+                item_id = item.get("id") or event_data.get("item_id") or ""
+                tool_call_state[item_id] = {
+                    "call_id": item.get("call_id") or "",
+                    "name": item.get("name") or "",
+                    "arguments": item.get("arguments") or "",
+                    "emitted": False,
+                }
+        elif event_type == "response.function_call_arguments.delta":
+            item_id = event_data.get("item_id") or event_data.get("call_id") or ""
+            state = tool_call_state.setdefault(
+                item_id,
+                {"call_id": "", "name": "", "arguments": "", "emitted": False},
+            )
+            state["call_id"] = state["call_id"] or event_data.get("call_id") or ""
+            state["name"] = state["name"] or event_data.get("name") or ""
+            delta = event_data.get("delta") or ""
+            state["arguments"] += delta
+            if state["call_id"] and delta:
+                events.append(
+                    RuntimeStreamEvent(
+                        type="tool_call_delta",
+                        index=index,
+                        data={
+                            "tool_call": {
+                                "id": state["call_id"],
+                                "type": "function",
+                                "function": {
+                                    "name": state["name"],
+                                    "arguments": delta,
+                                },
+                            }
+                        },
+                    )
+                )
+                state["emitted"] = True
                 index += 1
-            if result.usage:
-                yield RuntimeStreamEvent(type="usage", index=index, data={"usage": result.usage})
+        elif event_type == "response.output_item.done":
+            item = self._to_dict(event_data.get("item") or {})
+            if item.get("type") == "function_call":
+                item_id = item.get("id") or event_data.get("item_id") or ""
+                state = tool_call_state.pop(item_id, None)
+                if not state or not state.get("emitted"):
+                    events.append(
+                        RuntimeStreamEvent(
+                            type="tool_call_delta",
+                            index=index,
+                            data={
+                                "tool_call": {
+                                    "id": item.get("call_id") or item_id,
+                                    "type": "function",
+                                    "function": {
+                                        "name": item.get("name")
+                                        or (state or {}).get("name")
+                                        or "",
+                                        "arguments": item.get("arguments")
+                                        or (state or {}).get("arguments")
+                                        or "",
+                                    },
+                                }
+                            },
+                        )
+                    )
+                    index += 1
+        elif event_type in {
+            "response.completed",
+            "response.done",
+            "response.incomplete",
+        }:
+            response = event_data.get("response")
+            normalized = self.normalize_completion(response, request_kwargs)
+            if not full_text and normalized.message.content:
+                full_text = normalized.message.content
+                events.append(
+                    RuntimeStreamEvent(
+                        type="text_delta",
+                        index=index,
+                        data={"text": full_text},
+                    )
+                )
+                index += 1
+            if normalized.usage:
+                events.append(
+                    RuntimeStreamEvent(
+                        type="usage",
+                        index=index,
+                        data={"usage": normalized.usage},
+                    )
+                )
                 index += 1
             terminal = RuntimeTerminalMetadata(
-                finish_reason=result.finish_reason,
-                model=result.model,
-                usage=result.usage,
-                response_text=text,
-                metadata=result.metadata,
+                finish_reason=normalized.finish_reason,
+                model=normalized.model,
+                usage=normalized.usage,
+                response_text=full_text,
+                metadata=normalized.metadata,
             )
-            yield RuntimeStreamEvent(type="completed", index=index, data={"terminal": terminal.__dict__})
+            events.append(
+                RuntimeStreamEvent(
+                    type="completed",
+                    index=index,
+                    data={"terminal": terminal.__dict__},
+                )
+            )
+            index += 1
+            completed = True
+        elif event_type in {
+            "error",
+            "response.error",
+            "response.failed",
+        }:
+            payload = RuntimeErrorPayload(message=self._stream_error_message(event_data))
+            events.append(
+                RuntimeStreamEvent(type="error", index=index, data={"error": payload.__dict__})
+            )
+            index += 1
+            failed = True
+
+        return events, index, full_text, completed, failed
+
+    def stream_completion(self, messages: List[Dict[str, Any]], **kwargs: Any):
+        resolved = self.attachment_resolver.resolve_messages(messages)
+        request_kwargs = self.build_responses_request(resolved, kwargs)
+        request_kwargs["stream"] = True
+        self._debug_responses_payload("Responses HTTP SSE create payload", request_kwargs)
+        stream = None
+        index = 0
+        full_text = ""
+        terminal_seen = False
+        tool_call_state: Dict[str, Dict[str, Any]] = {}
+        try:
+            create = self._get_responses_create(async_mode=False)
+            stream = create(**self._prepare_sdk_create_kwargs(create, request_kwargs))
+            for sdk_event in stream:
+                if terminal_seen:
+                    continue
+                events, index, full_text, completed, failed = self._normalize_stream_event(
+                    sdk_event,
+                    index=index,
+                    request_kwargs=request_kwargs,
+                    full_text=full_text,
+                    tool_call_state=tool_call_state,
+                )
+                yield from events
+                if completed or failed:
+                    terminal_seen = True
+                    break
+            if not terminal_seen:
+                payload = RuntimeErrorPayload(message="Responses stream ended before a terminal event.")
+                yield RuntimeStreamEvent(type="error", index=index, data={"error": payload.__dict__})
         except Exception as exc:
             payload = RuntimeErrorPayload(message=str(exc))
             yield RuntimeStreamEvent(type="error", index=index, data={"error": payload.__dict__})
+        finally:
+            close = getattr(stream, "close", None)
+            if callable(close):
+                close()
 
     async def stream_completion_a(self, messages: List[Dict[str, Any]], **kwargs: Any):
+        resolved = await self.attachment_resolver.resolve_messages_async(messages)
+        request_kwargs = self.build_responses_request(resolved, kwargs)
+        request_kwargs["stream"] = True
+        self._debug_responses_payload("Responses HTTP SSE create payload", request_kwargs)
+        stream = None
+        stream_iterator = None
         index = 0
+        full_text = ""
+        terminal_seen = False
+        tool_call_state: Dict[str, Dict[str, Any]] = {}
         try:
-            result = await self.create_completion_a(messages, **kwargs)
-            text = result.message.content or ""
-            if text:
-                yield RuntimeStreamEvent(type="text_delta", index=index, data={"text": text})
-                index += 1
-            for tool_call in result.message.tool_calls:
-                yield RuntimeStreamEvent(type="tool_call_delta", index=index, data={"tool_call": tool_call.__dict__})
-                index += 1
-            if result.usage:
-                yield RuntimeStreamEvent(type="usage", index=index, data={"usage": result.usage})
-                index += 1
-            terminal = RuntimeTerminalMetadata(
-                finish_reason=result.finish_reason,
-                model=result.model,
-                usage=result.usage,
-                response_text=text,
-                metadata=result.metadata,
-            )
-            yield RuntimeStreamEvent(type="completed", index=index, data={"terminal": terminal.__dict__})
+            create = self._get_responses_create(async_mode=True)
+            stream = await create(**self._prepare_sdk_create_kwargs(create, request_kwargs))
+            stream_iterator = stream.__aiter__()
+            async for sdk_event in stream_iterator:
+                if terminal_seen:
+                    continue
+                events, index, full_text, completed, failed = self._normalize_stream_event(
+                    sdk_event,
+                    index=index,
+                    request_kwargs=request_kwargs,
+                    full_text=full_text,
+                    tool_call_state=tool_call_state,
+                )
+                for event in events:
+                    yield event
+                if completed or failed:
+                    terminal_seen = True
+                    break
+            if not terminal_seen:
+                payload = RuntimeErrorPayload(message="Responses stream ended before a terminal event.")
+                yield RuntimeStreamEvent(type="error", index=index, data={"error": payload.__dict__})
         except Exception as exc:
             payload = RuntimeErrorPayload(message=str(exc))
             yield RuntimeStreamEvent(type="error", index=index, data={"error": payload.__dict__})
+        finally:
+            closed_iterators = set()
+            for iterator in (stream_iterator, getattr(stream, "_iterator", None)):
+                if iterator is None or id(iterator) in closed_iterators:
+                    continue
+                closed_iterators.add(id(iterator))
+                close_iterator = getattr(iterator, "aclose", None)
+                if callable(close_iterator):
+                    try:
+                        await close_iterator()
+                    except Exception:
+                        pass
+            aclose = getattr(stream, "aclose", None)
+            if callable(aclose):
+                await aclose()
+            else:
+                close = getattr(stream, "close", None)
+                if callable(close):
+                    result = close()
+                    if inspect.isawaitable(result):
+                        await result

--- a/chatsnack/runtime/responses_common.py
+++ b/chatsnack/runtime/responses_common.py
@@ -21,6 +21,16 @@ class ResponsesNormalizationMixin:
 
     runtime_family = "responses"
     _RESPONSES_DEBUG_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+    _CLIENT_ONLY_KEYS = frozenset(
+        {
+            "base_url",
+            "api_key_env",
+            "api_base",
+            "api_type",
+            "api_version",
+            "deployment",
+        }
+    )
 
     @staticmethod
     def _to_dict(obj: Any) -> Dict[str, Any]:
@@ -158,14 +168,17 @@ class ResponsesNormalizationMixin:
                     items.append(item)
                     continue
                 function = self._to_dict(tool_call.get("function") or {})
-                items.append(
-                    {
-                        "type": "function_call",
-                        "call_id": tool_call.get("id", ""),
-                        "name": function.get("name", ""),
-                        "arguments": function.get("arguments", ""),
-                    }
-                )
+                item = {
+                    "type": "function_call",
+                    "call_id": tool_call.get("id", ""),
+                    "name": function.get("name", ""),
+                    "arguments": function.get("arguments", ""),
+                }
+                if tool_call.get("item_id"):
+                    item["id"] = tool_call["item_id"]
+                if tool_call.get("status"):
+                    item["status"] = tool_call["status"]
+                items.append(item)
             return items
 
         if role not in {"system", "developer", "user", "assistant"}:
@@ -368,6 +381,10 @@ class ResponsesNormalizationMixin:
 
     def build_responses_request(self, messages: List[Dict[str, Any]], kwargs: Dict[str, Any]) -> Dict[str, Any]:
         options = self._apply_profile_defaults(kwargs)
+        for key in self._CLIENT_ONLY_KEYS:
+            options.pop(key, None)
+        if "max_tokens" in options:
+            options.setdefault("max_output_tokens", options.pop("max_tokens"))
         input_messages = messages
         if options.get("previous_response_id"):
             input_messages = self._select_continuation_messages(messages)
@@ -457,6 +474,8 @@ class ResponsesNormalizationMixin:
                 tool_calls.append(
                     NormalizedToolCall(
                         id=item_dict.get("call_id", ""),
+                        item_id=item_dict.get("id"),
+                        status=item_dict.get("status"),
                         type="function",
                         function=NormalizedToolFunction(
                             name=item_dict.get("name", ""),

--- a/chatsnack/runtime/responses_websocket_adapter.py
+++ b/chatsnack/runtime/responses_websocket_adapter.py
@@ -13,7 +13,7 @@ from .types import RuntimeErrorPayload, RuntimeStreamEvent, RuntimeTerminalMetad
 
 # Minimum SDK version string for clear error messages.
 _SDK_VERSION_GUIDANCE = (
-    "Responses WebSocket mode requires openai>=2.29.0 with websocket support. "
+    "Responses WebSocket mode requires openai>=3.5.0 with websocket support. "
     "Upgrade OpenAI or install openai[realtime]."
 )
 

--- a/chatsnack/yamlformat.py
+++ b/chatsnack/yamlformat.py
@@ -35,6 +35,7 @@ from .compact_tools import parse_tools_authoring, serialize_tools_authoring, spl
 
 
 _ASSET_REFERENCE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_URL_REFERENCE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*://\S+$")
 
 
 # ── Phase 3 helpers ────────────────────────────────────────────────────
@@ -230,11 +231,23 @@ def _normalize_data_on_load(data):
     if not isinstance(data, dict):
         return data
 
+    params = data.get("params")
+    if isinstance(params, dict):
+        legacy_client_fields = sorted(
+            {"api_base", "api_type", "api_version", "deployment"}.intersection(params)
+        )
+        if legacy_client_fields:
+            names = ", ".join(legacy_client_fields)
+            raise ValueError(
+                "Legacy Chat client fields are no longer supported: "
+                f"{names}. Use a complete base_url plus api_key_env; for Azure v1, "
+                "put the deployment name in model."
+            )
+
     messages = data.get("messages")
     if isinstance(messages, list):
         data["messages"] = [_normalize_message_on_load(m) for m in messages]
 
-    params = data.get("params")
     if isinstance(params, dict) and "auto_feed" in params:
         # Validate the authored scalar before snapclass can coerce a float or
         # string into one of the bool/int union members.
@@ -358,6 +371,8 @@ class YAML(formatters.FileFormatter):
         def represent_plain_str(dumper, data):
             if _ASSET_REFERENCE.fullmatch(data):
                 return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="'")
+            if _URL_REFERENCE.fullmatch(data):
+                return dumper.represent_scalar("tag:yaml.org,2002:str", data, style='')
             if "\n" in data or "\r" in data or "#" in data or ":" in data or "'" in data or '"' in data:
                 return dumper.represent_scalar("tag:yaml.org,2002:str", data, style='|')
             return dumper.represent_scalar("tag:yaml.org,2002:str", data, style='')

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -1,0 +1,93 @@
+# OpenAI-compatible Providers
+
+A saved `Chat` can name its OpenAI-compatible endpoint and the environment
+variable that holds its key. The saved YAML contains only the environment
+variable name, so the key value stays out of the file.
+
+## Use OpenRouter with a saved Chat
+
+Save this as `datafiles/chatsnack/OpenRouterSnack.yml`, or place it under the
+directory named by `CHATSNACK_BASE_DIR`:
+
+```yaml
+params:
+  model: z-ai/glm-5.3-flash
+  base_url: https://openrouter.ai/api/v1
+  api_key_env: OPENROUTER_API_KEY
+messages:
+  - system: Answer tersely and recommend excellent snacks.
+```
+
+Load it and use it like any other named Chat:
+
+```python
+from chatsnack import Chat
+
+openrouter = Chat(name="OpenRouterSnack")
+print(openrouter.ask("Name one movie-night snack."))
+
+thread = openrouter.chat("Name one salty snack.")
+thread = thread.chat("What drink pairs with it?")
+print(thread.last)
+```
+
+`base_url` and `api_key_env` belong together. `api_key_env` names a nonblank
+environment variable; its value is never written to the Chat YAML.
+
+## Configure a dynamic Chat
+
+Applications that construct Chats dynamically can use the same fields directly:
+
+```python
+from chatsnack import Chat
+
+openrouter = Chat(
+    "Answer tersely and recommend excellent snacks.",
+    model="z-ai/glm-5.3-flash",
+    base_url="https://openrouter.ai/api/v1",
+    api_key_env="OPENROUTER_API_KEY",
+)
+```
+
+## Use Azure v1
+
+Azure v1 uses the same saved-Chat shape. Give it the complete `/openai/v1/`
+base URL and put the Azure deployment name in `model`:
+
+```yaml
+params:
+  model: my-deployment
+  base_url: https://my-resource.openai.azure.com/openai/v1/
+  api_key_env: AZURE_OPENAI_API_KEY
+messages:
+  - system: Answer tersely.
+```
+
+This path uses a static API key. Microsoft Entra authentication is outside the
+current built-in provider configuration.
+
+## Understand transport and client binding
+
+Custom endpoints use Responses HTTP, including SSE streaming, unless a runtime
+is selected explicitly. Chats without `base_url` and `api_key_env` keep the
+standard `OPENAI_API_KEY` / `OPENAI_BASE_URL` SDK behavior and Chatsnack's
+Responses WebSocket default.
+
+Client settings are bound when a Chat is created or first loaded. Continued and
+copied Chats keep that binding, and `reset()` does not re-read the credential
+environment variable. Create a new Chat to use a different endpoint, credential,
+or transport.
+
+## Migrate legacy Azure configuration
+
+Legacy Azure fields (`api_base`, `api_type`, `api_version`, and `deployment`) are
+no longer accepted. Replace them with:
+
+- `base_url` for the complete Azure v1 endpoint
+- `api_key_env` for the name of the credential environment variable
+- `model` for the Azure deployment name
+
+The legacy endpoint variables `OPENAI_AZURE_ENDPOINT` and `OPENAI_API_BASE`
+raise a migration error when no new endpoint is authored. Use per-Chat
+`base_url` and `api_key_env`, or use the SDK-standard `OPENAI_BASE_URL` for
+ordinary environment-wide configuration.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
   - Guides:
       - guides/chat-basics.md
       - guides/yaml-and-assets.md
+      - OpenAI-compatible providers: guides/providers.md
       - guides/fillings.md
       - guides/utensils.md
   - Examples:

--- a/notebooks/GettingStartedWithChatsnack.ipynb
+++ b/notebooks/GettingStartedWithChatsnack.ipynb
@@ -659,7 +659,7 @@
     "## Phase 2: Responses WebSocket sessions\n",
     "\n",
     "When you pass `session=\"inherit\"` (or `session=\"new\"`), chatsnack upgrades from HTTP Responses to a persistent WebSocket\n",
-    "backed by the official OpenAI SDK (`client.responses.connect()` / `openai>=2.29.0`).\n",
+    "backed by the official OpenAI SDK (`client.responses.connect()` / `openai>=3.5.0`).\n",
     "The session stays open across `chat()` continuations, so follow-ups are faster and the server remembers context.\n"
    ]
   },
@@ -1057,6 +1057,42 @@
     "    auto_feed=8,\n",
     ")\n",
     "print(deep_research.yaml)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### OpenRouter and Azure v1\n",
+    "\n",
+    "A Chat can carry its own endpoint and API-key environment-variable name. Custom endpoints use Responses HTTP by default, while the secret itself stays out of YAML. That client binding follows copied and continued Chats; create a new Chat to change providers, credentials, or transport.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if os.getenv(\"OPENROUTER_API_KEY\"):\n",
+    "    openrouter = Chat(\n",
+    "        \"Answer tersely.\",\n",
+    "        model=\"openai/gpt-oss-20b\",\n",
+    "        base_url=\"https://openrouter.ai/api/v1\",\n",
+    "        api_key_env=\"OPENROUTER_API_KEY\",\n",
+    "    )\n",
+    "    print(openrouter.yaml)\n",
+    "\n",
+    "if os.getenv(\"AZURE_OPENAI_API_KEY\"):\n",
+    "    azure = Chat(\n",
+    "        \"Answer tersely.\",\n",
+    "        model=\"my-deployment\",\n",
+    "        base_url=\"https://my-resource.openai.azure.com/openai/v1/\",\n",
+    "        api_key_env=\"AZURE_OPENAI_API_KEY\",\n",
+    "    )\n",
+    "    print(azure.yaml)\n"
    ]
   }
  ],

--- a/poetry.lock
+++ b/poetry.lock
@@ -45,18 +45,6 @@ files = [
 ]
 
 [[package]]
-name = "certifi"
-version = "2026.2.25"
-description = "Python package for providing Mozilla's CA Bundle."
-optional = false
-python-versions = ">=3.7"
-groups = ["main"]
-files = [
-    {file = "certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa"},
-    {file = "certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7"},
-]
-
-[[package]]
 name = "click"
 version = "8.3.1"
 description = "Composable command line interface toolkit"
@@ -83,19 +71,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
-
-[[package]]
-name = "distro"
-version = "1.9.0"
-description = "Distro - an OS platform information API"
-optional = false
-python-versions = ">=3.6"
-groups = ["main"]
-files = [
-    {file = "distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"},
-    {file = "distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed"},
-]
+markers = {main = "(extra == \"flask\" or extra == \"examples\") and platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "flask"
@@ -129,57 +105,75 @@ description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "sys_platform != \"emscripten\""
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
 ]
 
 [[package]]
-name = "httpcore"
-version = "1.0.9"
+name = "httpcore2"
+version = "2.12.0"
 description = "A minimal low-level HTTP client."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
+markers = "sys_platform != \"emscripten\""
 files = [
-    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
-    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
+    {file = "httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb"},
+    {file = "httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648"},
 ]
 
 [package.dependencies]
-certifi = "*"
 h11 = ">=0.16"
+truststore = ">=0.10"
 
 [package.extras]
-asyncio = ["anyio (>=4.0,<5.0)"]
+asyncio = ["anyio (>=4.5.0,<5.0)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
-trio = ["trio (>=0.22.0,<1.0)"]
+trio = ["trio (>=0.33.0,<1.0)"]
 
 [[package]]
-name = "httpx"
-version = "0.28.1"
+name = "httpx2"
+version = "2.12.0"
 description = "The next generation HTTP client."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
-    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+    {file = "httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36"},
+    {file = "httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf"},
 ]
 
 [package.dependencies]
-anyio = "*"
-certifi = "*"
-httpcore = "==1.*"
-idna = "*"
+anyio = {version = ">=4.10", markers = "sys_platform != \"emscripten\""}
+httpcore2 = {version = "2.12.0", markers = "sys_platform != \"emscripten\""}
+httpx2-jsfetch = {version = "*", markers = "sys_platform == \"emscripten\" and python_version >= \"3.12\""}
+idna = ">=3.18"
+truststore = {version = ">=0.10", markers = "sys_platform != \"emscripten\""}
+typing-extensions = {version = ">=4.5.0", markers = "python_version < \"3.13\""}
 
 [package.extras]
-brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
-cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
+cli = ["click (>=8.4.2)", "pygments (==2.*)", "rich (>=10,<16)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
-zstd = ["zstandard (>=0.18.0)"]
+ws = ["wsproto (>=1.2)"]
+zstd = ["backports-zstd (>=1.0.0) ; python_version <= \"3.13\""]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+description = "httpx2 transports for Emscripten/Pyodide, backed by the JavaScript fetch API."
+optional = false
+python-versions = ">=3.12"
+groups = ["main"]
+markers = "sys_platform == \"emscripten\" and python_version >= \"3.12\""
+files = [
+    {file = "httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32"},
+    {file = "httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60"},
+]
 
 [[package]]
 name = "idna"
@@ -242,114 +236,117 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "jiter"
-version = "0.13.0"
+version = "0.16.0"
 description = "Fast iterable JSON parser."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "jiter-0.13.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2ffc63785fd6c7977defe49b9824ae6ce2b2e2b77ce539bdaf006c26da06342e"},
-    {file = "jiter-0.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4a638816427006c1e3f0013eb66d391d7a3acda99a7b0cf091eff4497ccea33a"},
-    {file = "jiter-0.13.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19928b5d1ce0ff8c1ee1b9bdef3b5bfc19e8304f1b904e436caf30bc15dc6cf5"},
-    {file = "jiter-0.13.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:309549b778b949d731a2f0e1594a3f805716be704a73bf3ad9a807eed5eb5721"},
-    {file = "jiter-0.13.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bcdabaea26cb04e25df3103ce47f97466627999260290349a88c8136ecae0060"},
-    {file = "jiter-0.13.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a377af27b236abbf665a69b2bdd680e3b5a0bd2af825cd3b81245279a7606c"},
-    {file = "jiter-0.13.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe49d3ff6db74321f144dff9addd4a5874d3105ac5ba7c5b77fac099cfae31ae"},
-    {file = "jiter-0.13.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2113c17c9a67071b0f820733c0893ed1d467b5fcf4414068169e5c2cabddb1e2"},
-    {file = "jiter-0.13.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:ab1185ca5c8b9491b55ebf6c1e8866b8f68258612899693e24a92c5fdb9455d5"},
-    {file = "jiter-0.13.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:9621ca242547edc16400981ca3231e0c91c0c4c1ab8573a596cd9bb3575d5c2b"},
-    {file = "jiter-0.13.0-cp310-cp310-win32.whl", hash = "sha256:a7637d92b1c9d7a771e8c56f445c7f84396d48f2e756e5978840ecba2fac0894"},
-    {file = "jiter-0.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:c1b609e5cbd2f52bb74fb721515745b407df26d7b800458bd97cb3b972c29e7d"},
-    {file = "jiter-0.13.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ea026e70a9a28ebbdddcbcf0f1323128a8db66898a06eaad3a4e62d2f554d096"},
-    {file = "jiter-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:66aa3e663840152d18cc8ff1e4faad3dd181373491b9cfdc6004b92198d67911"},
-    {file = "jiter-0.13.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3524798e70655ff19aec58c7d05adb1f074fecff62da857ea9be2b908b6d701"},
-    {file = "jiter-0.13.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ec7e287d7fbd02cb6e22f9a00dd9c9cd504c40a61f2c61e7e1f9690a82726b4c"},
-    {file = "jiter-0.13.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:47455245307e4debf2ce6c6e65a717550a0244231240dcf3b8f7d64e4c2f22f4"},
-    {file = "jiter-0.13.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ee9da221dca6e0429c2704c1b3655fe7b025204a71d4d9b73390c759d776d165"},
-    {file = "jiter-0.13.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24ab43126d5e05f3d53a36a8e11eb2f23304c6c1117844aaaf9a0aa5e40b5018"},
-    {file = "jiter-0.13.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9da38b4fedde4fb528c740c2564628fbab737166a0e73d6d46cb4bb5463ff411"},
-    {file = "jiter-0.13.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0b34c519e17658ed88d5047999a93547f8889f3c1824120c26ad6be5f27b6cf5"},
-    {file = "jiter-0.13.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d2a6394e6af690d462310a86b53c47ad75ac8c21dc79f120714ea449979cb1d3"},
-    {file = "jiter-0.13.0-cp311-cp311-win32.whl", hash = "sha256:0f0c065695f616a27c920a56ad0d4fc46415ef8b806bf8fc1cacf25002bd24e1"},
-    {file = "jiter-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:0733312953b909688ae3c2d58d043aa040f9f1a6a75693defed7bc2cc4bf2654"},
-    {file = "jiter-0.13.0-cp311-cp311-win_arm64.whl", hash = "sha256:5d9b34ad56761b3bf0fbe8f7e55468704107608512350962d3317ffd7a4382d5"},
-    {file = "jiter-0.13.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0a2bd69fc1d902e89925fc34d1da51b2128019423d7b339a45d9e99c894e0663"},
-    {file = "jiter-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f917a04240ef31898182f76a332f508f2cc4b57d2b4d7ad2dbfebbfe167eb505"},
-    {file = "jiter-0.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1e2b199f446d3e82246b4fd9236d7cb502dc2222b18698ba0d986d2fecc6152"},
-    {file = "jiter-0.13.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04670992b576fa65bd056dbac0c39fe8bd67681c380cb2b48efa885711d9d726"},
-    {file = "jiter-0.13.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a1aff1fbdb803a376d4d22a8f63f8e7ccbce0b4890c26cc7af9e501ab339ef0"},
-    {file = "jiter-0.13.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b3fb8c2053acaef8580809ac1d1f7481a0a0bdc012fd7f5d8b18fb696a5a089"},
-    {file = "jiter-0.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdaba7d87e66f26a2c45d8cbadcbfc4bf7884182317907baf39cfe9775bb4d93"},
-    {file = "jiter-0.13.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7b88d649135aca526da172e48083da915ec086b54e8e73a425ba50999468cc08"},
-    {file = "jiter-0.13.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e404ea551d35438013c64b4f357b0474c7abf9f781c06d44fcaf7a14c69ff9e2"},
-    {file = "jiter-0.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1f4748aad1b4a93c8bdd70f604d0f748cdc0e8744c5547798acfa52f10e79228"},
-    {file = "jiter-0.13.0-cp312-cp312-win32.whl", hash = "sha256:0bf670e3b1445fc4d31612199f1744f67f889ee1bbae703c4b54dc097e5dd394"},
-    {file = "jiter-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:15db60e121e11fe186c0b15236bd5d18381b9ddacdcf4e659feb96fc6c969c92"},
-    {file = "jiter-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:41f92313d17989102f3cb5dd533a02787cdb99454d494344b0361355da52fcb9"},
-    {file = "jiter-0.13.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1f8a55b848cbabf97d861495cd65f1e5c590246fabca8b48e1747c4dfc8f85bf"},
-    {file = "jiter-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f556aa591c00f2c45eb1b89f68f52441a016034d18b65da60e2d2875bbbf344a"},
-    {file = "jiter-0.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7e1d61da332ec412350463891923f960c3073cf1aae93b538f0bb4c8cd46efb"},
-    {file = "jiter-0.13.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3097d665a27bc96fd9bbf7f86178037db139f319f785e4757ce7ccbf390db6c2"},
-    {file = "jiter-0.13.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d01ecc3a8cbdb6f25a37bd500510550b64ddf9f7d64a107d92f3ccb25035d0f"},
-    {file = "jiter-0.13.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ed9bbc30f5d60a3bdf63ae76beb3f9db280d7f195dfcfa61af792d6ce912d159"},
-    {file = "jiter-0.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98fbafb6e88256f4454de33c1f40203d09fc33ed19162a68b3b257b29ca7f663"},
-    {file = "jiter-0.13.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5467696f6b827f1116556cb0db620440380434591e93ecee7fd14d1a491b6daa"},
-    {file = "jiter-0.13.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:2d08c9475d48b92892583df9da592a0e2ac49bcd41fae1fec4f39ba6cf107820"},
-    {file = "jiter-0.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:aed40e099404721d7fcaf5b89bd3b4568a4666358bcac7b6b15c09fb6252ab68"},
-    {file = "jiter-0.13.0-cp313-cp313-win32.whl", hash = "sha256:36ebfbcffafb146d0e6ffb3e74d51e03d9c35ce7c625c8066cdbfc7b953bdc72"},
-    {file = "jiter-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:8d76029f077379374cf0dbc78dbe45b38dec4a2eb78b08b5194ce836b2517afc"},
-    {file = "jiter-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:bb7613e1a427cfcb6ea4544f9ac566b93d5bf67e0d48c787eca673ff9c9dff2b"},
-    {file = "jiter-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa476ab5dd49f3bf3a168e05f89358c75a17608dbabb080ef65f96b27c19ab10"},
-    {file = "jiter-0.13.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ade8cb6ff5632a62b7dbd4757d8c5573f7a2e9ae285d6b5b841707d8363205ef"},
-    {file = "jiter-0.13.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9950290340acc1adaded363edd94baebcee7dabdfa8bee4790794cd5cfad2af6"},
-    {file = "jiter-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2b4972c6df33731aac0742b64fd0d18e0a69bc7d6e03108ce7d40c85fd9e3e6d"},
-    {file = "jiter-0.13.0-cp313-cp313t-win_arm64.whl", hash = "sha256:701a1e77d1e593c1b435315ff625fd071f0998c5f02792038a5ca98899261b7d"},
-    {file = "jiter-0.13.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cc5223ab19fe25e2f0bf2643204ad7318896fe3729bf12fde41b77bfc4fafff0"},
-    {file = "jiter-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9776ebe51713acf438fd9b4405fcd86893ae5d03487546dae7f34993217f8a91"},
-    {file = "jiter-0.13.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:879e768938e7b49b5e90b7e3fecc0dbec01b8cb89595861fb39a8967c5220d09"},
-    {file = "jiter-0.13.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:682161a67adea11e3aae9038c06c8b4a9a71023228767477d683f69903ebc607"},
-    {file = "jiter-0.13.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a13b68cd1cd8cc9de8f244ebae18ccb3e4067ad205220ef324c39181e23bbf66"},
-    {file = "jiter-0.13.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87ce0f14c6c08892b610686ae8be350bf368467b6acd5085a5b65441e2bf36d2"},
-    {file = "jiter-0.13.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c365005b05505a90d1c47856420980d0237adf82f70c4aff7aebd3c1cc143ad"},
-    {file = "jiter-0.13.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1317fdffd16f5873e46ce27d0e0f7f4f90f0cdf1d86bf6abeaea9f63ca2c401d"},
-    {file = "jiter-0.13.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c05b450d37ba0c9e21c77fef1f205f56bcee2330bddca68d344baebfc55ae0df"},
-    {file = "jiter-0.13.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:775e10de3849d0631a97c603f996f518159272db00fdda0a780f81752255ee9d"},
-    {file = "jiter-0.13.0-cp314-cp314-win32.whl", hash = "sha256:632bf7c1d28421c00dd8bbb8a3bac5663e1f57d5cd5ed962bce3c73bf62608e6"},
-    {file = "jiter-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:f22ef501c3f87ede88f23f9b11e608581c14f04db59b6a801f354397ae13739f"},
-    {file = "jiter-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:07b75fe09a4ee8e0c606200622e571e44943f47254f95e2436c8bdcaceb36d7d"},
-    {file = "jiter-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:964538479359059a35fb400e769295d4b315ae61e4105396d355a12f7fef09f0"},
-    {file = "jiter-0.13.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e104da1db1c0991b3eaed391ccd650ae8d947eab1480c733e5a3fb28d4313e40"},
-    {file = "jiter-0.13.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e3a5f0cde8ff433b8e88e41aa40131455420fb3649a3c7abdda6145f8cb7202"},
-    {file = "jiter-0.13.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57aab48f40be1db920a582b30b116fe2435d184f77f0e4226f546794cedd9cf0"},
-    {file = "jiter-0.13.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7772115877c53f62beeb8fd853cab692dbc04374ef623b30f997959a4c0e7e95"},
-    {file = "jiter-0.13.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1211427574b17b633cfceba5040de8081e5abf114f7a7602f73d2e16f9fdaa59"},
-    {file = "jiter-0.13.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7beae3a3d3b5212d3a55d2961db3c292e02e302feb43fce6a3f7a31b90ea6dfe"},
-    {file = "jiter-0.13.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e5562a0f0e90a6223b704163ea28e831bd3a9faa3512a711f031611e6b06c939"},
-    {file = "jiter-0.13.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:6c26a424569a59140fb51160a56df13f438a2b0967365e987889186d5fc2f6f9"},
-    {file = "jiter-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:24dc96eca9f84da4131cdf87a95e6ce36765c3b156fc9ae33280873b1c32d5f6"},
-    {file = "jiter-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0a8d76c7524087272c8ae913f5d9d608bd839154b62c4322ef65723d2e5bb0b8"},
-    {file = "jiter-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2c26cf47e2cad140fa23b6d58d435a7c0161f5c514284802f25e87fddfe11024"},
-    {file = "jiter-0.13.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:4397ee562b9f69d283e5674445551b47a5e8076fdde75e71bfac5891113dc543"},
-    {file = "jiter-0.13.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7f90023f8f672e13ea1819507d2d21b9d2d1c18920a3b3a5f1541955a85b5504"},
-    {file = "jiter-0.13.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed0240dd1536a98c3ab55e929c60dfff7c899fecafcb7d01161b21a99fc8c363"},
-    {file = "jiter-0.13.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6207fc61c395b26fffdcf637a0b06b4326f35bfa93c6e92fe1a166a21aeb6731"},
-    {file = "jiter-0.13.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00203f47c214156df427b5989de74cb340c65c8180d09be1bf9de81d0abad599"},
-    {file = "jiter-0.13.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c26ad6967c9dcedf10c995a21539c3aa57d4abad7001b7a84f621a263a6b605"},
-    {file = "jiter-0.13.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a576f5dce9ac7de5d350b8e2f552cf364f32975ed84717c35379a51c7cb198bd"},
-    {file = "jiter-0.13.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b22945be8425d161f2e536cdae66da300b6b000f1c0ba3ddf237d1bfd45d21b8"},
-    {file = "jiter-0.13.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:6eeb7db8bc77dc20476bc2f7407a23dbe3d46d9cc664b166e3d474e1c1de4baa"},
-    {file = "jiter-0.13.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:19cd6f85e1dc090277c3ce90a5b7d96f32127681d825e71c9dce28788e39fc0c"},
-    {file = "jiter-0.13.0-cp39-cp39-win32.whl", hash = "sha256:dc3ce84cfd4fa9628fe62c4f85d0d597a4627d4242cfafac32a12cc1455d00f7"},
-    {file = "jiter-0.13.0-cp39-cp39-win_amd64.whl", hash = "sha256:9ffda299e417dc83362963966c50cb76d42da673ee140de8a8ac762d4bb2378b"},
-    {file = "jiter-0.13.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b1cbfa133241d0e6bdab48dcdc2604e8ba81512f6bbd68ec3e8e1357dd3c316c"},
-    {file = "jiter-0.13.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:db367d8be9fad6e8ebbac4a7578b7af562e506211036cba2c06c3b998603c3d2"},
-    {file = "jiter-0.13.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45f6f8efb2f3b0603092401dc2df79fa89ccbc027aaba4174d2d4133ed661434"},
-    {file = "jiter-0.13.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:597245258e6ad085d064780abfb23a284d418d3e61c57362d9449c6c7317ee2d"},
-    {file = "jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:3d744a6061afba08dd7ae375dcde870cffb14429b7477e10f67e9e6d68772a0a"},
-    {file = "jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f"},
-    {file = "jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59"},
-    {file = "jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19"},
-    {file = "jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4"},
+    {file = "jiter-0.16.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:c5fc4f8def331036a7b8e981b4347ebe409981edbc8308a5ea842b8c3614fa6c"},
+    {file = "jiter-0.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5a71d0d2014c3275043e1170bf3d4e771493cb0dcf07be54c567155f4d8ee64b"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:741eed508c233a76313a1c7b001f8f21b82f14327e9196ae8bd29a2cc164ae84"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3fb7bc819187b56dc48aa5c833aaf92257da8e07efdb9306156667bd2eeb491c"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c9610fd25ebccb43fca584136f5c2fbb26802447eccd430dfdbab95a0fd5126"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4a1d68ff7ca1d3b5dee20a97a3decda7d5f15003823bf6d140c81f8561d3bc5c"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb08c276dd02dac3a284acdd02cacc630d2e3cd6572a4b85519f35cbd133c3de"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:8fc4d94713c4697347e38faf7d6ef91547c142219bdcfc7220c4870879974244"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a0f05e229edb29e68cdd0ccb83cea13b64263416120cf943767a6fd72e6787f"},
+    {file = "jiter-0.16.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:2c842cbf374a8daf50b2c04212995bee34ca2ac2cdc29a901b4cdb072c9c4131"},
+    {file = "jiter-0.16.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5ed466aee31294d7cdcd4d37dfe5c42c97bc29d9a5f00eacf24504358309cb9b"},
+    {file = "jiter-0.16.0-cp310-cp310-win32.whl", hash = "sha256:b42e9ff5376819c053da25809a8d4b6fa6e473b4856ebe42e298ac958be3d7f9"},
+    {file = "jiter-0.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:10438939205546132189c8e74a2d536a707841f3a25cd7c74ee91fe503407a26"},
+    {file = "jiter-0.16.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:67fddeda1688f0cce2d2ae83ccf8a80f79936f2d2997d6cc2261f82fdb54a4d3"},
+    {file = "jiter-0.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c90c0f63df322be920eda6ce622e3083d8906ba267f8220fe7873213b8b4430e"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:64c0203212098470032aabcde9356fc168f377aade3e43def61dfe17e92f2037"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12288303c9844e61e1651d02a9a6f6633e47d39f897d6991d1427161ce6b746e"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cf109d010b4b05a105afb3d43be36a21322d345ad3111e13d15f680afef0e5b"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62c1b7fe1f77925acf5af68b6140b8810fa87dfd4dc0a9c8568ec2fa2a10429c"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8597d23c87f59294f83bcb6229b9ed1fccee13dbba967b46930d2f1759466fee"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:3126a5dbad56401989ac769aca0cb56005bfb3e2366eea0ca99d1a91c3c1ee03"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c4b4717bdb35ae456f831a6b08d01880fff399887a6bbc526a583a406e484eea"},
+    {file = "jiter-0.16.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:adff21bc78edfe086c15eb495b900306076de378dc2337c132401fc39bd79c91"},
+    {file = "jiter-0.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:dab907db06fc593645e73109acf4581ba5b548897d28b9348dc41ddc8343b2d3"},
+    {file = "jiter-0.16.0-cp311-cp311-win32.whl", hash = "sha256:560b2cf3fb03240cd34f27409a238547488708f05b7c3924f571a60422251ec7"},
+    {file = "jiter-0.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:e431cfc9caf44c1d5459ff77d4e64cbf85fddb6a35dad836a15c6a9ec23087c1"},
+    {file = "jiter-0.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:2a8e9e39cf083016137aa5cadafe3188adc2ba6ba1fbf1e5d18889ad3e9ad056"},
+    {file = "jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a"},
+    {file = "jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5"},
+    {file = "jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730"},
+    {file = "jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f"},
+    {file = "jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274"},
+    {file = "jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7"},
+    {file = "jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331"},
+    {file = "jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195"},
+    {file = "jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e"},
+    {file = "jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb"},
+    {file = "jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84"},
+    {file = "jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e"},
+    {file = "jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd"},
+    {file = "jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a"},
+    {file = "jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee"},
+    {file = "jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93"},
+    {file = "jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a"},
+    {file = "jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00"},
+    {file = "jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe"},
+    {file = "jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106"},
+    {file = "jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8"},
+    {file = "jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585"},
+    {file = "jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e"},
+    {file = "jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077"},
+    {file = "jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734"},
+    {file = "jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf"},
+    {file = "jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db"},
+    {file = "jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce"},
+    {file = "jiter-0.16.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:d8f80521644426d451e70f00c7974240cab8f6ee088aedaa9af2697153ab7805"},
+    {file = "jiter-0.16.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3b21b412b899fd8bd51a3046934b59a3bb068b79f70a5c6010053ac77cc53f0c"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0758ab7747a984797cf048e8eedea1d8ef39d7994b25611daf5b48fc903e8873"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9ec553a99b0987efd7a3645a1a825cf29c224e494db267a83369fcc8da9aeda5"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f3bd327cdfa118bc1ce69c214c2678571d5bd39b8ccd0ebf43a54db00541ba9a"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26d122613ada2b708eb714695446f40fce5bdf2edb4b02116dec62faa62dfab3"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e03a5f21a5ce96a9441b8cb32719a8b88ed5388f53e0f339c5bcf54f1317f9d0"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_31_riscv64.whl", hash = "sha256:a5c54ef4ff776d9675837ef535b3308d6e31c208d43ebc44a0f7ab8a208c68f7"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b1e7923093a376d93c6eb507c77045ae258d689ba577392846a1b3f10d0b09a9"},
+    {file = "jiter-0.16.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:2a0d46ef67cc58d906a6132dd3040ca70ae4f0b0d7c9c052fe432c658a69b3f6"},
+    {file = "jiter-0.16.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:70a490b55634dc0d2606ce8a8e01b1d62459011beb368d15d76e1eaf62460e3d"},
+    {file = "jiter-0.16.0-cp39-cp39-win32.whl", hash = "sha256:9acf1b2faec82d998811ecce7ae84d9005e53410773e9d37d61cdc424ba4581b"},
+    {file = "jiter-0.16.0-cp39-cp39-win_amd64.whl", hash = "sha256:491e7d072a253b156fff46b78bceac4652a697aa8d7082c9c18c03d7b7917d24"},
+    {file = "jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:850ccb1d7eedb4200f4014b1c0e8a577de114fc3cd88faad646dcc9bc4bb12ad"},
+    {file = "jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:e34e97bda77eb63242a410243c071e28ac7e0d8c0948c5ee658498690a4b2f2f"},
+    {file = "jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7dc85ea77d4abbae8bad0d3538678aedee75bceec4e2f6c8dfb1c74772e5aa5"},
+    {file = "jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17ca7fae79f6d99cd9a042b75f917eaada7b895cfc7dd2ee3a16089dcaec7a85"},
+    {file = "jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127"},
+    {file = "jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3"},
+    {file = "jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702"},
+    {file = "jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2"},
+    {file = "jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c"},
 ]
 
 [[package]]
@@ -535,29 +532,28 @@ files = [
 
 [[package]]
 name = "openai"
-version = "2.29.0"
+version = "3.5.0"
 description = "The official Python library for the openai API"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "openai-2.29.0-py3-none-any.whl", hash = "sha256:b7c5de513c3286d17c5e29b92c4c98ceaf0d775244ac8159aeb1bddf840eb42a"},
-    {file = "openai-2.29.0.tar.gz", hash = "sha256:32d09eb2f661b38d3edd7d7e1a2943d1633f572596febe64c0cd370c86d52bec"},
+    {file = "openai-3.5.0-py3-none-any.whl", hash = "sha256:7c0873d379655f65fa515c5692c8620e73bf6a6dce3e63f37589bc99bda3fdfd"},
+    {file = "openai-3.5.0.tar.gz", hash = "sha256:743738bb458a586d0d02d173bf398d29d7d7a80d182d167aa74f1c08814ecc78"},
 ]
 
 [package.dependencies]
-anyio = ">=3.5.0,<5"
-distro = ">=1.7.0,<2"
-httpx = ">=0.23.0,<1"
-jiter = ">=0.10.0,<1"
-pydantic = ">=1.9.0,<3"
+anyio = ">=4.10.0,<5"
+httpx2 = ">=2.7.0,<3"
+jiter = ">=0.16.0,<1"
+pydantic = ">=1.10.13,<2.0.dev0 || >=2.4.dev0,<3"
 sniffio = "*"
-tqdm = ">4"
 typing-extensions = ">=4.14,<5"
 
 [package.extras]
-aiohttp = ["aiohttp", "httpx-aiohttp (>=0.1.9)"]
-datalib = ["numpy (>=1)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1.0.11)"]
+aiohttp = ["aiohttp (>=3.14.3)"]
+bedrock = ["botocore (>=1.40.0,<2)", "urllib3 (>=2.7.0,<3)"]
+datalib = ["numpy (>=1)", "pandas (>=1.2.3)"]
 realtime = ["websockets (>=13,<16)"]
 voice-helpers = ["numpy (>=2.0.2)", "sounddevice (>=0.5.1)"]
 
@@ -956,26 +952,17 @@ files = [
 ]
 
 [[package]]
-name = "tqdm"
-version = "4.67.3"
-description = "Fast, Extensible Progress Meter"
+name = "truststore"
+version = "0.10.4"
+description = "Verify certificates using native system trust stores"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["main"]
+markers = "sys_platform != \"emscripten\""
 files = [
-    {file = "tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf"},
-    {file = "tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb"},
+    {file = "truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"},
+    {file = "truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301"},
 ]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
-
-[package.extras]
-dev = ["nbval", "pytest (>=6)", "pytest-asyncio (>=0.24)", "pytest-cov", "pytest-timeout"]
-discord = ["requests"]
-notebook = ["ipywidgets (>=6)"]
-slack = ["slack-sdk"]
-telegram = ["requests"]
 
 [[package]]
 name = "typing-extensions"
@@ -1132,4 +1119,4 @@ rich = ["rich"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "91823a882ebce216feab3e8125cf08786e3d3cbc5a7156d71caad3f481a9b476"
+content-hash = "cf87206a34c8a1cdafe7a4572c54f5def4f8fddce823f5a2cdb93d4c5a598e6b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chatsnack"
-version = "0.7.0"
+version = "0.8.0"
 description = "chatsnack is the easiest Python library for rapid development with OpenAI's ChatGPT API. It provides an intuitive interface for creating and managing chat-based prompts and responses, making it convenient to build complex, interactive conversations with AI."
 authors = ["Mattie Casper"]
 license = "MIT"
@@ -15,7 +15,7 @@ snapclass = "^0.2.0"
 python-dotenv = "^1.0.0"
 loguru = "^0.6.0"
 nest-asyncio = "^1.5.6"
-openai = ">=2.29.0"
+openai = ">=3.5.0,<4.0.0"
 websockets = ">=13.0"
 Flask = {version = "^3.1.3", optional = true}
 questionary = {version = "^1.10.0", optional = true}
@@ -37,6 +37,7 @@ asyncio_mode = "auto"
 markers = [
     "notebooks: notebook-derived pytest coverage",
     "notebooks_live: live notebook-derived pytest coverage",
+    "openrouter_live: opt-in live OpenRouter integration coverage",
 ]
 
 [build-system]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Keep paid-test opt-ins explicit before chatsnack loads the project .env."""
+
+import os
+
+
+for _live_flag in (
+    "CHATSNACK_RUN_LIVE_TESTS",
+    "CHATSNACK_RUN_OPENROUTER_LIVE",
+):
+    os.environ.setdefault(_live_flag, "")

--- a/tests/features/test_provider_client_configuration.py
+++ b/tests/features/test_provider_client_configuration.py
@@ -1,0 +1,475 @@
+"""Goal contracts for per-Chat OpenAI-compatible provider configuration.
+
+These tests exercise the installed OpenAI SDK against a loopback HTTP server.
+They prove the user-visible YAML -> Chat -> ask/chat/listen path while keeping
+real provider credentials and network calls out of the offline suite.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from chatsnack import Chat, utensil
+from chatsnack.runtime import ResponsesAdapter
+
+
+def _response_payload(model: str, text: str, *, tool_call: bool = False) -> dict:
+    output = []
+    if tool_call:
+        output.extend(
+            [
+                {
+                    "type": "reasoning",
+                    "id": "rs_lookup",
+                    "summary": [],
+                    "encrypted_content": "encrypted-snack-state",
+                },
+                {
+                    "type": "message",
+                    "id": "msg_lookup",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Looking that up.",
+                            "annotations": [],
+                            "logprobs": [],
+                        }
+                    ],
+                },
+                {
+                    "type": "function_call",
+                    "id": "fc_lookup",
+                    "call_id": "call_lookup",
+                    "name": "lookup_snack",
+                    "arguments": '{"name":"popcorn"}',
+                    "status": "completed",
+                },
+            ]
+        )
+    else:
+        output.append(
+            {
+                "type": "message",
+                "id": "msg_test",
+                "role": "assistant",
+                "status": "completed",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": text,
+                        "annotations": [],
+                        "logprobs": [],
+                    }
+                ],
+            }
+        )
+    return {
+        "id": "resp_test",
+        "object": "response",
+        "created_at": 1,
+        "status": "completed",
+        "model": model,
+        "output": output,
+        "parallel_tool_calls": True,
+        "store": False,
+        "temperature": 0.4,
+        "tool_choice": "auto",
+        "tools": [],
+        "top_p": 1.0,
+        "usage": {
+            "input_tokens": 3,
+            "input_tokens_details": {"cached_tokens": 0},
+            "output_tokens": 2,
+            "output_tokens_details": {"reasoning_tokens": 0},
+            "total_tokens": 5,
+        },
+    }
+
+
+@pytest.fixture
+def provider_server():
+    """Run a temporary OpenAI-compatible endpoint and retain every request."""
+    records: list[dict] = []
+    records_lock = threading.Lock()
+
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, format, *args):  # noqa: A003 - stdlib hook name
+            return
+
+        def do_POST(self):  # noqa: N802 - stdlib hook name
+            body = json.loads(self.rfile.read(int(self.headers.get("content-length", "0"))))
+            record = {
+                "path": self.path,
+                "authorization": self.headers.get("authorization"),
+                "api_key": self.headers.get("api-key"),
+                "organization": self.headers.get("openai-organization"),
+                "project": self.headers.get("openai-project"),
+                "ambient_private": self.headers.get("x-private-tenant"),
+                "explicit_header": self.headers.get("x-explicit"),
+                "openrouter_title": self.headers.get("x-openrouter-title"),
+                "provider_secret": self.headers.get("x-provider-secret"),
+                "body": body,
+            }
+            with records_lock:
+                records.append(record)
+
+            provider = "azure" if self.path.startswith("/azure/") else "openrouter"
+            model = body.get("model", "unknown")
+            text = f"{provider}:{model}"
+            input_items = body.get("input") or []
+            has_tool_output = any(
+                item.get("type") == "function_call_output"
+                for item in input_items
+                if isinstance(item, dict)
+            )
+            needs_tool = bool(body.get("tools")) and not has_tool_output
+            response = _response_payload(model, text, tool_call=needs_tool)
+
+            if body.get("stream"):
+                self.send_response(200)
+                self.send_header("content-type", "text/event-stream")
+                self.send_header("connection", "close")
+                self.end_headers()
+                delta_type = (
+                    "response.content_part.delta"
+                    if provider == "openrouter"
+                    else "response.output_text.delta"
+                )
+                terminal_type = (
+                    "response.done"
+                    if provider == "openrouter"
+                    else "response.completed"
+                )
+                events = (
+                    {
+                        "type": delta_type,
+                        "sequence_number": 1,
+                        "item_id": "msg_test",
+                        "output_index": 0,
+                        "content_index": 0,
+                        "delta": f"{provider}:",
+                        "logprobs": [],
+                    },
+                    {
+                        "type": delta_type,
+                        "sequence_number": 2,
+                        "item_id": "msg_test",
+                        "output_index": 0,
+                        "content_index": 0,
+                        "delta": model,
+                        "logprobs": [],
+                    },
+                    {
+                        "type": terminal_type,
+                        "sequence_number": 3,
+                        "response": response,
+                    },
+                )
+                for event in events:
+                    payload = json.dumps(event).encode()
+                    self.wfile.write(b"data: " + payload + b"\n\n")
+                    self.wfile.flush()
+                if provider == "openrouter":
+                    self.wfile.write(b"data: [DONE]\n\n")
+                    self.wfile.flush()
+                self.close_connection = True
+                return
+
+            payload = json.dumps(response).encode()
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(payload)))
+            self.send_header("connection", "close")
+            self.end_headers()
+            self.wfile.write(payload)
+            self.close_connection = True
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield type(
+            "ProviderServer",
+            (),
+            {
+                "url": f"http://127.0.0.1:{server.server_port}",
+                "records": records,
+            },
+        )()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+
+
+def _write_named_chat(
+    root: Path,
+    *,
+    name: str,
+    model: str,
+    base_url: str,
+    api_key_env: str,
+    provider_extensions: bool = False,
+) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    params = [
+        "params:",
+        f"  model: {model}",
+        f"  base_url: {base_url}",
+        f"  api_key_env: {api_key_env}",
+    ]
+    if provider_extensions:
+        params.extend(
+            (
+                "  temperature: 0.4",
+                "  responses:",
+                "    extra_body:",
+                "      presence_penalty: 0.3",
+                "      frequency_penalty: 0.4",
+            )
+        )
+    (root / f"{name}.yml").write_text(
+        "\n".join(
+            (
+                *params,
+                "messages:",
+                "  - system: Respond with the provider route.",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_goal_g1_named_openrouter_chat_asks_chats_and_streams(provider_server, tmp_path, monkeypatch):
+    """G1: one named OpenRouter asset keeps the ordinary Chat interaction shape."""
+    monkeypatch.setenv("CHATSNACK_BASE_DIR", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_TEST_KEY", "openrouter-sentinel")
+    monkeypatch.setenv("OPENAI_ORG_ID", "ambient-openai-org")
+    monkeypatch.setenv("OPENAI_PROJECT_ID", "ambient-openai-project")
+    monkeypatch.setenv(
+        "OPENAI_CUSTOM_HEADERS",
+        "X-Private-Tenant: ambient-tenant-secret\nAuthorization: Bearer ambient-secret",
+    )
+    _write_named_chat(
+        tmp_path,
+        name="OpenRouterGoal",
+        model="openai/gpt-oss-20b",
+        base_url=f"{provider_server.url}/openrouter/api/v1",
+        api_key_env="OPENROUTER_TEST_KEY",
+        provider_extensions=True,
+    )
+
+    chat = Chat(name="OpenRouterGoal")
+    assert isinstance(chat.runtime, ResponsesAdapter)
+    assert chat.ask("Which route?") == "openrouter:openai/gpt-oss-20b"
+    continued = chat.chat("Continue once.")
+    assert continued.last == "openrouter:openai/gpt-oss-20b"
+    continued_again = continued.chat("Continue twice.")
+    assert continued_again.last == "openrouter:openai/gpt-oss-20b"
+
+    chat.stream = True
+    assert "".join(chat.listen("Stream it.")) == "openrouter:openai/gpt-oss-20b"
+
+    relevant = [record for record in provider_server.records if record["path"].startswith("/openrouter/")]
+    assert relevant
+    assert {record["path"] for record in relevant} == {"/openrouter/api/v1/responses"}
+    assert {record["authorization"] for record in relevant} == {"Bearer openrouter-sentinel"}
+    assert all(record["organization"] is None for record in relevant)
+    assert all(record["project"] is None for record in relevant)
+    assert all(record["ambient_private"] is None for record in relevant)
+    assert all("base_url" not in record["body"] for record in relevant)
+    assert all("api_key_env" not in record["body"] for record in relevant)
+    assert all(record["body"].get("store") is False for record in relevant)
+    assert all("previous_response_id" not in record["body"] for record in relevant)
+    assert all(record["body"]["temperature"] == 0.4 for record in relevant)
+    assert all(record["body"]["presence_penalty"] == 0.3 for record in relevant)
+    assert all(record["body"]["frequency_penalty"] == 0.4 for record in relevant)
+
+    continued_again.close()
+    continued.close()
+    chat.close()
+
+
+def test_goal_g1b_continuations_keep_the_root_credential_binding(
+    provider_server,
+    monkeypatch,
+):
+    """G1b: a conversation lineage does not re-read its named credential."""
+    base_url = f"{provider_server.url}/openrouter/api/v1"
+    monkeypatch.setenv("OPENROUTER_LINEAGE_KEY", "lineage-original")
+    root = Chat(
+        "Keep using the provider selected for this conversation.",
+        model="openrouter/lineage-model",
+        base_url=base_url,
+        api_key_env="OPENROUTER_LINEAGE_KEY",
+    )
+
+    first = root.chat("First turn.")
+    monkeypatch.setenv("OPENROUTER_LINEAGE_KEY", "lineage-rotated")
+    second = first.chat("Second turn.")
+    assert second.ask("Read from the continued binding.") == (
+        "openrouter:openrouter/lineage-model"
+    )
+
+    fresh = Chat(
+        "Use the current environment for a new conversation.",
+        model="openrouter/lineage-model",
+        base_url=base_url,
+        api_key_env="OPENROUTER_LINEAGE_KEY",
+    )
+    assert fresh.ask("Read from the fresh binding.") == (
+        "openrouter:openrouter/lineage-model"
+    )
+
+    relevant = [
+        record
+        for record in provider_server.records
+        if record["path"].startswith("/openrouter/")
+    ]
+    assert [record["authorization"] for record in relevant] == [
+        "Bearer lineage-original",
+        "Bearer lineage-original",
+        "Bearer lineage-original",
+        "Bearer lineage-rotated",
+    ]
+
+    fresh.close()
+    second.close()
+    first.close()
+    root.close()
+
+
+@pytest.mark.asyncio
+async def test_goal_g1c_continuation_keeps_ownership_of_the_opened_client(
+    provider_server,
+    monkeypatch,
+):
+    """G1c: closing a returned continuation closes the client that made its request."""
+    monkeypatch.setenv("OPENROUTER_OWNER_KEY", "owner-sentinel")
+    root = Chat(
+        "Keep the request client with this conversation.",
+        model="openrouter/owner-model",
+        base_url=f"{provider_server.url}/openrouter/api/v1",
+        api_key_env="OPENROUTER_OWNER_KEY",
+    )
+
+    continued = await root.chat_a("Continue once.")
+
+    assert continued.ai is root.ai
+    assert root.ai._aclient is not None
+    await continued.close_a()
+    assert root.ai._aclient is None
+    await root.close_a()
+
+
+@pytest.mark.asyncio
+async def test_goal_g2_modern_azure_v1_uses_standard_responses_routes(provider_server, monkeypatch):
+    """G2: Azure v1 uses a normal OpenAI client and deployment-as-model."""
+    monkeypatch.setenv("AZURE_CHAT_TEST_KEY", "azure-sentinel")
+    chat = Chat(
+        "Use the Azure deployment.",
+        model="snack-deployment",
+        base_url=f"{provider_server.url}/azure/openai/v1/",
+        api_key_env="AZURE_CHAT_TEST_KEY",
+    )
+
+    assert isinstance(chat.runtime, ResponsesAdapter)
+    assert await chat.ask_a("Which route?") == "azure:snack-deployment"
+    chat.stream = True
+    listener = await chat.listen_a("Stream it.")
+    assert "".join([chunk async for chunk in listener]) == "azure:snack-deployment"
+
+    relevant = [record for record in provider_server.records if record["path"].startswith("/azure/")]
+    assert {record["path"] for record in relevant} == {"/azure/openai/v1/responses"}
+    assert {record["authorization"] for record in relevant} == {"Bearer azure-sentinel"}
+    assert all("api-version" not in record["path"] for record in relevant)
+    assert all("/deployments/" not in record["path"] for record in relevant)
+    assert all(record["body"]["model"] == "snack-deployment" for record in relevant)
+
+    await chat.close_a()
+
+
+@pytest.mark.asyncio
+async def test_goal_g3_mixed_providers_stay_isolated_through_copy_and_utensil_continuation(
+    provider_server,
+    monkeypatch,
+):
+    """G3: concurrent providers retain endpoints and keys through child Chats."""
+    monkeypatch.setenv("OPENROUTER_ISOLATION_KEY", "openrouter-isolation")
+    monkeypatch.setenv("AZURE_ISOLATION_KEY", "azure-isolation")
+
+    @utensil
+    def lookup_snack(name: str) -> dict:
+        """Look up one snack for the provider-isolation Goal."""
+        return {"name": name, "rating": "crunchy"}
+
+    openrouter = Chat(
+        "Use the lookup utensil.",
+        model="openrouter/tool-model",
+        base_url=f"{provider_server.url}/openrouter/api/v1",
+        api_key_env="OPENROUTER_ISOLATION_KEY",
+        utensils=[lookup_snack],
+    )
+    azure = Chat(
+        "Answer directly.",
+        model="azure-isolation-deployment",
+        base_url=f"{provider_server.url}/azure/openai/v1/",
+        api_key_env="AZURE_ISOLATION_KEY",
+    )
+
+    copied_openrouter = openrouter.copy()
+    tool_thread, azure_thread = await asyncio.gather(
+        copied_openrouter.chat_a("Look up popcorn."),
+        azure.chat_a("Answer once."),
+    )
+
+    assert tool_thread.last == "openrouter:openrouter/tool-model"
+    assert azure_thread.last == "azure:azure-isolation-deployment"
+
+    for record in provider_server.records:
+        if record["path"].startswith("/openrouter/"):
+            assert record["authorization"] == "Bearer openrouter-isolation"
+            assert record["body"]["model"] == "openrouter/tool-model"
+        elif record["path"].startswith("/azure/"):
+            assert record["authorization"] == "Bearer azure-isolation"
+            assert record["body"]["model"] == "azure-isolation-deployment"
+        else:
+            pytest.fail(f"Unexpected provider route: {record['path']}")
+
+    tool_follow_up = next(
+        record
+        for record in provider_server.records
+        if any(
+            item.get("type") == "function_call_output"
+            for item in record["body"].get("input", [])
+            if isinstance(item, dict)
+        )
+    )
+    replayed_call = next(
+        item
+        for item in tool_follow_up["body"]["input"]
+        if item.get("type") == "function_call"
+    )
+    assert replayed_call["id"] == "fc_lookup"
+    assert replayed_call["call_id"] == "call_lookup"
+    assert replayed_call["status"] == "completed"
+
+    await asyncio.gather(
+        tool_thread.close_a(),
+        azure_thread.close_a(),
+        copied_openrouter.close_a(),
+        openrouter.close_a(),
+        azure.close_a(),
+    )

--- a/tests/mixins/test_chatparams.py
+++ b/tests/mixins/test_chatparams.py
@@ -1,4 +1,6 @@
 import os
+import warnings
+
 import pytest
 
 _RUN_OPENAI_LIVE = os.environ.get("CHATSNACK_RUN_LIVE_TESTS", "").lower() in {
@@ -136,12 +138,14 @@ def test_provider_model_options_pass_through_and_client_fields_do_not():
     assert "api_key_env" not in provider_params
 
 
-def test_known_unsupported_temperature_warns_and_passes_through():
+def test_reasoning_model_temperature_passes_through_without_local_warning():
     params = ChatParams(model="gpt-5.4", temperature=0.2)
 
-    with pytest.warns(UserWarning, match="forwarding as authored"):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
         provider_params = params._get_non_none_params()
 
+    assert caught == []
     assert provider_params["temperature"] == 0.2
 
 

--- a/tests/mixins/test_chatparams.py
+++ b/tests/mixins/test_chatparams.py
@@ -1,5 +1,12 @@
 import os
 import pytest
+
+_RUN_OPENAI_LIVE = os.environ.get("CHATSNACK_RUN_LIVE_TESTS", "").lower() in {
+    "1",
+    "true",
+    "yes",
+}
+
 from chatsnack.packs import Jane
 from chatsnack.chat.mixin_params import DEFAULT_MODEL_FALLBACK
 from chatsnack import Chat, ChatParams
@@ -75,11 +82,12 @@ def test_set_tool_choice_creates_params(chat_params_mixin):
 
 # Existing engine tests for various models; you can skip these if needed.
 @pytest.mark.parametrize("engine", ["gpt-3.5-turbo", "gpt-4", "gpt-4o", "o1", "o3-mini", "gpt-4o-mini", "gpt-4-turbo", "gpt-5-nano", "gpt-5-mini", "gpt-5.6-terra", "gpt-5.4"])
-@pytest.mark.skipif(os.environ.get("OPENAI_API_KEY") is None, reason="OPENAI_API_KEY is not set in environment or .env")
+@pytest.mark.skipif(
+    not _RUN_OPENAI_LIVE or not os.environ.get("OPENAI_API_KEY"),
+    reason="Live OpenAI tests require OPENAI_API_KEY and CHATSNACK_RUN_LIVE_TESTS=1",
+)
 def test_engines(engine):
     SENTENCE = "A short sentence about the difference between green and blue."
-    TEMPERATURE = 0.0
-    SEED = 42
     ENGINE = engine
     
     # Jane is an existing chat we can build upon
@@ -87,8 +95,6 @@ def test_engines(engine):
     cp = chat.user(SENTENCE)
     assert cp.last == SENTENCE
 
-    cp.temperature = TEMPERATURE
-    cp.seed = SEED
     cp.model = ENGINE
 
     output_iter = cp.listen()
@@ -111,6 +117,32 @@ def test_get_non_none_params_preserves_profile(chat_params):
     out = chat_params._get_non_none_params()
     assert "profile" in out
     assert out["profile"] == {"defaults": {"temperature": 0.5}}
+
+
+def test_provider_model_options_pass_through_and_client_fields_do_not():
+    params = ChatParams(
+        model="openrouter/vendor-new-model",
+        temperature=0.73,
+        max_tokens=321,
+        base_url="https://provider.example/v1",
+        api_key_env="PROVIDER_KEY",
+    )
+
+    provider_params = params._get_non_none_params()
+
+    assert provider_params["temperature"] == 0.73
+    assert provider_params["max_tokens"] == 321
+    assert "base_url" not in provider_params
+    assert "api_key_env" not in provider_params
+
+
+def test_known_unsupported_temperature_warns_and_passes_through():
+    params = ChatParams(model="gpt-5.4", temperature=0.2)
+
+    with pytest.warns(UserWarning, match="forwarding as authored"):
+        provider_params = params._get_non_none_params()
+
+    assert provider_params["temperature"] == 0.2
 
 
 @pytest.mark.asyncio

--- a/tests/mixins/test_query.py
+++ b/tests/mixins/test_query.py
@@ -548,17 +548,18 @@ def test_copy_chatprompt_no_system():
 
 def test_copy_chatprompt_copies_params():
     """Copying a ChatPrompt should copy over params."""
-    chat = Chat(name="test", params={"key": "value"})
+    chat = Chat(name="test", params={"temperature": 0.2})
     new_chat = chat.copy()
-    assert new_chat.params == {"key": "value"}
+    assert isinstance(new_chat.params, ChatParams)
+    assert new_chat.params.temperature == 0.2
 
 def test_copy_chatprompt_independent_params():
     """Copying a ChatPrompt should result in independent params."""
-    chat = Chat(name="test", params={"key": "value"})
+    chat = Chat(name="test", params={"temperature": 0.2})
     new_chat = chat.copy()
-    new_chat.params["key"] = "new_value"
-    assert chat.params == {"key": "value"}
-    assert new_chat.params == {"key": "new_value"}
+    new_chat.params.temperature = 0.8
+    assert chat.params.temperature == 0.2
+    assert new_chat.params.temperature == 0.8
 
 
 

--- a/tests/mixins/test_query.py
+++ b/tests/mixins/test_query.py
@@ -173,7 +173,7 @@ def test_copy_creates_independent_adapter_instances():
 
 
 def test_chat_continuation_creates_independent_adapter_instance(chat, monkeypatch):
-    """chat() continuation must not share the source chat's adapter instance."""
+    """chat() keeps request-client ownership while isolating adapter state."""
     chat.runtime = ResponsesAdapter(chat.ai)
 
     async def fake_create_completion_a(self, messages, **kwargs):
@@ -184,7 +184,7 @@ def test_chat_continuation_creates_independent_adapter_instance(chat, monkeypatc
     result = chat.chat("hello")
     assert isinstance(result.runtime, ResponsesAdapter)
     assert result.runtime is not chat.runtime
-    assert result.runtime.ai_client is not chat.runtime.ai_client
+    assert result.runtime.ai_client is chat.runtime.ai_client
 
 
 

--- a/tests/mixins/test_query_listen.py
+++ b/tests/mixins/test_query_listen.py
@@ -1,4 +1,13 @@
+import os
+
 import pytest
+
+_RUN_OPENAI_LIVE = os.environ.get("CHATSNACK_RUN_LIVE_TESTS", "").lower() in {
+    "1",
+    "true",
+    "yes",
+}
+
 from chatsnack import Chat, Text, CHATSNACK_BASE_DIR
 
 
@@ -9,38 +18,49 @@ from chatsnack.chat.mixin_utensil import ChatUtensilMixin
 from chatsnack.aiclient import AiClient
 
 
+_SKIP_OPENAI_LIVE = pytest.mark.skipif(
+    not _RUN_OPENAI_LIVE or not os.environ.get("OPENAI_API_KEY"),
+    reason="Live OpenAI tests require OPENAI_API_KEY and CHATSNACK_RUN_LIVE_TESTS=1",
+)
 
 
+
+@_SKIP_OPENAI_LIVE
 @pytest.mark.asyncio
 async def test_get_responses_a():
     ai = AiClient()
-    listener = ChatStreamListener(ai, '[{"role":"system","content":"Respond only with POPSICLE 20 times."}]')
-    responses = []
-    await listener.start_a()
-    async for resp in listener:
-        responses.append(resp)
-    assert len(responses) > 10
-    assert listener.is_complete
-    assert 'POPSICLE' in listener.current_content
-    assert 'POPSICLE' in listener.response
+    try:
+        listener = ChatStreamListener(ai, '[{"role":"system","content":"Respond only with POPSICLE 20 times."}]')
+        responses = []
+        await listener.start_a()
+        async for resp in listener:
+            responses.append(resp)
+        assert len(responses) > 10
+        assert listener.is_complete
+        assert 'POPSICLE' in listener.current_content
+        assert 'POPSICLE' in listener.response
+    finally:
+        await ai.close_a()
 
+@_SKIP_OPENAI_LIVE
 def test_get_responses():
     ai = AiClient()
-    listener = ChatStreamListener(ai, '[{"role":"system","content":"Respond only with POPSICLE 20 times."}]')
-    listener.start()
-    responses = list(listener)
-    assert len(responses) > 10
-    assert listener.is_complete
-    assert 'POPSICLE' in listener.current_content
-    assert 'POPSICLE' in listener.response
+    try:
+        listener = ChatStreamListener(ai, '[{"role":"system","content":"Respond only with POPSICLE 20 times."}]')
+        listener.start()
+        responses = list(listener)
+        assert len(responses) > 10
+        assert listener.is_complete
+        assert 'POPSICLE' in listener.current_content
+        assert 'POPSICLE' in listener.response
+    finally:
+        ai.close()
 
-import os
-import pytest
 from chatsnack.packs import Jane
 
 
 
-@pytest.mark.skipif(os.environ.get("OPENAI_API_KEY") is None, reason="OPENAI_API_KEY is not set in environment or .env")
+@_SKIP_OPENAI_LIVE
 def test_listen():
     # Define constants
     SENTENCE = "A short sentence about the difference between green and blue."

--- a/tests/runtime/test_chat_completions_adapter.py
+++ b/tests/runtime/test_chat_completions_adapter.py
@@ -203,6 +203,35 @@ def test_profile_is_stripped_before_api_call():
     assert "profile" not in captured
 
 
+def test_chat_completions_boundary_strips_client_fields_and_maps_token_limit():
+    captured = {}
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return _FakeObj(
+            {
+                "model": "provider/model",
+                "choices": [
+                    {"finish_reason": "stop", "message": {"role": "assistant", "content": "hi"}}
+                ],
+            }
+        )
+
+    ai = SimpleNamespace(client=SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create))))
+    ChatCompletionsAdapter(ai).create_completion(
+        messages=[],
+        model="provider/model",
+        max_tokens=456,
+        base_url="https://wrong.example/v1",
+        api_key_env="SECRET_NAME",
+    )
+
+    assert captured["max_completion_tokens"] == 456
+    assert "max_tokens" not in captured
+    assert "base_url" not in captured
+    assert "api_key_env" not in captured
+
+
 def test_profile_is_stripped_in_stream_completion():
     captured = {}
     chunks = iter([

--- a/tests/runtime/test_responses_adapter.py
+++ b/tests/runtime/test_responses_adapter.py
@@ -694,3 +694,125 @@ def test_supported_client_path_succeeds_without_capability_error():
     result = adapter.create_completion(messages=[{"role": "user", "content": "hello"}], model="gpt-4.1")
 
     assert result.metadata["response_id"] == "resp_ok"
+
+
+def test_responses_boundary_strips_client_fields_and_maps_token_limit():
+    captured = {}
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return _FakeObj({"id": "resp_clean", "status": "completed", "model": "alias", "output": []})
+
+    ai = SimpleNamespace(client=SimpleNamespace(responses=SimpleNamespace(create=create)))
+    ResponsesAdapter(ai).create_completion(
+        messages=[],
+        model="alias",
+        max_tokens=123,
+        base_url="https://wrong.example/v1",
+        api_key_env="SECRET_NAME",
+    )
+
+    assert captured["max_output_tokens"] == 123
+    assert "max_tokens" not in captured
+    assert "base_url" not in captured
+    assert "api_key_env" not in captured
+
+
+def test_real_sse_events_are_incremental_and_close_transport():
+    class Stream:
+        def __init__(self):
+            self.closed = False
+            self.events = iter(
+                (
+                    _FakeObj({"type": "response.output_text.delta", "delta": "Pop"}),
+                    _FakeObj(
+                        {
+                            "type": "response.completed",
+                            "response": {
+                                "id": "resp_stream",
+                                "status": "completed",
+                                "model": "provider/model",
+                                "usage": {"total_tokens": 9},
+                                "output": [],
+                            },
+                        }
+                    ),
+                )
+            )
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return next(self.events)
+
+        def close(self):
+            self.closed = True
+
+    stream = Stream()
+    ai = SimpleNamespace(
+        client=SimpleNamespace(
+            responses=SimpleNamespace(create=lambda **kwargs: stream)
+        )
+    )
+
+    events = list(ResponsesAdapter(ai).stream_completion(messages=[], model="provider/model"))
+
+    assert [event.type for event in events] == ["text_delta", "usage", "completed"]
+    assert events[0].data["text"] == "Pop"
+    assert stream.closed is True
+
+
+@pytest.mark.asyncio
+async def test_async_real_sse_is_incremental_and_closes_transport():
+    class Stream:
+        def __init__(self):
+            self.closed = False
+            self.events = iter(
+                (
+                    _FakeObj({"type": "response.output_text.delta", "delta": "Corn"}),
+                    _FakeObj(
+                        {
+                            "type": "response.completed",
+                            "response": {
+                                "id": "resp_stream",
+                                "status": "completed",
+                                "model": "provider/model",
+                                "output": [],
+                            },
+                        }
+                    ),
+                )
+            )
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self.events)
+            except StopIteration:
+                raise StopAsyncIteration
+
+        async def aclose(self):
+            self.closed = True
+
+    stream = Stream()
+
+    async def create(**kwargs):
+        return stream
+
+    ai = SimpleNamespace(
+        aclient=SimpleNamespace(responses=SimpleNamespace(create=create))
+    )
+
+    events = [
+        event
+        async for event in ResponsesAdapter(ai).stream_completion_a(
+            messages=[], model="provider/model"
+        )
+    ]
+
+    assert [event.type for event in events] == ["text_delta", "completed"]
+    assert events[0].data["text"] == "Corn"
+    assert stream.closed is True

--- a/tests/runtime/test_responses_websocket_adapter.py
+++ b/tests/runtime/test_responses_websocket_adapter.py
@@ -1225,7 +1225,7 @@ def test_sdk_version_check_raises_clear_message():
     adapter = ResponsesWebSocketAdapter(ai, session=ResponsesWebSocketSession(mode="inherit"))
 
     # Try to connect - should raise the version guidance message
-    with pytest.raises(ResponsesWebSocketTransportError, match="openai>=2.29.0") as exc_info:
+    with pytest.raises(ResponsesWebSocketTransportError, match="openai>=3.5.0") as exc_info:
         adapter._connect_sync()
 
     assert exc_info.value.code == "sdk_unsupported"

--- a/tests/test_apply_patch_utensil.py
+++ b/tests/test_apply_patch_utensil.py
@@ -216,7 +216,7 @@ async def test_goal_saved_apply_patch_chat_requires_and_accepts_explicit_rebind(
     assert "- apply_patch" in authored.yaml
     assert "execute" not in authored.yaml
 
-    unbound = Chat(name="SavedPatchWriter")
+    unbound = Chat(name="SavedPatchWriter", runtime="responses")
     unbound_requests = []
 
     async def should_not_submit(adapter, messages, **kwargs):
@@ -224,12 +224,15 @@ async def test_goal_saved_apply_patch_chat_requires_and_accepts_explicit_rebind(
         raise AssertionError("unbound chat reached provider I/O")
 
     monkeypatch.setattr(ResponsesAdapter, "create_completion_a", should_not_submit)
-    unbound.runtime = ResponsesAdapter(unbound.ai)
     with pytest.raises(RuntimeError, match="Missing runtime binding for apply_patch"):
         await unbound.chat_a("Make the edit.")
     assert unbound_requests == []
 
-    rebound = Chat(name="SavedPatchWriter", utensils=[patch])
+    rebound = Chat(
+        name="SavedPatchWriter",
+        utensils=[patch],
+        runtime="responses",
+    )
     rebound.load()
     completions = iter([_patch_completion(), _final_completion()])
 
@@ -237,8 +240,6 @@ async def test_goal_saved_apply_patch_chat_requires_and_accepts_explicit_rebind(
         return next(completions)
 
     monkeypatch.setattr(ResponsesAdapter, "create_completion_a", create_completion_a)
-    rebound.runtime = ResponsesAdapter(rebound.ai)
-
     continued = await rebound.chat_a("Make the edit.")
 
     assert continued.last == "Patch complete."

--- a/tests/test_call_usage.py
+++ b/tests/test_call_usage.py
@@ -223,17 +223,16 @@ async def test_chat_a_failure_exposes_partial_usage_without_wrapping_exception()
 
 @pytest.mark.asyncio
 async def test_next_call_replaces_source_usage_and_leaves_prior_result_intact():
-    first_runtime = _SequenceRuntime(
-        [_completion("First.", {"total_tokens": 5}, response_id="resp_first")]
+    runtime = _SequenceRuntime(
+        [
+            _completion("First.", {"total_tokens": 5}, response_id="resp_first"),
+            _completion("Second.", {"total_tokens": 8}, response_id="resp_second"),
+        ]
     )
-    source = Chat("Answer briefly.", runtime=first_runtime)
+    source = Chat("Answer briefly.", runtime=runtime)
     first = await source.chat_a("First?")
     first_call = first.last_call_usage
 
-    second_runtime = _SequenceRuntime(
-        [_completion("Second.", {"total_tokens": 8}, response_id="resp_second")]
-    )
-    source.runtime = second_runtime
     second = await source.chat_a("Second?")
 
     assert first.last_call_usage is first_call
@@ -245,19 +244,20 @@ async def test_next_call_replaces_source_usage_and_leaves_prior_result_intact():
 
 @pytest.mark.asyncio
 async def test_in_flight_call_preserves_most_recently_finished_source_usage():
-    first_runtime = _SequenceRuntime(
-        [_completion("First.", {"total_tokens": 5}, response_id="resp_first")]
-    )
-    source = Chat("Answer briefly.", runtime=first_runtime)
-    first = await source.chat_a("First?")
-    first_call = first.last_call_usage
-
-    class _BlockingRuntime:
+    class _BlockingSecondRuntime:
         def __init__(self):
             self.started = asyncio.Event()
             self.release = asyncio.Event()
+            self.calls = 0
 
         async def create_completion_a(self, messages, **kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                return _completion(
+                    "First.",
+                    {"total_tokens": 5},
+                    response_id="resp_first",
+                )
             self.started.set()
             await self.release.wait()
             return _completion(
@@ -266,8 +266,11 @@ async def test_in_flight_call_preserves_most_recently_finished_source_usage():
                 response_id="resp_second",
             )
 
-    runtime = _BlockingRuntime()
-    source.runtime = runtime
+    runtime = _BlockingSecondRuntime()
+    source = Chat("Answer briefly.", runtime=runtime)
+    first = await source.chat_a("First?")
+    first_call = first.last_call_usage
+
     pending = asyncio.create_task(source.chat_a("Second?"))
     await runtime.started.wait()
 

--- a/tests/test_chatsnack_pattern.py
+++ b/tests/test_chatsnack_pattern.py
@@ -41,7 +41,11 @@ def test_set_response_filter():
     with pytest.raises(ValueError):
         chat.set_response_filter(pattern=test_pattern, prefix=test_prefix)
 
-@pytest.mark.skipif(os.environ.get("OPENAI_API_KEY") is None, reason="OPENAI_API_KEY is not set in environment or .env")
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY")
+    or os.environ.get("CHATSNACK_RUN_LIVE_TESTS", "").lower() not in {"1", "true", "yes"},
+    reason="Live OpenAI tests require OPENAI_API_KEY and CHATSNACK_RUN_LIVE_TESTS=1",
+)
 def test_ask_with_pattern():
     chat = Chat()
     chat.temperature = 0.0
@@ -60,7 +64,11 @@ def test_response_with_pattern():
     response = chat.response
     assert response == "POPSICLE"
 
-@pytest.mark.skipif(os.environ.get("OPENAI_API_KEY") is None, reason="OPENAI_API_KEY is not set in environment or .env")
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY")
+    or os.environ.get("CHATSNACK_RUN_LIVE_TESTS", "").lower() not in {"1", "true", "yes"},
+    reason="Live OpenAI tests require OPENAI_API_KEY and CHATSNACK_RUN_LIVE_TESTS=1",
+)
 def test_ask_without_pattern():
     chat = Chat()
     chat.temperature = 0.0

--- a/tests/test_chatsnack_reset.py
+++ b/tests/test_chatsnack_reset.py
@@ -53,7 +53,8 @@ def test_reset_empty_chat():
     # Check the chat messages after reset
     assert len(my_chat.get_messages()) == 0
 
-def test_reset_with_includes():
+def test_reset_with_includes(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHATSNACK_BASE_DIR", str(tmp_path))
     # Create a base chat and save it
     base_chat = Chat(name="BaseChat").user("What's your favorite color?")
     base_chat.save()

--- a/tests/test_file_snack_fillings.py
+++ b/tests/test_file_snack_fillings.py
@@ -81,7 +81,11 @@ def test_text_save2():
     assert os.path.exists(text.datafile.path)
 
 
-@pytest.mark.skipif(os.environ.get("OPENAI_API_KEY") is None, reason="OPENAI_API_KEY is not set in environment or .env")
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY")
+    or os.environ.get("CHATSNACK_RUN_LIVE_TESTS", "").lower() not in {"1", "true", "yes"},
+    reason="Live OpenAI tests require OPENAI_API_KEY and CHATSNACK_RUN_LIVE_TESTS=1",
+)
 def test_text_expansion():
     # we need a text object saved to disk
     text = Text(name="test_text_expansion", content="Respond only with 'YES' regardless of what is said.")
@@ -95,7 +99,11 @@ def test_text_expansion():
     # new chat object should have the text expanded in the system message
     assert output.system_message == "Respond only with 'YES' regardless of what is said."
 
-@pytest.mark.skipif(os.environ.get("OPENAI_API_KEY") is None, reason="OPENAI_API_KEY is not set in environment or .env")
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY")
+    or os.environ.get("CHATSNACK_RUN_LIVE_TESTS", "").lower() not in {"1", "true", "yes"},
+    reason="Live OpenAI tests require OPENAI_API_KEY and CHATSNACK_RUN_LIVE_TESTS=1",
+)
 def test_text_nested_expansion():
     # we need a text object saved to disk
     text = Text(name="test_text_expansion", content="Respond only with '{text.test_text_expansion2}' regardless of what is said.")
@@ -114,7 +122,11 @@ def test_text_nested_expansion():
     # new chat object should have the text expanded in the system message
     assert output.system_message == "Respond only with 'NO' regardless of what is said."
 
-@pytest.mark.skipif(os.environ.get("OPENAI_API_KEY") is None, reason="OPENAI_API_KEY is not set in environment or .env")
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY")
+    or os.environ.get("CHATSNACK_RUN_LIVE_TESTS", "").lower() not in {"1", "true", "yes"},
+    reason="Live OpenAI tests require OPENAI_API_KEY and CHATSNACK_RUN_LIVE_TESTS=1",
+)
 def test_text_chat_expansion():
     chat = Chat(name="test_text_chat_expansion")
     chat.system("Respond only with 'DUCK!' regardless of what is said.")

--- a/tests/test_live_openrouter.py
+++ b/tests/test_live_openrouter.py
@@ -1,0 +1,260 @@
+r"""Opt-in live Goals for Chatsnack's OpenRouter Responses workflow.
+
+Run from PowerShell with::
+
+    $env:CHATSNACK_RUN_OPENROUTER_LIVE = "1"
+    .\.venv\Scripts\python.exe -m pytest -q -m openrouter_live tests/test_live_openrouter.py
+
+The module reads ``.env.openrouter`` only after the explicit live flag is set.
+Shell environment variables take precedence over values in that file.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import secrets
+from pathlib import Path
+
+import pytest
+from dotenv import load_dotenv
+
+
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+_RUN_LIVE = (
+    os.environ.get("CHATSNACK_RUN_OPENROUTER_LIVE", "").strip().lower()
+    in _TRUE_VALUES
+)
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_MODEL = "z-ai/glm-5.3-flash"
+_API_KEY_ENV = "OPENROUTER_API_KEY"
+_API_BASE_ENV = "OPENROUTER_API_BASE"
+
+if _RUN_LIVE:
+    load_dotenv(_REPO_ROOT / ".env.openrouter", override=False)
+    _missing = [
+        name
+        for name in (_API_KEY_ENV, _API_BASE_ENV)
+        if not os.environ.get(name, "").strip()
+    ]
+    if _missing:
+        raise RuntimeError(
+            "OpenRouter live tests were enabled, but these environment variables "
+            f"are missing or blank: {', '.join(_missing)}"
+        )
+
+pytestmark = [
+    pytest.mark.openrouter_live,
+    pytest.mark.filterwarnings(
+        "ignore:Model 'z-ai/glm-5.3-flash' may not support reasoning options; "
+        "forwarding as authored.:UserWarning"
+    ),
+    pytest.mark.skipif(
+        not _RUN_LIVE,
+        reason=(
+            "Live OpenRouter tests require "
+            "CHATSNACK_RUN_OPENROUTER_LIVE=1"
+        ),
+    ),
+]
+
+# Capture the opt-in decision before importing chatsnack, whose normal startup
+# loads the ordinary .env file. A saved .env value must not enable paid tests.
+from chatsnack import Chat, ChatParams, utensil
+from chatsnack.runtime import ResponsesAdapter
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _close_sync_test_loop_workers():
+    """Release workers left on chatsnack's process-wide sync wrapper loop."""
+    yield
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        return
+    if loop.is_running() or loop.is_closed():
+        return
+    loop.run_until_complete(loop.shutdown_asyncgens())
+    loop.run_until_complete(loop.shutdown_default_executor())
+    loop.close()
+    asyncio.set_event_loop(None)
+
+
+def _required_env(name: str) -> str:
+    """Return one configuration value after the opt-in setup has validated it."""
+    return os.environ[name].strip()
+
+
+def _live_params() -> ChatParams:
+    """Build the bounded parameter set shared by live OpenRouter Goals."""
+    return ChatParams(
+        model=_MODEL,
+        base_url=_required_env(_API_BASE_ENV),
+        api_key_env=_API_KEY_ENV,
+        max_tokens=512,
+        temperature=0,
+        responses={"timeout": 60, "reasoning": {"effort": "low"}},
+    )
+
+
+def _live_chat(system: str, **kwargs) -> Chat:
+    """Build a dynamic Chat while leaving custom-endpoint runtime selection implicit."""
+    return Chat(system, params=_live_params(), **kwargs)
+
+
+def _label(prefix: str) -> str:
+    """Create a harmless per-request label that cannot come from a cached response."""
+    return f"{prefix.lower()}-{secrets.token_hex(3)}"
+
+
+def _close_sync(*chats: Chat | None) -> None:
+    """Close every sync Chat client opened by a live Goal."""
+    for chat in chats:
+        if chat is not None:
+            chat.close()
+
+
+async def _close_async(*chats: Chat | None) -> None:
+    """Close every async Chat client opened by a live Goal."""
+    for chat in chats:
+        if chat is not None:
+            await chat.close_a()
+
+
+def test_goal_or_live_1_named_yaml_chat_asks_and_replays_history(
+    tmp_path: Path,
+    monkeypatch,
+):
+    """A named OpenRouter asset keeps ordinary ask/chat behavior and local history."""
+    monkeypatch.setenv("CHATSNACK_BASE_DIR", str(tmp_path))
+    base_url = _required_env(_API_BASE_ENV)
+    asset_path = tmp_path / "OpenRouterLiveGoal.yml"
+    asset_path.write_text(
+        "\n".join(
+            (
+                "params:",
+                f"  model: {json.dumps(_MODEL)}",
+                "  max_tokens: 512",
+                "  temperature: 0",
+                f"  base_url: {json.dumps(base_url)}",
+                f"  api_key_env: {_API_KEY_ENV}",
+                "  responses:",
+                "    timeout: 60",
+                "    reasoning:",
+                "      effort: low",
+                "messages:",
+                "  - system: This is a text-copy integration test. Copy TESTLABEL values exactly.",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    chat = None
+    first = None
+    continued = None
+    ask_label = _label("snackask")
+    history_label = _label("snackhistory")
+    try:
+        chat = Chat(name="OpenRouterLiveGoal")
+        assert isinstance(chat.runtime, ResponsesAdapter)
+        assert chat.params.base_url == base_url
+        assert chat.params.api_key_env == _API_KEY_ENV
+
+        answer = chat.ask(f"Copy this TESTLABEL exactly: {ask_label}")
+        assert isinstance(answer, str)
+        assert ask_label in answer.lower()
+
+        first = chat.chat(
+            f"The TESTLABEL for this conversation is {history_label}. Reply with ACK."
+        )
+        continued = first.chat(
+            "Copy the TESTLABEL from my previous message. Reply with the label only."
+        )
+        assert history_label in (continued.last or "").lower()
+    finally:
+        _close_sync(continued, first, chat)
+
+
+def test_goal_or_live_2_sync_responses_sse_completes():
+    """A dynamic OpenRouter Chat streams and accumulates its complete response."""
+    label = _label("snacksync")
+    chat = _live_chat(
+        "Copy requested TESTLABEL values exactly with no explanation.",
+        stream=True,
+    )
+    try:
+        assert isinstance(chat.runtime, ResponsesAdapter)
+        listener = chat.listen(f"Copy this TESTLABEL exactly: {label}")
+        full_text = "".join(listener)
+
+        assert label in full_text.lower()
+        assert listener.is_complete
+        assert label in listener.response.lower()
+    finally:
+        _close_sync(chat)
+
+
+@pytest.mark.asyncio
+async def test_goal_or_live_3_async_responses_sse_completes():
+    """A dynamic OpenRouter Chat streams asynchronously and closes cleanly."""
+    label = _label("snackasync")
+    chat = _live_chat(
+        "Copy requested TESTLABEL values exactly with no explanation.",
+        stream=True,
+    )
+
+    async def consume():
+        listener = await chat.listen_a(f"Copy this TESTLABEL exactly: {label}")
+        full_text = "".join([chunk async for chunk in listener])
+        return listener, full_text
+
+    try:
+        assert isinstance(chat.runtime, ResponsesAdapter)
+        listener, full_text = await asyncio.wait_for(consume(), timeout=75)
+
+        assert label in full_text.lower()
+        assert listener.is_complete
+        assert label in listener.response.lower()
+    finally:
+        await _close_async(chat)
+
+
+def test_goal_or_live_4_local_utensil_executes_and_continues():
+    """OpenRouter calls a local utensil and receives its output for the final turn."""
+    result_label = _label("snacktool")
+    received_values: list[int] = []
+
+    @utensil(
+        name="openrouter_live_number",
+        description="Return the live-test label associated with an integer.",
+    )
+    def reveal_number(value: int) -> dict:
+        """Record the model's argument and return the test result label."""
+        received_values.append(value)
+        return {"label": result_label}
+
+    chat = _live_chat(
+        (
+            "Call the supplied function exactly once. After it succeeds, reply "
+            "with only the label value returned by the function."
+        ),
+        utensils=[reveal_number],
+        tool_choice="required",
+        auto_feed=1,
+    )
+    continued = None
+    try:
+        assert isinstance(chat.runtime, ResponsesAdapter)
+        continued = chat.chat("Call openrouter_live_number with value 7.")
+
+        assert received_values == [7]
+        assert result_label in (continued.last or "").lower()
+        assert any(
+            message.get("role") == "tool"
+            and result_label in str(message.get("content", "")).lower()
+            for message in continued.get_messages()
+        )
+    finally:
+        _close_sync(continued, chat)

--- a/tests/test_phase2_sessions.py
+++ b/tests/test_phase2_sessions.py
@@ -41,15 +41,18 @@ def test_constructor_kwargs_apply_model_and_session():
 def test_responses_runtime_with_inherit_selects_websocket_and_inherits_lineage(monkeypatch):
     chat = Chat(params=ChatParams(runtime="responses", session="inherit"))
     assert isinstance(chat.runtime, ResponsesWebSocketAdapter)
+    captured = {}
 
     async def fake_create_completion_a(self, messages, **kwargs):
+        captured["request_session"] = self.session
         return SimpleNamespace(message=SimpleNamespace(content="hello", tool_calls=[]), metadata={"response_id": "r1"})
 
     monkeypatch.setattr(ResponsesWebSocketAdapter, "create_completion_a", fake_create_completion_a)
     next_chat = chat.chat("hello")
 
     assert isinstance(next_chat.runtime, ResponsesWebSocketAdapter)
-    assert next_chat.runtime.session is chat.runtime.session
+    assert next_chat.runtime.session is captured["request_session"]
+    assert next_chat.runtime.session is not chat.runtime.session
 
 
 def test_responses_runtime_with_new_selects_websocket_and_descendants_get_new_session(monkeypatch):

--- a/tests/test_prompt_last.py
+++ b/tests/test_prompt_last.py
@@ -54,7 +54,11 @@ def test_message_order(empty_prompt):
 # def test_invalid_role(empty_prompt):
 #     with pytest.raises(Exception):
 #         empty_prompt.add_message("invalid_role", "Test content")
-@pytest.mark.skipif(os.environ.get("OPENAI_API_KEY") is None, reason="OPENAI_API_KEY is not set in environment or .env")
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY")
+    or os.environ.get("CHATSNACK_RUN_LIVE_TESTS", "").lower() not in {"1", "true", "yes"},
+    reason="Live OpenAI tests require OPENAI_API_KEY and CHATSNACK_RUN_LIVE_TESTS=1",
+)
 def test_chaining_methods_execution(populated_prompt):
     new_prompt = populated_prompt().user("How's the weather?")
     assert new_prompt.last == "How's the weather?"

--- a/tests/test_provider_client_binding.py
+++ b/tests/test_provider_client_binding.py
@@ -98,6 +98,8 @@ def test_authored_client_configuration_takes_precedence_over_legacy_environment(
 
     assert chat.ai.base_url == "https://authored.example/v1"
     assert chat.ai.api_key == "authored-sentinel"
+    assert str(chat.ai.client.base_url) == "https://authored.example/v1/"
+    chat.close()
 
 
 @pytest.mark.parametrize("legacy_key", ("api_base", "deployment", "api_type", "api_version"))

--- a/tests/test_provider_client_binding.py
+++ b/tests/test_provider_client_binding.py
@@ -446,6 +446,29 @@ def test_in_place_transport_change_fails_before_submit(monkeypatch, change):
         chat.ask("Do not submit this request.")
 
 
+@pytest.mark.parametrize("change", ("runtime", "session"))
+def test_copied_chat_transport_change_fails_before_submit(monkeypatch, change):
+    monkeypatch.setenv("COPIED_TRANSPORT_KEY", "provider-sentinel")
+    root = Chat(
+        base_url="https://copied-transport.example/v1",
+        api_key_env="COPIED_TRANSPORT_KEY",
+    )
+    copied = root.copy()
+
+    async def fail_if_submitted(*args, **kwargs):
+        pytest.fail("transport changes must fail before the provider request")
+
+    monkeypatch.setattr(ResponsesAdapter, "create_completion_a", fail_if_submitted)
+
+    if change == "runtime":
+        copied.params.runtime = "chat_completions"
+    else:
+        copied.session = "inherit"
+
+    with pytest.raises(ValueError, match="Provider and transport settings.*new Chat"):
+        copied.ask("Do not submit this request.")
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("change", ("runtime", "session"))
 async def test_continued_chat_transport_change_fails_before_submit(
@@ -474,6 +497,8 @@ async def test_continued_chat_transport_change_fails_before_submit(
     try:
         continued = await root.chat_a("Make the first request.")
         assert len(calls) == 1
+        continued.temperature = 0.4
+        assert root.temperature is None
 
         if change == "runtime":
             continued.params.runtime = "chat_completions"

--- a/tests/test_provider_client_binding.py
+++ b/tests/test_provider_client_binding.py
@@ -53,6 +53,53 @@ def test_missing_named_credential_fails_before_sdk_client_creation(monkeypatch):
         )
 
 
+@pytest.mark.parametrize(
+    "legacy_env",
+    ("OPENAI_AZURE_ENDPOINT", "OPENAI_API_BASE"),
+)
+@pytest.mark.parametrize("client_attr", ("client", "aclient"))
+def test_legacy_endpoint_environment_fails_closed_with_overlapping_openai_key(
+    monkeypatch,
+    legacy_env,
+    client_attr,
+):
+    monkeypatch.setenv("OPENAI_API_KEY", "overlapping-openai-sentinel")
+    monkeypatch.setenv(legacy_env, "https://legacy-provider.example/v1")
+    for other_env in {"OPENAI_AZURE_ENDPOINT", "OPENAI_API_BASE"} - {legacy_env}:
+        monkeypatch.delenv(other_env, raising=False)
+
+    chat = Chat()
+    assert chat.ai._client is None
+    assert chat.ai._aclient is None
+
+    with pytest.raises(ValueError) as exc_info:
+        getattr(chat.ai, client_attr)
+
+    message = str(exc_info.value)
+    assert legacy_env in message
+    assert "base_url" in message
+    assert "api_key_env" in message
+    assert "https://legacy-provider.example/v1" not in message
+    assert chat.ai._client is None
+    assert chat.ai._aclient is None
+
+
+def test_authored_client_configuration_takes_precedence_over_legacy_environment(
+    monkeypatch,
+):
+    monkeypatch.setenv("OPENAI_AZURE_ENDPOINT", "https://legacy-azure.example")
+    monkeypatch.setenv("OPENAI_API_BASE", "https://legacy-base.example/v1")
+    monkeypatch.setenv("AUTHORED_PROVIDER_KEY", "authored-sentinel")
+
+    chat = Chat(
+        base_url="https://authored.example/v1",
+        api_key_env="AUTHORED_PROVIDER_KEY",
+    )
+
+    assert chat.ai.base_url == "https://authored.example/v1"
+    assert chat.ai.api_key == "authored-sentinel"
+
+
 @pytest.mark.parametrize("legacy_key", ("api_base", "deployment", "api_type", "api_version"))
 def test_python_legacy_client_fields_are_unexpected_keywords(legacy_key):
     with pytest.raises(TypeError, match=rf"unexpected keyword argument '{legacy_key}'"):

--- a/tests/test_provider_client_binding.py
+++ b/tests/test_provider_client_binding.py
@@ -614,6 +614,32 @@ def test_copy_clones_the_resolved_binding_without_rereading_the_environment(monk
     assert child.runtime is not root.runtime
 
 
+@pytest.mark.parametrize("opened_client", ("client", "aclient"))
+def test_copy_keeps_the_ambient_key_resolved_by_an_opened_sdk_client(
+    monkeypatch,
+    opened_client,
+):
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    monkeypatch.delenv("OPENAI_AZURE_ENDPOINT", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "source-sentinel")
+    root = Chat(runtime="chat_completions")
+    child = None
+
+    try:
+        assert getattr(root.ai, opened_client).api_key == "source-sentinel"
+        monkeypatch.setenv("OPENAI_API_KEY", "rotated-sentinel")
+
+        child = root.copy()
+
+        assert child.ai is not root.ai
+        assert child.ai.api_key == "source-sentinel"
+        assert child.ai.client.api_key == "source-sentinel"
+    finally:
+        if child is not None:
+            child.close()
+        root.close()
+
+
 def test_transport_defaults_remain_configuration_driven(monkeypatch):
     monkeypatch.setenv("CUSTOM_PROVIDER_KEY", "provider-sentinel")
 

--- a/tests/test_provider_client_binding.py
+++ b/tests/test_provider_client_binding.py
@@ -1,0 +1,452 @@
+"""Focused Steers for per-Chat endpoint and credential binding."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from snapclass import SnapclassError
+
+from chatsnack import Chat, ChatParams
+from chatsnack.runtime import (
+    ChatCompletionsAdapter,
+    ResponsesAdapter,
+    ResponsesWebSocketAdapter,
+)
+
+
+@pytest.mark.parametrize(
+    "params",
+    (
+        ChatParams(base_url="https://example.test/v1"),
+        ChatParams(api_key_env="EXAMPLE_API_KEY"),
+        ChatParams(base_url="  ", api_key_env="EXAMPLE_API_KEY"),
+        ChatParams(base_url="https://example.test/v1", api_key_env="  "),
+    ),
+)
+def test_client_configuration_requires_nonblank_atomic_pair(params):
+    with pytest.raises(ValueError, match="base_url.*api_key_env.*together"):
+        Chat(params=params)
+
+
+def test_named_credential_is_resolved_when_chat_is_bound(monkeypatch):
+    monkeypatch.setenv("BOUND_PROVIDER_KEY", "provider-sentinel")
+
+    chat = Chat(
+        base_url=" https://example.test/v1/ ",
+        api_key_env=" BOUND_PROVIDER_KEY ",
+    )
+
+    assert chat.params.base_url == "https://example.test/v1/"
+    assert chat.params.api_key_env == "BOUND_PROVIDER_KEY"
+    assert chat.ai.api_key == "provider-sentinel"
+    assert isinstance(chat.runtime, ResponsesAdapter)
+
+
+def test_missing_named_credential_fails_before_sdk_client_creation(monkeypatch):
+    monkeypatch.delenv("MISSING_PROVIDER_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="MISSING_PROVIDER_KEY.*not set or is blank"):
+        Chat(
+            base_url="https://example.test/v1",
+            api_key_env="MISSING_PROVIDER_KEY",
+        )
+
+
+@pytest.mark.parametrize("legacy_key", ("api_base", "deployment", "api_type", "api_version"))
+def test_python_legacy_client_fields_are_unexpected_keywords(legacy_key):
+    with pytest.raises(TypeError, match=rf"unexpected keyword argument '{legacy_key}'"):
+        Chat(**{legacy_key: "legacy"})
+
+    with pytest.raises(TypeError, match=rf"unexpected keyword argument '{legacy_key}'"):
+        ChatParams(**{legacy_key: "legacy"})
+
+
+def test_yaml_legacy_fields_raise_one_migration_error(tmp_path):
+    path = tmp_path / "LegacyProvider.yml"
+    path.write_text(
+        """params:
+  model: deployment-name
+  api_base: https://legacy.example/openai
+  deployment: deployment-name
+  api_type: azure
+  api_version: 2024-10-21
+messages:
+  - user: Hello
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SnapclassError) as exc_info:
+        Chat().load(path)
+
+    message = str(exc_info.value)
+    assert "api_base, api_type, api_version, deployment" in message
+    assert "base_url" in message
+    assert "api_key_env" in message
+    assert "deployment name in model" in message
+
+
+def test_fresh_load_binds_named_credential_and_reset_keeps_it(tmp_path, monkeypatch):
+    path = tmp_path / "RebindProvider.yml"
+    monkeypatch.setenv("REBIND_PROVIDER_KEY", "saved-sentinel")
+    Chat(
+        name="RebindProvider",
+        base_url="https://saved.example/v1",
+        api_key_env="REBIND_PROVIDER_KEY",
+    ).save(path)
+
+    loaded = Chat()
+    loaded.load(path)
+    assert loaded.ai.api_key == "saved-sentinel"
+    assert isinstance(loaded.runtime, ResponsesAdapter)
+
+    monkeypatch.setenv("REBIND_PROVIDER_KEY", "reset-sentinel")
+    loaded.reset()
+    assert loaded.ai.api_key == "saved-sentinel"
+    assert isinstance(loaded.runtime, ResponsesAdapter)
+
+    fresh = Chat()
+    fresh.load(path)
+    assert fresh.ai.api_key == "reset-sentinel"
+
+
+@pytest.mark.asyncio
+async def test_reset_after_async_use_keeps_the_bound_client(monkeypatch):
+    monkeypatch.setenv("RESET_PROVIDER_KEY", "bound-sentinel")
+    chat = Chat(
+        base_url="https://reset.example/v1",
+        api_key_env="RESET_PROVIDER_KEY",
+    )
+    original_ai = chat.ai
+    original_runtime = chat.runtime
+    async_client = _AsyncCloseProbe()
+    chat.ai.aclient = async_client
+
+    monkeypatch.setenv("RESET_PROVIDER_KEY", "rotated-sentinel")
+    chat.reset()
+
+    assert chat.ai is original_ai
+    assert chat.runtime is original_runtime
+    assert chat.ai.api_key == "bound-sentinel"
+    assert async_client.closed is False
+    await chat.close_a()
+    assert async_client.closed is True
+
+
+def test_active_load_with_same_binding_keeps_client_and_runtime(tmp_path, monkeypatch):
+    monkeypatch.setenv("SAME_PROVIDER_KEY", "same-sentinel")
+    path = tmp_path / "SameProvider.yml"
+    Chat(
+        name="SameProvider",
+        model="updated-model",
+        base_url="https://same.example/v1",
+        api_key_env="SAME_PROVIDER_KEY",
+    ).user("Loaded history.").save(path)
+
+    active = Chat(
+        params=ChatParams(
+            model="original-model",
+            base_url="https://same.example/v1",
+            api_key_env="SAME_PROVIDER_KEY",
+        )
+    )
+    original_ai = active.ai
+    original_runtime = active.runtime
+
+    active.load(path)
+
+    assert active.ai is original_ai
+    assert active.runtime is original_runtime
+    assert active.model == "updated-model"
+    assert active.last == "Loaded history."
+
+
+def test_reset_starts_fresh_websocket_session_without_rebinding_client(monkeypatch):
+    monkeypatch.setenv("RESET_WS_KEY", "reset-ws-sentinel")
+    chat = Chat(
+        base_url="https://reset-ws.example/v1",
+        api_key_env="RESET_WS_KEY",
+        session="inherit",
+    )
+    original_ai = chat.ai
+    original_session = chat.runtime.session
+    original_session.last_response_id = "resp_old_conversation"
+
+    chat.reset()
+
+    assert chat.ai is original_ai
+    assert chat.runtime.session is not original_session
+    assert chat.runtime.session.last_response_id is None
+    request = chat.runtime._request_with_session(
+        [{"role": "user", "content": "Fresh local history."}],
+        {"model": "test-model", "store": True},
+    )
+    assert "previous_response_id" not in request
+
+
+def test_same_binding_load_starts_fresh_websocket_session(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOAD_WS_KEY", "load-ws-sentinel")
+    path = tmp_path / "LoadWebSocket.yml"
+    configured = Chat(
+        name="LoadWebSocket",
+        base_url="https://load-ws.example/v1",
+        api_key_env="LOAD_WS_KEY",
+        session="inherit",
+    )
+    configured.user("Loaded local history.").save(path)
+
+    active = Chat(
+        base_url="https://load-ws.example/v1",
+        api_key_env="LOAD_WS_KEY",
+        session="inherit",
+    )
+    original_ai = active.ai
+    original_session = active.runtime.session
+    original_session.last_response_id = "resp_old_conversation"
+
+    active.load(path)
+
+    assert active.ai is original_ai
+    assert active.runtime.session is not original_session
+    assert active.runtime.session.last_response_id is None
+    request = active.runtime._request_with_session(
+        [{"role": "user", "content": "Continue loaded local history."}],
+        {"model": "test-model", "store": True},
+    )
+    assert "previous_response_id" not in request
+
+
+def test_active_load_cannot_change_provider_binding(tmp_path, monkeypatch):
+    monkeypatch.setenv("FIRST_PROVIDER_KEY", "first-sentinel")
+    monkeypatch.setenv("SECOND_PROVIDER_KEY", "second-sentinel")
+    first_path = tmp_path / "FirstProvider.yml"
+    path = tmp_path / "SecondProvider.yml"
+    Chat(
+        name="FirstProvider",
+        base_url="https://first.example/v1",
+        api_key_env="FIRST_PROVIDER_KEY",
+    ).save(first_path)
+    Chat(
+        name="SecondProvider",
+        base_url="https://second.example/v1",
+        api_key_env="SECOND_PROVIDER_KEY",
+    ).save(path)
+
+    active = Chat()
+    active.load(first_path)
+    original_ai = active.ai
+
+    with pytest.raises(SnapclassError, match="new Chat"):
+        active.load(path)
+
+    active.reset()
+    assert active.ai is original_ai
+    assert active.params.base_url == "https://first.example/v1"
+    assert active.params.api_key_env == "FIRST_PROVIDER_KEY"
+    recovered = active.copy()
+    assert recovered.params.base_url == "https://first.example/v1"
+
+
+def test_active_load_cannot_change_transport_binding(tmp_path, monkeypatch):
+    monkeypatch.setenv("TRANSPORT_PROVIDER_KEY", "transport-sentinel")
+    responses_path = tmp_path / "ResponsesProvider.yml"
+    completions_path = tmp_path / "CompletionsProvider.yml"
+    Chat(
+        name="ResponsesProvider",
+        base_url="https://transport.example/v1",
+        api_key_env="TRANSPORT_PROVIDER_KEY",
+    ).save(responses_path)
+    Chat(
+        name="CompletionsProvider",
+        params=ChatParams(
+            base_url="https://transport.example/v1",
+            api_key_env="TRANSPORT_PROVIDER_KEY",
+            runtime="chat_completions",
+        ),
+    ).save(completions_path)
+
+    active = Chat()
+    active.load(responses_path)
+
+    with pytest.raises(SnapclassError, match="new Chat"):
+        active.load(completions_path)
+
+    active.reset()
+    assert isinstance(active.runtime, ResponsesAdapter)
+    assert isinstance(active.copy().runtime, ResponsesAdapter)
+
+
+def test_in_place_client_parameter_change_requires_a_new_chat(monkeypatch):
+    monkeypatch.setenv("BOUND_PROVIDER_KEY", "bound-sentinel")
+    monkeypatch.setenv("OTHER_PROVIDER_KEY", "other-sentinel")
+    chat = Chat(
+        base_url="https://bound.example/v1",
+        api_key_env="BOUND_PROVIDER_KEY",
+    )
+
+    chat.params.base_url = "https://other.example/v1"
+    chat.params.api_key_env = "OTHER_PROVIDER_KEY"
+
+    with pytest.raises(ValueError, match="new Chat"):
+        chat.copy()
+
+
+def test_authored_provider_binding_is_fixed_before_first_request(tmp_path, monkeypatch):
+    monkeypatch.setenv("FIRST_PROVIDER_KEY", "first-sentinel")
+    monkeypatch.setenv("SECOND_PROVIDER_KEY", "second-sentinel")
+    path = tmp_path / "SecondProvider.yml"
+    Chat(
+        name="SecondProvider",
+        base_url="https://second.example/v1",
+        api_key_env="SECOND_PROVIDER_KEY",
+    ).save(path)
+    chat = Chat(
+        params=ChatParams(
+            base_url="https://first.example/v1",
+            api_key_env="FIRST_PROVIDER_KEY",
+        )
+    )
+
+    with pytest.raises(SnapclassError, match="new Chat"):
+        chat.load(path)
+
+
+def test_copy_clones_the_resolved_binding_without_rereading_the_environment(monkeypatch):
+    monkeypatch.setenv("LINEAGE_PROVIDER_KEY", "lineage-sentinel")
+    root = Chat(
+        base_url="https://lineage.example/v1",
+        api_key_env="LINEAGE_PROVIDER_KEY",
+    )
+
+    monkeypatch.setenv("LINEAGE_PROVIDER_KEY", "rotated-sentinel")
+    child = root.copy()
+
+    assert child.ai is not root.ai
+    assert child.ai.api_key == "lineage-sentinel"
+    assert child.runtime is not root.runtime
+
+
+def test_transport_defaults_remain_configuration_driven(monkeypatch):
+    monkeypatch.setenv("CUSTOM_PROVIDER_KEY", "provider-sentinel")
+
+    default_openai = Chat()
+    custom = Chat(
+        base_url="https://custom.example/v1",
+        api_key_env="CUSTOM_PROVIDER_KEY",
+    )
+    completions = Chat(
+        base_url="https://custom.example/v1",
+        api_key_env="CUSTOM_PROVIDER_KEY",
+        runtime="chat_completions",
+    )
+
+    assert isinstance(default_openai.runtime, ResponsesWebSocketAdapter)
+    assert isinstance(custom.runtime, ResponsesAdapter)
+    assert isinstance(completions.runtime, ChatCompletionsAdapter)
+
+
+def test_yaml_round_trip_keeps_names_and_omits_secret(tmp_path, monkeypatch):
+    monkeypatch.setenv("ROUND_TRIP_PROVIDER_KEY", "private-sentinel-value")
+    path = tmp_path / "RoundTripProvider.yml"
+    Chat(
+        name="RoundTripProvider",
+        base_url="https://round-trip.example/v1",
+        api_key_env="ROUND_TRIP_PROVIDER_KEY",
+    ).save(path)
+
+    saved = path.read_text(encoding="utf-8")
+    loaded = Chat()
+    loaded.load(path)
+
+    assert "base_url: https://round-trip.example/v1" in saved
+    assert "api_key_env: ROUND_TRIP_PROVIDER_KEY" in saved
+    assert "private-sentinel-value" not in saved
+    assert loaded.params.base_url == "https://round-trip.example/v1"
+    assert loaded.params.api_key_env == "ROUND_TRIP_PROVIDER_KEY"
+
+
+class _SyncCloseProbe:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class _AsyncCloseProbe:
+    def __init__(self):
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_chat_close_a_closes_opened_sdk_clients():
+    chat = Chat(runtime="chat_completions")
+    sync_client = _SyncCloseProbe()
+    async_client = _AsyncCloseProbe()
+    chat.ai.client = sync_client
+    chat.ai.aclient = async_client
+
+    await chat.close_a()
+
+    assert sync_client.closed is True
+    assert async_client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_continuation_owns_the_websocket_session_that_made_its_request(
+    monkeypatch,
+):
+    root = Chat()
+    request_connection = _AsyncCloseProbe()
+    captured = {}
+
+    async def fake_create_completion_a(runtime, messages, **kwargs):
+        captured["session"] = runtime.session
+        runtime.session.async_connection = request_connection
+        runtime.session.last_response_id = "resp_request"
+        return SimpleNamespace(
+            message=SimpleNamespace(content="reply", tool_calls=[])
+        )
+
+    monkeypatch.setattr(
+        ResponsesWebSocketAdapter,
+        "create_completion_a",
+        fake_create_completion_a,
+    )
+
+    continued = await root.chat_a("hello")
+
+    assert continued.runtime.session is captured["session"]
+    await continued.close_a()
+    assert request_connection.closed is True
+    await root.close_a()
+
+
+@pytest.mark.asyncio
+async def test_ask_closes_its_temporary_websocket_request_session(monkeypatch):
+    root = Chat()
+    request_connection = _AsyncCloseProbe()
+    captured = {}
+
+    async def fake_create_completion_a(runtime, messages, **kwargs):
+        captured["session"] = runtime.session
+        runtime.session.async_connection = request_connection
+        return SimpleNamespace(
+            message=SimpleNamespace(content="reply", tool_calls=[])
+        )
+
+    monkeypatch.setattr(
+        ResponsesWebSocketAdapter,
+        "create_completion_a",
+        fake_create_completion_a,
+    )
+
+    assert await root.ask_a("hello") == "reply"
+
+    assert captured["session"] is not root.runtime.session
+    assert request_connection.closed is True
+    await root.close_a()

--- a/tests/test_provider_client_binding.py
+++ b/tests/test_provider_client_binding.py
@@ -446,6 +446,53 @@ def test_in_place_transport_change_fails_before_submit(monkeypatch, change):
         chat.ask("Do not submit this request.")
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("change", ("runtime", "session"))
+async def test_continued_chat_transport_change_fails_before_submit(
+    monkeypatch,
+    change,
+):
+    monkeypatch.setenv("CONTINUED_TRANSPORT_KEY", "provider-sentinel")
+    calls = []
+
+    async def fake_create_completion(runtime, messages, **kwargs):
+        calls.append((runtime, messages, kwargs))
+        return SimpleNamespace(
+            message=SimpleNamespace(content="first reply", tool_calls=[]),
+        )
+
+    monkeypatch.setattr(
+        ResponsesAdapter,
+        "create_completion_a",
+        fake_create_completion,
+    )
+    root = Chat(
+        base_url="https://continued-transport.example/v1",
+        api_key_env="CONTINUED_TRANSPORT_KEY",
+    )
+    continued = None
+    try:
+        continued = await root.chat_a("Make the first request.")
+        assert len(calls) == 1
+
+        if change == "runtime":
+            continued.params.runtime = "chat_completions"
+        else:
+            continued.session = "inherit"
+
+        with pytest.raises(
+            ValueError,
+            match="Provider and transport settings.*new Chat",
+        ):
+            await continued.ask_a("Do not submit this request.")
+
+        assert len(calls) == 1
+    finally:
+        if continued is not None:
+            await continued.close_a()
+        await root.close_a()
+
+
 def test_explicit_runtime_does_not_mask_later_param_change(monkeypatch):
     chat = Chat(runtime="responses")
 

--- a/tests/test_provider_client_binding.py
+++ b/tests/test_provider_client_binding.py
@@ -43,6 +43,67 @@ def test_named_credential_is_resolved_when_chat_is_bound(monkeypatch):
     assert isinstance(chat.runtime, ResponsesAdapter)
 
 
+def test_named_autoload_endpoint_overrides_preserve_saved_params(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("CHATSNACK_BASE_DIR", str(tmp_path))
+    monkeypatch.setenv("AUTOLOAD_PROVIDER_KEY", "provider-sentinel")
+    saved = Chat(
+        name="SavedProvider",
+        params=ChatParams(
+            model="saved-model",
+            temperature=0.42,
+            runtime="chat_completions",
+        ),
+    )
+    saved.system("Load this saved prompt.")
+    saved.save()
+
+    loaded = Chat(
+        name="SavedProvider",
+        model="override-model",
+        base_url="https://provider.example/v1",
+        api_key_env="AUTOLOAD_PROVIDER_KEY",
+    )
+
+    assert loaded.system_message == "Load this saved prompt."
+    assert loaded.model == "override-model"
+    assert loaded.temperature == 0.42
+    assert loaded.params.runtime == "chat_completions"
+    assert loaded.params.base_url == "https://provider.example/v1"
+    assert loaded.params.api_key_env == "AUTOLOAD_PROVIDER_KEY"
+    assert isinstance(loaded.runtime, ChatCompletionsAdapter)
+
+
+def test_named_new_chat_still_applies_endpoint_overrides(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHATSNACK_BASE_DIR", str(tmp_path))
+    monkeypatch.setenv("NEW_PROVIDER_KEY", "provider-sentinel")
+
+    chat = Chat(
+        name="NewProvider",
+        base_url="https://provider.example/v1",
+        api_key_env="NEW_PROVIDER_KEY",
+    )
+
+    assert chat.params.base_url == "https://provider.example/v1"
+    assert chat.params.api_key_env == "NEW_PROVIDER_KEY"
+    assert isinstance(chat.runtime, ResponsesAdapter)
+
+
+def test_mapping_client_params_default_custom_endpoint_to_responses_http(monkeypatch):
+    monkeypatch.setenv("MAPPING_PROVIDER_KEY", "provider-sentinel")
+
+    chat = Chat(
+        params={
+            "base_url": "https://provider.example/v1",
+            "api_key_env": "MAPPING_PROVIDER_KEY",
+        }
+    )
+
+    assert isinstance(chat.runtime, ResponsesAdapter)
+
+
 def test_missing_named_credential_fails_before_sdk_client_creation(monkeypatch):
     monkeypatch.delenv("MISSING_PROVIDER_KEY", raising=False)
 
@@ -339,6 +400,28 @@ def test_in_place_client_parameter_change_requires_a_new_chat(monkeypatch):
 
     with pytest.raises(ValueError, match="new Chat"):
         chat.copy()
+
+
+@pytest.mark.parametrize("change", ("runtime", "session"))
+def test_in_place_transport_change_fails_before_submit(monkeypatch, change):
+    monkeypatch.setenv("TRANSPORT_CHANGE_KEY", "provider-sentinel")
+    chat = Chat(
+        base_url="https://transport-change.example/v1",
+        api_key_env="TRANSPORT_CHANGE_KEY",
+    )
+
+    async def fail_if_submitted(*args, **kwargs):
+        pytest.fail("transport changes must fail before the provider request")
+
+    monkeypatch.setattr(ResponsesAdapter, "create_completion_a", fail_if_submitted)
+
+    if change == "runtime":
+        chat.params.runtime = "chat_completions"
+    else:
+        chat.session = "inherit"
+
+    with pytest.raises(ValueError, match="Provider and transport settings.*new Chat"):
+        chat.ask("Do not submit this request.")
 
 
 def test_authored_provider_binding_is_fixed_before_first_request(tmp_path, monkeypatch):

--- a/tests/test_provider_client_binding.py
+++ b/tests/test_provider_client_binding.py
@@ -469,6 +469,29 @@ def test_copied_chat_transport_change_fails_before_submit(monkeypatch, change):
         copied.ask("Do not submit this request.")
 
 
+def test_copy_rebuilds_an_authored_builtin_runtime_for_the_child(monkeypatch):
+    calls = []
+
+    async def fake_create_completion(runtime, messages, **kwargs):
+        calls.append((runtime, messages, kwargs))
+        return SimpleNamespace(
+            message=SimpleNamespace(content="copied reply", tool_calls=[]),
+        )
+
+    monkeypatch.setattr(ResponsesAdapter, "create_completion_a", fake_create_completion)
+    root = Chat(runtime=ResponsesAdapter(SimpleNamespace()))
+    copied = root.copy()
+
+    try:
+        assert copied.ai is not root.ai
+        assert copied.runtime.ai_client is copied.ai
+        assert copied.ask("Use the copied runtime.") == "copied reply"
+        assert len(calls) == 1
+    finally:
+        copied.close()
+        root.close()
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("change", ("runtime", "session"))
 async def test_continued_chat_transport_change_fails_before_submit(

--- a/tests/test_provider_client_binding.py
+++ b/tests/test_provider_client_binding.py
@@ -615,25 +615,31 @@ def test_copy_clones_the_resolved_binding_without_rereading_the_environment(monk
 
 
 @pytest.mark.parametrize("opened_client", ("client", "aclient"))
-def test_copy_keeps_the_ambient_key_resolved_by_an_opened_sdk_client(
+def test_copy_keeps_ambient_settings_resolved_by_an_opened_sdk_client(
     monkeypatch,
     opened_client,
 ):
     monkeypatch.delenv("OPENAI_API_BASE", raising=False)
     monkeypatch.delenv("OPENAI_AZURE_ENDPOINT", raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "source-sentinel")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://source.example/v1")
     root = Chat(runtime="chat_completions")
     child = None
 
     try:
-        assert getattr(root.ai, opened_client).api_key == "source-sentinel"
+        source_client = getattr(root.ai, opened_client)
+        assert source_client.api_key == "source-sentinel"
+        assert str(source_client.base_url) == "https://source.example/v1/"
         monkeypatch.setenv("OPENAI_API_KEY", "rotated-sentinel")
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://rotated.example/v1")
 
         child = root.copy()
 
         assert child.ai is not root.ai
+        assert child.params.base_url is None
         assert child.ai.api_key == "source-sentinel"
         assert child.ai.client.api_key == "source-sentinel"
+        assert str(child.ai.client.base_url) == "https://source.example/v1/"
     finally:
         if child is not None:
             child.close()

--- a/tests/test_provider_client_binding.py
+++ b/tests/test_provider_client_binding.py
@@ -91,17 +91,39 @@ def test_named_new_chat_still_applies_endpoint_overrides(tmp_path, monkeypatch):
     assert isinstance(chat.runtime, ResponsesAdapter)
 
 
-def test_mapping_client_params_default_custom_endpoint_to_responses_http(monkeypatch):
+def test_mapping_client_params_run_custom_endpoint_request(monkeypatch):
     monkeypatch.setenv("MAPPING_PROVIDER_KEY", "provider-sentinel")
+    captured = {}
+
+    async def fake_create_completion_a(self, messages, **kwargs):
+        captured["messages"] = messages
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(
+            message=SimpleNamespace(content="mapping-reply", tool_calls=[])
+        )
+
+    monkeypatch.setattr(
+        ResponsesAdapter,
+        "create_completion_a",
+        fake_create_completion_a,
+    )
 
     chat = Chat(
         params={
+            "model": "provider/model",
             "base_url": "https://provider.example/v1",
             "api_key_env": "MAPPING_PROVIDER_KEY",
         }
     )
 
+    assert isinstance(chat.params, ChatParams)
     assert isinstance(chat.runtime, ResponsesAdapter)
+    assert chat.ask("Prove the mapping request ran.") == "mapping-reply"
+    assert captured["messages"][-1] == {
+        "role": "user",
+        "content": "Prove the mapping request ran.",
+    }
+    assert captured["kwargs"]["model"] == "provider/model"
 
 
 def test_missing_named_credential_fails_before_sdk_client_creation(monkeypatch):
@@ -419,6 +441,67 @@ def test_in_place_transport_change_fails_before_submit(monkeypatch, change):
         chat.params.runtime = "chat_completions"
     else:
         chat.session = "inherit"
+
+    with pytest.raises(ValueError, match="Provider and transport settings.*new Chat"):
+        chat.ask("Do not submit this request.")
+
+
+def test_explicit_runtime_does_not_mask_later_param_change(monkeypatch):
+    chat = Chat(runtime="responses")
+
+    async def fail_if_submitted(*args, **kwargs):
+        pytest.fail("transport changes must fail before the provider request")
+
+    monkeypatch.setattr(ResponsesAdapter, "create_completion_a", fail_if_submitted)
+    chat.params.runtime = "chat_completions"
+
+    with pytest.raises(ValueError, match="Provider and transport settings.*new Chat"):
+        chat.ask("Do not submit this request.")
+
+
+@pytest.mark.parametrize(
+    "change",
+    ("runtime_family", "runtime_client", "websocket_mode"),
+)
+def test_installed_transport_change_fails_before_submit(monkeypatch, change):
+    monkeypatch.setenv("INSTALLED_TRANSPORT_KEY", "provider-sentinel")
+
+    async def fail_if_submitted(*args, **kwargs):
+        pytest.fail("installed transport changes must fail before the provider request")
+
+    monkeypatch.setattr(
+        ResponsesAdapter,
+        "create_completion_a",
+        fail_if_submitted,
+    )
+    monkeypatch.setattr(
+        ChatCompletionsAdapter,
+        "create_completion_a",
+        fail_if_submitted,
+    )
+    monkeypatch.setattr(
+        ResponsesWebSocketAdapter,
+        "create_completion_a",
+        fail_if_submitted,
+    )
+
+    if change in {"runtime_family", "runtime_client"}:
+        chat = Chat(
+            base_url="https://installed-transport.example/v1",
+            api_key_env="INSTALLED_TRANSPORT_KEY",
+        )
+        chat.runtime = (
+            ChatCompletionsAdapter(chat.ai)
+            if change == "runtime_family"
+            else ResponsesAdapter(SimpleNamespace())
+        )
+    else:
+        chat = Chat(
+            base_url="https://installed-transport.example/v1",
+            api_key_env="INSTALLED_TRANSPORT_KEY",
+            session="inherit",
+        )
+        chat.runtime.session.mode = "new"
 
     with pytest.raises(ValueError, match="Provider and transport settings.*new Chat"):
         chat.ask("Do not submit this request.")

--- a/tests/test_responses_continuation.py
+++ b/tests/test_responses_continuation.py
@@ -231,8 +231,9 @@ class TestHTTPResponsesToolFollowUp:
 # ═══════════════════════════════════════════════════════════════════════
 
 @pytest.mark.skipif(
-    os.environ.get("OPENAI_API_KEY") is None,
-    reason="OPENAI_API_KEY is not set",
+    not os.environ.get("OPENAI_API_KEY")
+    or os.environ.get("CHATSNACK_RUN_LIVE_TESTS", "").lower() not in {"1", "true", "yes"},
+    reason="Live OpenAI tests require OPENAI_API_KEY and CHATSNACK_RUN_LIVE_TESTS=1",
 )
 class TestLiveHTTPResponsesToolLoop:
 

--- a/tests/test_snackpack_base.py
+++ b/tests/test_snackpack_base.py
@@ -3,7 +3,11 @@ import pytest
 from chatsnack.packs import Jane as chat
 
 
-@pytest.mark.skipif(os.environ.get("OPENAI_API_KEY") is None, reason="OPENAI_API_KEY is not set in environment or .env")
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY")
+    or os.environ.get("CHATSNACK_RUN_LIVE_TESTS", "").lower() not in {"1", "true", "yes"},
+    reason="Live OpenAI tests require OPENAI_API_KEY and CHATSNACK_RUN_LIVE_TESTS=1",
+)
 def test_snackpack_chat():
     cp = chat.user("Or is green a form of blue?")
     assert cp.last == "Or is green a form of blue?"
@@ -15,7 +19,11 @@ def test_snackpack_chat():
     assert len(output) > 0
 
 
-@pytest.mark.skipif(os.environ.get("OPENAI_API_KEY") is None, reason="OPENAI_API_KEY is not set in environment or .env")
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY")
+    or os.environ.get("CHATSNACK_RUN_LIVE_TESTS", "").lower() not in {"1", "true", "yes"},
+    reason="Live OpenAI tests require OPENAI_API_KEY and CHATSNACK_RUN_LIVE_TESTS=1",
+)
 def test_snackpack_ask_with_existing_asst():
     cp = chat.copy()
     cp.user("Is the sky blue?")

--- a/tests/test_utensils.py
+++ b/tests/test_utensils.py
@@ -17,8 +17,11 @@ TOOL_COMPATIBLE_ENGINES = [
 ]
 
 @pytest.mark.parametrize("engine", TOOL_COMPATIBLE_ENGINES)
-@pytest.mark.skipif(os.environ.get("OPENAI_API_KEY") is None, 
-                    reason="OPENAI_API_KEY is not set in environment or .env")
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY")
+    or os.environ.get("CHATSNACK_RUN_LIVE_TESTS", "").lower() not in {"1", "true", "yes"},
+    reason="Live OpenAI tests require OPENAI_API_KEY and CHATSNACK_RUN_LIVE_TESTS=1",
+)
 def test_engine_tool_calls(engine):
     """Test that each compatible engine can properly make tool calls."""
     # Define test-local utensil
@@ -370,8 +373,11 @@ def test_utensil_group_local_registry():
 
 
 @pytest.mark.parametrize("engine", TOOL_COMPATIBLE_ENGINES)
-@pytest.mark.skipif(os.environ.get("OPENAI_API_KEY") is None, 
-                    reason="OPENAI_API_KEY is not set in environment or .env")
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY")
+    or os.environ.get("CHATSNACK_RUN_LIVE_TESTS", "").lower() not in {"1", "true", "yes"},
+    reason="Live OpenAI tests require OPENAI_API_KEY and CHATSNACK_RUN_LIVE_TESTS=1",
+)
 def test_engine_tool_calls_local_registry(engine):
     """Test that each compatible engine can properly make tool calls using a local utensil group registry."""
     # Create a unique local utensil group
@@ -477,8 +483,11 @@ def test_auto_feed_initialization():
 
 # === Test 8: Execution Without Feeding Tool Results ===
 @pytest.mark.parametrize("engine", TOOL_COMPATIBLE_ENGINES[:1])  # Use just the first engine for this test
-@pytest.mark.skipif(os.environ.get("OPENAI_API_KEY") is None, 
-                    reason="OPENAI_API_KEY is not set in environment or .env")
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY")
+    or os.environ.get("CHATSNACK_RUN_LIVE_TESTS", "").lower() not in {"1", "true", "yes"},
+    reason="Live OpenAI tests require OPENAI_API_KEY and CHATSNACK_RUN_LIVE_TESTS=1",
+)
 def test_auto_execute_without_auto_feed(engine):
     """Test that tools execute but don't feed results back to the engine when auto_execute=True and auto_feed=False."""
     
@@ -550,8 +559,11 @@ def test_auto_execute_without_auto_feed(engine):
 
 # === Test 9: Comparing Behavior with auto_feed True vs False ===
 @pytest.mark.parametrize("engine", TOOL_COMPATIBLE_ENGINES[:1])  # Use just the first engine to save time
-@pytest.mark.skipif(os.environ.get("OPENAI_API_KEY") is None, 
-                    reason="OPENAI_API_KEY is not set in environment or .env")
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY")
+    or os.environ.get("CHATSNACK_RUN_LIVE_TESTS", "").lower() not in {"1", "true", "yes"},
+    reason="Live OpenAI tests require OPENAI_API_KEY and CHATSNACK_RUN_LIVE_TESTS=1",
+)
 def test_auto_feed_behavior_comparison(engine):
     """Compare behavior with auto_feed True vs False."""
     


### PR DESCRIPTION
## Summary

- add per-Chat `base_url` and `api_key_env` configuration for OpenRouter, Azure v1, and other OpenAI-compatible endpoints
- keep provider credentials fixed for a Chat conversation while preserving ordinary YAML -> `Chat` -> `.ask()` / `.chat()` usage
- document the provider path in a dedicated OpenAI-compatible providers guide, led by a named YAML Chat with constructor configuration retained for dynamic applications
- use ordinary OpenAI clients for modern Azure v1 and Responses HTTP/SSE for custom endpoints
- remove legacy Azure client fields and fail closed on legacy endpoint environment variables
- require `openai>=3.5.0,<4.0.0`
- add explicit paid-test gates and four opt-in live OpenRouter Goals using `z-ai/glm-5.3-flash`

This provides the Chatsnack side of Snackplatter's mixed OpenAI/OpenRouter workflow without adding a provider registry or hostname detection.

## Binding and lifecycle behavior

- endpoint and key-variable name bind when a Chat is created or first loaded
- continuations retain the client/session that performed the request
- ordinary copies clone the already-resolved credential and endpoint binding without writing ambient SDK values into YAML
- a caller-authored built-in runtime is rebuilt around the copied Chat's own client
- `reset()` and same-binding loads keep the provider client while starting fresh WebSocket conversation state
- changing endpoint, credential variable, or transport on an active Chat requires a new Chat

## Parameter behavior

- caller-authored provider options remain intact for model aliases and deployment names
- `temperature` is forwarded without deriving a blanket warning from the reasoning-model table
- client-only fields are stripped before provider request assembly

## Breaking changes

- remove `api_base`, `api_type`, `api_version`, and `deployment`
- reject `OPENAI_AZURE_ENDPOINT` and `OPENAI_API_BASE` before an unconfigured client can silently route through ordinary OpenAI; use per-Chat configuration or the SDK-standard `OPENAI_BASE_URL`
- Azure v1 uses the complete `/openai/v1/` base URL and deployment name in `model`
- OpenAI Python SDK 3.5.0 is the new floor

## Verification

- complete offline suite at `cfec813`: `681 passed, 115 skipped`
- final affected suites after `c7dae2f`: `93 passed, 11 skipped`
- a subsequent complete-suite attempt exposed nine identical failures from a removed shared `warnings` import; the import was restored and every affected area passed, though the entire suite was not rerun after that import-only repair
- live OpenRouter Goal suite: `4 passed` during provider verification
- strict MkDocs build passed after moving provider setup into the dedicated guide
- Poetry lock validation passed
- `pip check` reported no broken requirements
- Chatsnack 0.8.0 wheel and source distribution built successfully
- notebook JSON and `git diff --check` passed

## Scope notes

- Azure behavior is covered through the real SDK against loopback contract tests; no live Azure credentials were available
- Entra authentication remains outside this release
- the review-driven lifecycle fixes remain private implementation details; the public path stays named YAML or `Chat(...)` followed by `.ask()` / `.chat()`
- a narrow pre-existing cleanup edge after an exception in post-response tool processing remains a follow-up; the reviewed provider-binding paths have no known blocker