### PR TITLE
Resolve known fillings through Chatsnack's main engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,8 @@ explosions.ask("What is your name?")
 
 If you have a prompt that requires expanding multiple fillings, `chatsnack` will resolve them in parallel as it expands the prompt. This comes in handy with `{chat.__}` and `{vectorsearch.__}` (TODO) snack fillings.
 
-TODO: See the notebooks for more details on this.
+See the [Fillings and Composition guide](docs/guides/fillings.md) for reusable
+text, saved chats, and direct filling resolution.
 
 ## License
 

--- a/chatsnack/__init__.py
+++ b/chatsnack/__init__.py
@@ -98,18 +98,14 @@ from .utensil import utensil, get_all_utensils, get_openai_tools, UtensilGroup, 
 from .runtime import ApplyPatchCall, CallUsage, ResponseUsage, UsageCounts
 
 from .fillings import (
-    ChatsnackFillingSource,
     FillingAuthorityError,
-    FillingCycleError,
     FillingError,
     FillingLimitError,
-    FillingLimits,
-    FillingResolution,
-    FillingResolutionError,
-    FillingSource,
     active_filling_stash,
+    bounded_filling_expansion,
     filling_machine,
-    resolve_fillings,
+    filling_resolution_active,
+    missing_filling,
     resolve_fillings_a,
     snack_catalog,
 )
@@ -117,18 +113,48 @@ from .fillings import (
 
 async def _text_name_expansion(text_name: str, additional: Optional[dict] = None) -> str:
     stash = active_filling_stash.get()
-    prompt = Text.objects(stash).get(text_name) if stash is not None else Text.objects.get(text_name)
-    result = await aformatter.async_format(prompt.content, **filling_machine(additional))
-    return result
+    objects = Text.objects(stash) if stash is not None else Text.objects
+
+    if not filling_resolution_active():
+        prompt = objects.get(text_name)
+        return await aformatter.async_format(
+            prompt.content,
+            **filling_machine(additional),
+        )
+
+    reference = f"text.{text_name}"
+
+    async def expand() -> str:
+        prompt = objects.get_or_none(text_name)
+        if prompt is None:
+            raise missing_filling(reference)
+        return await aformatter.async_format(
+            prompt.content,
+            **filling_machine(additional),
+        )
+
+    return await bounded_filling_expansion(reference, expand)
 
 # accepts a petition name as a string and calls petition_completion2, returning only the completion text
 async def _chat_name_query_expansion(prompt_name: str, additional: Optional[dict] = None) -> str:
     stash = active_filling_stash.get()
-    chatprompt = Chat.objects(stash).get_or_none(prompt_name) if stash is not None else Chat.objects.get_or_none(prompt_name)
-    if chatprompt is None:
-        raise Exception(f"Prompt {prompt_name} not found")
-    text = await chatprompt.ask_a(**additional)
-    return text
+    objects = Chat.objects(stash) if stash is not None else Chat.objects
+
+    if not filling_resolution_active():
+        chatprompt = objects.get_or_none(prompt_name)
+        if chatprompt is None:
+            raise Exception(f"Prompt {prompt_name} not found")
+        return await chatprompt.ask_a(**additional)
+
+    reference = f"chat.{prompt_name}"
+
+    async def expand() -> str:
+        chatprompt = objects.get_or_none(prompt_name)
+        if chatprompt is None:
+            raise missing_filling(reference)
+        return await chatprompt.ask_a(**additional)
+
+    return await bounded_filling_expansion(reference, expand, is_chat=True)
 
 
 # default snack vendors

--- a/chatsnack/__init__.py
+++ b/chatsnack/__init__.py
@@ -128,9 +128,9 @@ async def _text_name_expansion(text_name: str, additional: Optional[dict] = None
         prompt = objects.get_or_none(text_name)
         if prompt is None:
             raise _missing_filling(reference)
-        return await aformatter.async_format(
+        return await aformatter.async_format_mapping(
             prompt.content,
-            **filling_machine(additional),
+            filling_machine(additional),
         )
 
     return await expand()

--- a/chatsnack/__init__.py
+++ b/chatsnack/__init__.py
@@ -104,6 +104,7 @@ from .fillings import (
     active_filling_stash,
     _filling_resolution_active,
     _missing_filling,
+    _reserve_chat_filling_call,
     filling_machine,
     resolve_fillings_a,
     snack_catalog,
@@ -151,9 +152,15 @@ async def _chat_name_query_expansion(prompt_name: str, additional: Optional[dict
         chatprompt = objects.get_or_none(prompt_name)
         if chatprompt is None:
             raise _missing_filling(reference)
+        _reserve_chat_filling_call(reference)
         return await chatprompt._ask_a_with_template_vars(additional)
 
     return await expand()
+
+
+# The built-in Chat callback can check existence before reserving model work.
+# Replacement callbacks remain bounded before dispatch at the catalog boundary.
+_chat_name_query_expansion._chatsnack_reserves_chat_after_lookup = True
 
 
 # default snack vendors

--- a/chatsnack/__init__.py
+++ b/chatsnack/__init__.py
@@ -151,7 +151,7 @@ async def _chat_name_query_expansion(prompt_name: str, additional: Optional[dict
         chatprompt = objects.get_or_none(prompt_name)
         if chatprompt is None:
             raise _missing_filling(reference)
-        return await chatprompt.ask_a(**additional)
+        return await chatprompt._ask_a_with_template_vars(additional)
 
     return await expand()
 

--- a/chatsnack/__init__.py
+++ b/chatsnack/__init__.py
@@ -102,10 +102,9 @@ from .fillings import (
     FillingError,
     FillingLimitError,
     active_filling_stash,
-    bounded_filling_expansion,
+    _filling_resolution_active,
+    _missing_filling,
     filling_machine,
-    filling_resolution_active,
-    missing_filling,
     resolve_fillings_a,
     snack_catalog,
 )
@@ -115,7 +114,7 @@ async def _text_name_expansion(text_name: str, additional: Optional[dict] = None
     stash = active_filling_stash.get()
     objects = Text.objects(stash) if stash is not None else Text.objects
 
-    if not filling_resolution_active():
+    if not _filling_resolution_active():
         prompt = objects.get(text_name)
         return await aformatter.async_format(
             prompt.content,
@@ -127,20 +126,20 @@ async def _text_name_expansion(text_name: str, additional: Optional[dict] = None
     async def expand() -> str:
         prompt = objects.get_or_none(text_name)
         if prompt is None:
-            raise missing_filling(reference)
+            raise _missing_filling(reference)
         return await aformatter.async_format(
             prompt.content,
             **filling_machine(additional),
         )
 
-    return await bounded_filling_expansion(reference, expand)
+    return await expand()
 
 # accepts a petition name as a string and calls petition_completion2, returning only the completion text
 async def _chat_name_query_expansion(prompt_name: str, additional: Optional[dict] = None) -> str:
     stash = active_filling_stash.get()
     objects = Chat.objects(stash) if stash is not None else Chat.objects
 
-    if not filling_resolution_active():
+    if not _filling_resolution_active():
         chatprompt = objects.get_or_none(prompt_name)
         if chatprompt is None:
             raise Exception(f"Prompt {prompt_name} not found")
@@ -151,10 +150,10 @@ async def _chat_name_query_expansion(prompt_name: str, additional: Optional[dict
     async def expand() -> str:
         chatprompt = objects.get_or_none(prompt_name)
         if chatprompt is None:
-            raise missing_filling(reference)
+            raise _missing_filling(reference)
         return await chatprompt.ask_a(**additional)
 
-    return await bounded_filling_expansion(reference, expand, is_chat=True)
+    return await expand()
 
 
 # default snack vendors

--- a/chatsnack/__init__.py
+++ b/chatsnack/__init__.py
@@ -97,7 +97,22 @@ from . import packs
 from .utensil import utensil, get_all_utensils, get_openai_tools, UtensilGroup, HostedUtensil
 from .runtime import ApplyPatchCall, CallUsage, ResponseUsage, UsageCounts
 
-from .fillings import active_filling_stash, snack_catalog, filling_machine
+from .fillings import (
+    ChatsnackFillingSource,
+    FillingAuthorityError,
+    FillingCycleError,
+    FillingError,
+    FillingLimitError,
+    FillingLimits,
+    FillingResolution,
+    FillingResolutionError,
+    FillingSource,
+    active_filling_stash,
+    filling_machine,
+    resolve_fillings,
+    resolve_fillings_a,
+    snack_catalog,
+)
 
 
 async def _text_name_expansion(text_name: str, additional: Optional[dict] = None) -> str:

--- a/chatsnack/asynchelpers.py
+++ b/chatsnack/asynchelpers.py
@@ -41,12 +41,17 @@ class _AsyncFormatter(string.Formatter):
         return value
 
     async def async_format(self, format_string, *args, **kwargs):
+        return await self.async_format_mapping(format_string, kwargs, args)
+
+    async def async_format_mapping(self, format_string, variables, args=()):
+        """Format with variables passed as data instead of method keywords."""
+
         coros = []
         parsed_format = list(self.parse(format_string))
 
         for literal_text, field_name, format_spec, conversion in parsed_format:
             if field_name:
-                coro = self.async_expand_field(field_name, args, kwargs)
+                coro = self.async_expand_field(field_name, args, variables)
                 coros.append(coro)
 
         expanded_fields = await _gather_cancel_on_error(*coros)

--- a/chatsnack/asynchelpers.py
+++ b/chatsnack/asynchelpers.py
@@ -24,6 +24,13 @@ class _AsyncFormatter(string.Formatter):
             obj, method = field.split(".", 1)
             if obj in kwargs:
                 obj_instance = kwargs[obj]
+                field_resolver = getattr(
+                    type(obj_instance),
+                    "_chatsnack_expand_field",
+                    None,
+                )
+                if field_resolver is not None:
+                    return await field_resolver(obj_instance, method)
                 if hasattr(obj_instance, method):
                     method_instance = getattr(obj_instance, method)
                     if asyncio.iscoroutinefunction(method_instance):

--- a/chatsnack/asynchelpers.py
+++ b/chatsnack/asynchelpers.py
@@ -3,6 +3,21 @@ import string
 
 from loguru import logger
 
+
+async def _gather_cancel_on_error(*awaitables):
+    """Gather concurrent work without letting siblings outlive a failure."""
+
+    tasks = [asyncio.ensure_future(awaitable) for awaitable in awaitables]
+    try:
+        return await asyncio.gather(*tasks)
+    except BaseException:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
+
+
 class _AsyncFormatter(string.Formatter):
     async def async_expand_field(self, field, args, kwargs):
         if "." in field:
@@ -27,7 +42,7 @@ class _AsyncFormatter(string.Formatter):
                 coro = self.async_expand_field(field_name, args, kwargs)
                 coros.append(coro)
 
-        expanded_fields = await asyncio.gather(*coros)
+        expanded_fields = await _gather_cancel_on_error(*coros)
         expanded_iter = iter(expanded_fields)
 
         return ''.join([

--- a/chatsnack/asynchelpers.py
+++ b/chatsnack/asynchelpers.py
@@ -41,10 +41,31 @@ class _AsyncFormatter(string.Formatter):
         return value
 
     async def async_format(self, format_string, *args, **kwargs):
-        return await self.async_format_mapping(format_string, kwargs, args)
+        return await self._async_format_fields(
+            format_string,
+            kwargs,
+            args,
+            asyncio.gather,
+        )
 
     async def async_format_mapping(self, format_string, variables, args=()):
         """Format with variables passed as data instead of method keywords."""
+
+        return await self._async_format_fields(
+            format_string,
+            variables,
+            args,
+            _gather_cancel_on_error,
+        )
+
+    async def _async_format_fields(
+        self,
+        format_string,
+        variables,
+        args,
+        gather_fields,
+    ):
+        """Format fields with the sibling-failure policy chosen by the caller."""
 
         coros = []
         parsed_format = list(self.parse(format_string))
@@ -54,7 +75,7 @@ class _AsyncFormatter(string.Formatter):
                 coro = self.async_expand_field(field_name, args, variables)
                 coros.append(coro)
 
-        expanded_fields = await _gather_cancel_on_error(*coros)
+        expanded_fields = await gather_fields(*coros)
         expanded_iter = iter(expanded_fields)
 
         return ''.join([

--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -453,10 +453,28 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         async def format_mapping(value, variables):
             return await format_coro(value, **variables)
 
-        return await self._gather_format_mapping(format_mapping, kwargs)
+        return await self._gather_formatted_messages(
+            format_mapping,
+            kwargs,
+            asyncio.gather,
+        )
 
     async def _gather_format_mapping(self, format_coro, format_vars) -> str:
         """Format every message while keeping variables in a positional map."""
+
+        return await self._gather_formatted_messages(
+            format_coro,
+            format_vars,
+            _gather_cancel_on_error,
+        )
+
+    async def _gather_formatted_messages(
+        self,
+        format_coro,
+        format_vars,
+        gather_messages,
+    ) -> str:
+        """Format messages with the sibling-failure policy chosen by the caller."""
 
         new_messages = self.get_messages()
         # TODO: Allow format messages in the tool calls
@@ -490,7 +508,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
             coros.append(format_key(message))
             coros.append(format_message(message))
         # gather the results
-        await _gather_cancel_on_error(*coros)
+        await gather_messages(*coros)
         logger.trace(new_messages)
         
         # if the current model is a reasoning model, we need the role of "system" to become "developer" in the json dump messages

--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -450,6 +450,14 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
 
     # async method that gathers will execute an async format method on every message in the chat prompt and gather the results into a final json string
     async def _gather_format(self, format_coro, **kwargs) -> str:
+        async def format_mapping(value, variables):
+            return await format_coro(value, **variables)
+
+        return await self._gather_format_mapping(format_mapping, kwargs)
+
+    async def _gather_format_mapping(self, format_coro, format_vars) -> str:
+        """Format every message while keeping variables in a positional map."""
+
         new_messages = self.get_messages()
         # TODO: Allow format messages in the tool calls
         # we now apply the format_coro to the content of each message in each dictionary in the list
@@ -458,7 +466,10 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
             async def format_key(message):
                 logger.trace("formatting key: {role}", role=message['role'])
                 if isinstance(message["role"], str):
-                    message["role"] = await format_coro(message["role"], **kwargs)
+                    message["role"] = await format_coro(
+                        message["role"],
+                        format_vars,
+                    )
                 return
             async def format_message(message):
                 logger.trace("formatting content: {content}", content=message['content'])
@@ -466,7 +477,10 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
                     return
                 if isinstance(message["content"], str):
                     try:
-                        message["content"] = await format_coro(message["content"], **kwargs)
+                        message["content"] = await format_coro(
+                            message["content"],
+                            format_vars,
+                        )
                     except FillingError:
                         raise
                     except Exception:
@@ -498,7 +512,17 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         token = active_filling_stash.set(self.snapshot_lookup_stash if hasattr(self, "snapshot_lookup_stash") else None)
         try:
             # format the prompt text with the passed-in variables as well as doing internal expansion
-            prompt = await self._gather_format(aformatter.async_format, **filling_machine(promptvars))
+            active_template_vars = _active_template_vars.get()
+            if active_template_vars is not None and active_template_vars[0] is self:
+                prompt = await self._gather_format_mapping(
+                    aformatter.async_format_mapping,
+                    filling_machine(promptvars),
+                )
+            else:
+                prompt = await self._gather_format(
+                    aformatter.async_format,
+                    **filling_machine(promptvars),
+                )
             return prompt
         finally:
             active_filling_stash.reset(token)
@@ -1024,11 +1048,17 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
 
         Filling adapters use this path so names that overlap query controls,
         such as ``usermsg`` or ``files``, remain data without bypassing an
-        overridden ``ask_a`` implementation.
+        overridden ``ask_a`` implementation. ``self`` stays context-only
+        because Python bound methods cannot receive it again as a keyword.
         """
         token = _active_template_vars.set((self, dict(template_vars)))
         try:
-            return await self.ask_a(**dict(template_vars))
+            forwarded_vars = {
+                name: value
+                for name, value in template_vars.items()
+                if name != "self"
+            }
+            return await self.ask_a(**forwarded_vars)
         finally:
             _active_template_vars.reset(token)
     def listen(self, usermsg=None, events=False, event_schema="legacy", files=None, images=None, **additional_vars) -> ChatStreamListener:

--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -12,7 +12,7 @@ from loguru import logger
 
 from ..assets import capture_asset
 from ..asynchelpers import _gather_cancel_on_error, aformatter
-from ..fillings import active_filling_stash, filling_machine
+from ..fillings import FillingError, active_filling_stash, filling_machine
 from ..runtime import ApplyPatchCall, EVENT_SCHEMA_VERSION, ResponsesWebSocketAdapter
 from ..runtime.attachment_inputs import normalize_attachment_inputs
 
@@ -467,6 +467,8 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
                 if isinstance(message["content"], str):
                     try:
                         message["content"] = await format_coro(message["content"], **kwargs)
+                    except FillingError:
+                        raise
                     except Exception:
                         if message.get("role") != "assistant":
                             raise

--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -12,7 +12,12 @@ from loguru import logger
 
 from ..assets import capture_asset
 from ..asynchelpers import _gather_cancel_on_error, aformatter
-from ..fillings import FillingError, active_filling_stash, filling_machine
+from ..fillings import (
+    FillingError,
+    _filling_resolution_active,
+    active_filling_stash,
+    filling_machine,
+)
 from ..runtime import ApplyPatchCall, EVENT_SCHEMA_VERSION, ResponsesWebSocketAdapter
 from ..runtime.attachment_inputs import normalize_attachment_inputs
 
@@ -500,7 +505,11 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
                             format_vars,
                         )
                     except FillingError:
-                        raise
+                        if (
+                            _filling_resolution_active()
+                            or message.get("role") != "assistant"
+                        ):
+                            raise
                     except Exception:
                         if message.get("role") != "assistant":
                             raise
@@ -532,6 +541,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
             # format the prompt text with the passed-in variables as well as doing internal expansion
             active_template_vars = _active_template_vars.get()
             if active_template_vars is not None and active_template_vars[0] is self:
+                promptvars = dict(active_template_vars[1])
                 prompt = await self._gather_format_mapping(
                     aformatter.async_format_mapping,
                     filling_machine(promptvars),

--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional
 from loguru import logger
 
 from ..assets import capture_asset
-from ..asynchelpers import aformatter
+from ..asynchelpers import _gather_cancel_on_error, aformatter
 from ..fillings import active_filling_stash, filling_machine
 from ..runtime import ApplyPatchCall, EVENT_SCHEMA_VERSION, ResponsesWebSocketAdapter
 from ..runtime.attachment_inputs import normalize_attachment_inputs
@@ -474,7 +474,7 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
             coros.append(format_key(message))
             coros.append(format_message(message))
         # gather the results
-        await asyncio.gather(*coros)
+        await _gather_cancel_on_error(*coros)
         logger.trace(new_messages)
         
         # if the current model is a reasoning model, we need the role of "system" to become "developer" in the json dump messages
@@ -624,13 +624,23 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         **additional_vars,
     ):
         """ Executes the query as-is and returns a tuple of the final prompt and the response"""
+        active_template_vars = _active_template_vars.get()
+        resolver_template_dispatch = (
+            active_template_vars is not None and active_template_vars[0] is self
+        )
+        if resolver_template_dispatch:
+            track_continuation = False
+            _call_usage_ledger = None
+            _submitted_runtime_out = None
+            additional_vars = dict(active_template_vars[1])
+
         assert_binding = getattr(self, "_assert_bound_configuration", None)
         if assert_binding is not None:
             assert_binding()
         self._provider_binding_locked = True
         prompter = self
         # if the user in additional_vars, we're going to instead deepcopy this prompt into a new prompt and add the .user() to it
-        if "__user" in additional_vars:
+        if "__user" in additional_vars and not resolver_template_dispatch:
             new_chatprompt = self.copy(_share_ai_client=True)
             new_chatprompt.user(additional_vars["__user"])
             prompter = new_chatprompt
@@ -999,7 +1009,10 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         self._validate_caller_executed_tools("ask")
         if self.stream:
             raise Exception("Cannot use ask() with a stream")
-        _, response = await self._submit_for_response_and_prompt(**template_vars)
+        if active_template_vars is None or active_template_vars[0] is not self:
+            _, response = await self._submit_for_response_and_prompt(**template_vars)
+        else:
+            _, response = await self._submit_for_response_and_prompt()
         # filter the response if we have a pattern
         response = self.filter_by_pattern(response)
         return response

--- a/chatsnack/chat/mixin_query.py
+++ b/chatsnack/chat/mixin_query.py
@@ -4,6 +4,7 @@ import json
 import uuid
 import warnings
 from collections.abc import Mapping
+from contextvars import ContextVar
 from datetime import datetime
 from typing import Dict, List, Optional
 
@@ -20,6 +21,12 @@ from .mixin_params import (
     ChatParamsMixin,
     DEFAULT_MODEL_FALLBACK,
     _resolve_auto_feed_limit,
+)
+
+
+_active_template_vars = ContextVar(
+    "chatsnack_active_query_template_vars",
+    default=None,
 )
 
 
@@ -978,14 +985,37 @@ class ChatQueryMixin(ChatMessagesMixin, ChatParamsMixin):
         return self._run_sync(self.ask_a(**additional_vars), "ask")
     async def ask_a(self, usermsg=None, files=None, images=None, **additional_vars) -> str:
         """Async form of `ask()`."""
+        active_template_vars = _active_template_vars.get()
+        if active_template_vars is None or active_template_vars[0] is not self:
+            template_vars = self._prepare_query_vars(
+                usermsg,
+                files=files,
+                images=images,
+                **additional_vars,
+            )
+        else:
+            template_vars = dict(active_template_vars[1])
+
         self._validate_caller_executed_tools("ask")
         if self.stream:
             raise Exception("Cannot use ask() with a stream")
-        additional_vars = self._prepare_query_vars(usermsg, files=files, images=images, **additional_vars)
-        _, response = await self._submit_for_response_and_prompt(**additional_vars)
+        _, response = await self._submit_for_response_and_prompt(**template_vars)
         # filter the response if we have a pattern
         response = self.filter_by_pattern(response)
         return response
+
+    async def _ask_a_with_template_vars(self, template_vars) -> str:
+        """Dispatch through ``ask_a`` while preserving formatter variable names.
+
+        Filling adapters use this path so names that overlap query controls,
+        such as ``usermsg`` or ``files``, remain data without bypassing an
+        overridden ``ask_a`` implementation.
+        """
+        token = _active_template_vars.set((self, dict(template_vars)))
+        try:
+            return await self.ask_a(**dict(template_vars))
+        finally:
+            _active_template_vars.reset(token)
     def listen(self, usermsg=None, events=False, event_schema="legacy", files=None, images=None, **additional_vars) -> ChatStreamListener:
         """
         Executes the internal chat query as-is and returns a listener object that can be iterated on for the text.

--- a/chatsnack/fillings.py
+++ b/chatsnack/fillings.py
@@ -55,6 +55,11 @@ class _AsyncFillingMachine:
 
         return completer_coro
 
+    async def _chatsnack_expand_field(self, key):
+        """Force formatter fields through catalog dispatch, not attributes."""
+
+        return await self[key]()
+
     __getattr__ = __getitem__
 
 

--- a/chatsnack/fillings.py
+++ b/chatsnack/fillings.py
@@ -56,7 +56,7 @@ def filling_machine(additional: Optional[Dict] = None) -> dict:
 
 
 _STATIC_FILLING_REFERENCE = re.compile(
-    r"^(?P<vendor>text|chat)\.(?P<name>[A-Za-z_][A-Za-z0-9_]*)$"
+    r"^(?P<vendor>text|chat)\.(?P<name>[A-Za-z_][A-Za-z0-9_-]*)$"
 )
 
 
@@ -160,7 +160,15 @@ class ChatsnackFillingSource:
         prompt = self._objects(Chat).get_or_none(name)
         if prompt is None:
             return None
-        response = await prompt.ask_a(**dict(variables))
+        # Resolver override namespaces would replace the saved chat's built-in
+        # filling machines if forwarded as query variables. Ordinary template
+        # variables still belong to the nested chat call.
+        query_variables = {
+            key: value
+            for key, value in variables.items()
+            if key not in {"text", "chat"}
+        }
+        response = await prompt.ask_a(**query_variables)
         if not isinstance(response, str):
             raise TypeError("chat filling response must be a string")
         return response

--- a/chatsnack/fillings.py
+++ b/chatsnack/fillings.py
@@ -87,7 +87,7 @@ def filling_machine(additional: Optional[Dict] = None) -> dict:
 
 
 _STATIC_FILLING_REFERENCE = re.compile(
-    r"^(?P<vendor>text|chat)\.(?P<name>[A-Za-z_][A-Za-z0-9_-]*)$"
+    r"^(?P<vendor>text|chat)\.(?P<name>[A-Za-z0-9_][A-Za-z0-9_-]*)$"
 )
 _MAX_DEPTH = 16
 _MAX_EXPANSIONS = 256
@@ -115,6 +115,8 @@ class _ResolverState:
 
 
 class _MissingFilling(FillingError):
+    """Carry a missing reference chain without exposing asset content."""
+
     def __init__(self, reference: str, chain: tuple[str, ...]):
         self.reference = reference
         self.chain = chain

--- a/chatsnack/fillings.py
+++ b/chatsnack/fillings.py
@@ -38,6 +38,13 @@ class _AsyncFillingMachine:
                 reference,
                 expand,
                 is_chat=self.vendor == "chat",
+                defer_chat_limit=bool(
+                    getattr(
+                        self.src,
+                        "_chatsnack_reserves_chat_after_lookup",
+                        False,
+                    )
+                ),
             )
             logger.trace(
                 "Filling machine: {key} filled with:\n{value}",
@@ -102,7 +109,7 @@ class _ResolverState:
     chat_calls: int = 0
 
 
-class _MissingFilling(Exception):
+class _MissingFilling(FillingError):
     def __init__(self, reference: str, chain: tuple[str, ...]):
         self.reference = reference
         self.chain = chain
@@ -118,11 +125,29 @@ def _filling_resolution_active() -> bool:
     return _active_resolver.get() is not None
 
 
+def _reserve_chat_filling_call(reference: str) -> None:
+    """Reserve one resolver-authorized model call before provider dispatch."""
+
+    state = _active_resolver.get()
+    if state is None:
+        return
+    state.chat_calls += 1
+    if state.chat_calls > _MAX_CHAT_CALLS:
+        state.chat_calls -= 1
+        raise FillingLimitError(
+            _with_chain(
+                f"chat filling call limit exceeded while resolving {reference}",
+                _active_chain.get(),
+            )
+        )
+
+
 async def _bounded_filling_expansion(
     reference: str,
     expand: Callable[[], Awaitable[str]],
     *,
     is_chat: bool = False,
+    defer_chat_limit: bool = False,
 ) -> str:
     """Apply resolver-only authority and recursion bounds to one callback.
 
@@ -157,6 +182,7 @@ async def _bounded_filling_expansion(
             )
         )
 
+    chat_call_reserved = False
     if is_chat:
         if not state.allow_chat:
             raise FillingAuthorityError(
@@ -165,20 +191,15 @@ async def _bounded_filling_expansion(
                     current_chain,
                 )
             )
-        state.chat_calls += 1
-        if state.chat_calls > _MAX_CHAT_CALLS:
-            raise FillingLimitError(
-                _with_chain(
-                    f"chat filling call limit exceeded while resolving {reference}",
-                    current_chain,
-                )
-            )
+        if not defer_chat_limit:
+            _reserve_chat_filling_call(reference)
+            chat_call_reserved = True
 
     token = _active_chain.set(current_chain)
     try:
         return await expand()
     except _MissingFilling:
-        if is_chat:
+        if chat_call_reserved:
             state.chat_calls -= 1
         raise
     except FillingError:

--- a/chatsnack/fillings.py
+++ b/chatsnack/fillings.py
@@ -1,35 +1,41 @@
-"""Prompt fillings and the public, policy-aware filling resolver.
+"""Prompt fillings and a small public adapter for resolving known references.
 
-The legacy formatter-facing catalog remains available through
-``filling_machine``.  ``resolve_fillings`` and ``resolve_fillings_a`` are the
-public boundary for tools that already know the finite set of static
-``text.Name`` and ``chat.Name`` references they need.
+Chatsnack's normal prompt path and the public resolver use the same filling
+catalog and async formatter. The resolver adds an invocation-local policy
+around those existing callbacks so external assemblers can authorize model
+work and keep recursive expansion finite.
 """
 
-import asyncio
-import re
-import string
 from contextvars import ContextVar
 from dataclasses import dataclass
-from types import MappingProxyType
-from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Protocol
+import re
+from typing import Any, Awaitable, Callable, Dict, Iterable, Mapping, Optional
 
 from loguru import logger
+
+from .asynchelpers import aformatter
 
 
 active_filling_stash = ContextVar("chatsnack_active_filling_stash", default=None)
 
+
 class _AsyncFillingMachine:
-    """Used for parallel variable expansion"""
+    """Expose one async catalog callback through formatter field access."""
+
     def __init__(self, src, addl=None):
         self.src = src
         self.addl = addl
 
-    def __getitem__(self, k):
+    def __getitem__(self, key):
         async def completer_coro():
-            x = await self.src(k, self.addl)
-            logger.trace("Filling machine: {k} filled with:\n{x}", k=k, x=x)
-            return x
+            value = await self.src(key, self.addl)
+            logger.trace(
+                "Filling machine: {key} filled with:\n{value}",
+                key=key,
+                value=value,
+            )
+            return value
+
         return completer_coro
 
     __getattr__ = __getitem__
@@ -40,476 +46,225 @@ class _FillingsCatalog:
         self.vendors = {}
 
     def add_filling(self, filling_name: str, filling_machine_callback: Callable):
-        """Add a new filling machine to the fillings catalog"""
+        """Add a named async filling callback to the shared catalog."""
+
         self.vendors[filling_name] = filling_machine_callback
-    
-# singleton
+
+
 snack_catalog = _FillingsCatalog()
 
+
 def filling_machine(additional: Optional[Dict] = None) -> dict:
+    """Build formatter variables with registered filling vendors included."""
+
     fillings_dict = additional.copy() if additional is not None else {}
-    for k, v in snack_catalog.vendors.items():
-        if k not in fillings_dict:
-            # don't overwrite if they had an argument with the same name
-            fillings_dict[k] = _AsyncFillingMachine(v, additional)
+    for key, callback in snack_catalog.vendors.items():
+        if key not in fillings_dict:
+            fillings_dict[key] = _AsyncFillingMachine(callback, additional)
     return fillings_dict
 
 
 _STATIC_FILLING_REFERENCE = re.compile(
     r"^(?P<vendor>text|chat)\.(?P<name>[A-Za-z_][A-Za-z0-9_-]*)$"
 )
+_MAX_DEPTH = 16
+_MAX_EXPANSIONS = 256
+_MAX_CHAT_CALLS = 16
+_MISSING = object()
 
 
 class FillingError(RuntimeError):
-    """Base class for public filling-resolution failures."""
+    """Raised when a requested filling cannot be safely resolved."""
 
 
 class FillingAuthorityError(FillingError):
-    """Raised before an unresolved chat filling can perform provider I/O."""
+    """Raised before a resolver-scoped Chat filling can call a model."""
 
 
 class FillingLimitError(FillingError):
-    """Raised when a bounded filling graph exceeds an invocation limit."""
+    """Raised when resolver-scoped recursive expansion exceeds a fixed bound."""
 
 
-class FillingCycleError(FillingError):
-    """Raised when text fillings form a recursive dependency cycle."""
+@dataclass
+class _ResolverState:
+    allow_chat: bool
+    expansions: int = 0
+    chat_calls: int = 0
 
 
-class FillingResolutionError(FillingError):
-    """Raised when an existing filling cannot be loaded or resolved."""
+class _MissingFilling(Exception):
+    def __init__(self, reference: str, chain: tuple[str, ...]):
+        self.reference = reference
+        self.chain = chain
 
 
-@dataclass(frozen=True)
-class FillingLimits:
-    """Per-invocation filling limits with finite implementation ceilings."""
-
-    max_depth: int = 16
-    max_nodes: int = 256
-    max_chat_calls: int = 16
-    max_chat_concurrency: int = 4
-
-    _CEILINGS = {
-        "max_depth": 64,
-        "max_nodes": 4096,
-        "max_chat_calls": 256,
-        "max_chat_concurrency": 32,
-    }
-
-    def __post_init__(self):
-        for field_name, ceiling in self._CEILINGS.items():
-            value = getattr(self, field_name)
-            if not isinstance(value, int) or isinstance(value, bool):
-                raise TypeError(f"{field_name} must be an integer")
-            if value < 1 or value > ceiling:
-                raise ValueError(
-                    f"{field_name} must be between 1 and {ceiling}"
-                )
+_active_resolver = ContextVar("chatsnack_active_filling_resolver", default=None)
+_active_chain = ContextVar("chatsnack_active_filling_chain", default=())
 
 
-@dataclass(frozen=True)
-class FillingResolution:
-    """Frozen result metadata plus a JSON-like filling context."""
+def filling_resolution_active() -> bool:
+    """Return whether a public resolver currently owns filling expansion."""
 
-    context: Mapping[str, Mapping[str, Any]]
-    resolved_references: tuple[str, ...]
-    missing_references: tuple[str, ...]
-    chat_calls: int
+    return _active_resolver.get() is not None
 
 
-class FillingSource(Protocol):
-    """Injectable source used by the resolver and its network-free tests."""
+async def bounded_filling_expansion(
+    reference: str,
+    expand: Callable[[], Awaitable[str]],
+    *,
+    is_chat: bool = False,
+) -> str:
+    """Apply resolver-only authority and recursion bounds to one callback.
 
-    def load_text(self, name: str) -> Optional[str]:
-        """Return text content, or ``None`` when the name is absent."""
-
-    async def resolve_chat(
-        self,
-        name: str,
-        variables: Mapping[str, Any],
-    ) -> Optional[str]:
-        """Return a chat response, or ``None`` when the name is absent."""
-
-
-class ChatsnackFillingSource:
-    """Resolve persisted ``Text`` and self-contained ``Chat`` objects.
-
-    Nested saved-asset fillings inside a Chat are rejected before submission so
-    provider calls cannot escape the direct resolver's invocation limits.
+    Outside :func:`resolve_fillings_a`, this delegates directly so the normal
+    Chat prompt path retains its existing behavior.
     """
 
-    def __init__(self, *, stash=None):
-        self.stash = stash
+    state = _active_resolver.get()
+    if state is None:
+        return await expand()
 
-    def _objects(self, model):
-        return model.objects(self.stash) if self.stash is not None else model.objects
-
-    def load_text(self, name: str) -> Optional[str]:
-        from .chat import Text
-
-        prompt = self._objects(Text).get_or_none(name)
-        if prompt is None:
-            return None
-        if not isinstance(prompt.content, str):
-            raise TypeError("text filling content must be a string")
-        return prompt.content
-
-    async def resolve_chat(
-        self,
-        name: str,
-        variables: Mapping[str, Any],
-    ) -> Optional[str]:
-        from .chat import Chat
-
-        prompt = self._objects(Chat).get_or_none(name)
-        if prompt is None:
-            return None
-        parent_reference = f"chat.{name}"
-        nested_vendor = _first_legacy_filling_vendor_in_chat(
-            prompt,
-            parent_reference,
-        )
-        if nested_vendor is not None:
-            raise FillingResolutionError(
-                f"nested {nested_vendor} filling in {parent_reference} "
-                "is outside the bounded resolver graph"
+    chain = _active_chain.get()
+    if reference in chain:
+        start = chain.index(reference)
+        cycle = chain[start:] + (reference,)
+        raise FillingError(f"filling cycle: {' -> '.join(cycle)}")
+    current_chain = chain + (reference,)
+    if len(current_chain) > _MAX_DEPTH:
+        raise FillingLimitError(
+            _with_chain(
+                f"filling depth limit exceeded while resolving {reference}",
+                current_chain,
             )
-        # Resolver override namespaces would replace the saved chat's built-in
-        # filling machines if forwarded as query variables. Ordinary template
-        # variables still belong to the nested chat call.
-        query_variables = {
-            key: value
-            for key, value in variables.items()
-            if key not in {"text", "chat"}
-        }
-        response = await prompt.ask_a(**query_variables)
-        if not isinstance(response, str):
-            raise TypeError("chat filling response must be a string")
-        return response
+        )
 
+    state.expansions += 1
+    if state.expansions > _MAX_EXPANSIONS:
+        raise FillingLimitError(
+            _with_chain(
+                f"filling expansion limit exceeded while resolving {reference}",
+                current_chain,
+            )
+        )
 
-_MISSING = object()
-_FORMATTER = string.Formatter()
+    if is_chat:
+        if not state.allow_chat:
+            raise FillingAuthorityError(
+                _with_chain(
+                    f"chat filling authority is required for {reference}",
+                    current_chain,
+                )
+            )
+        state.chat_calls += 1
+        if state.chat_calls > _MAX_CHAT_CALLS:
+            raise FillingLimitError(
+                _with_chain(
+                    f"chat filling call limit exceeded while resolving {reference}",
+                    current_chain,
+                )
+            )
 
-
-def _static_reference(field_name: str) -> Optional[str]:
-    match = _STATIC_FILLING_REFERENCE.fullmatch(field_name)
-    return match.group(0) if match is not None else None
-
-
-def _lookup_mapping_path(values: Mapping[str, Any], path: str):
-    current: Any = values
-    for part in path.split("."):
-        if not isinstance(current, Mapping) or part not in current:
-            return _MISSING
-        current = current[part]
-    return current
-
-
-def _explicit_filling(values: Mapping[str, Any], reference: str):
-    vendor, name = reference.split(".", 1)
-    namespace = values.get(vendor, _MISSING)
-    if not isinstance(namespace, Mapping) or name not in namespace:
-        return _MISSING
-    return namespace[name]
-
-
-def _parse_fields(template: str, reference: str) -> list[str]:
+    token = _active_chain.set(current_chain)
     try:
-        return [
-            field_name
-            for _, field_name, _, _ in _FORMATTER.parse(template)
-            if field_name is not None
-        ]
-    except ValueError:
-        raise FillingResolutionError(f"could not resolve {reference}") from None
-
-
-def _legacy_filling_vendor(field_name: str) -> Optional[str]:
-    """Return the built-in vendor a legacy formatter field would dispatch."""
-
-    for vendor in ("text", "chat"):
-        if field_name.startswith(f"{vendor}.") or field_name.startswith(
-            f"{vendor}["
-        ):
-            return vendor
-    return None
-
-
-def _first_legacy_filling_vendor_in_chat(
-    prompt,
-    parent_reference: str,
-) -> Optional[str]:
-    """Find a nested legacy filling vendor that would bypass resolver limits."""
-
-    try:
-        messages = prompt.get_messages()
+        return await expand()
+    except (_MissingFilling, FillingError):
+        raise
     except Exception:
-        raise FillingResolutionError(
-            f"could not resolve {parent_reference}"
+        raise FillingError(
+            _with_chain(f"could not resolve {reference}", current_chain)
         ) from None
-    for message in messages:
-        if not isinstance(message, Mapping):
-            continue
-        for key in ("role", "content"):
-            value = message.get(key)
-            if not isinstance(value, str):
-                continue
-            for field_name in _parse_fields(value, parent_reference):
-                vendor = _legacy_filling_vendor(field_name)
-                if vendor is not None:
-                    return vendor
-    return None
+    finally:
+        _active_chain.reset(token)
+
+
+def missing_filling(reference: str) -> Exception:
+    """Create the internal missing-asset signal for a resolver callback."""
+
+    return _MissingFilling(reference, _active_chain.get())
 
 
 async def resolve_fillings_a(
     references: Iterable[str],
     *,
-    variables: Optional[Mapping[str, Any]] = None,
+    variables: Mapping[str, Any] | None = None,
     allow_chat: bool = False,
-    limits: Optional[FillingLimits] = None,
-    source: Optional[FillingSource] = None,
-) -> FillingResolution:
-    """Resolve a finite sequence of static filling references.
+) -> dict[str, dict[str, Any]]:
+    """Resolve known static Text and Chat references with the main formatter.
 
-    Explicit values under ``variables["text"]`` or ``variables["chat"]`` win
-    without catalog access.  Unresolved chat references require
-    ``allow_chat=True`` before the source is called.  Text dependencies are
-    discovered transitively, while inserted results remain opaque.
+    ``references`` must contain static ``text.Name`` or ``chat.Name`` values.
+    Explicit values in the matching ``variables`` namespace are returned as
+    opaque data. Saved assets expand through the same callbacks used by
+    :meth:`Chat.ask_a`. Missing requested assets are omitted. Chat fillings,
+    including transitive ones, require explicit authority for this invocation.
     """
 
-    variables = variables or {}
+    if variables is None:
+        variables = {}
     if not isinstance(variables, Mapping):
         raise TypeError("variables must be a mapping")
     if not isinstance(allow_chat, bool):
         raise TypeError("allow_chat must be a bool")
-    limits = limits or FillingLimits()
-    source = source or ChatsnackFillingSource()
 
     requested: list[str] = []
-    seen_requested: set[str] = set()
+    seen: set[str] = set()
     for reference in references:
-        if not isinstance(reference, str) or _static_reference(reference) is None:
+        if not isinstance(reference, str) or not _STATIC_FILLING_REFERENCE.fullmatch(
+            reference
+        ):
             raise ValueError(
                 "filling references must be static text.Name or chat.Name values"
             )
-        if reference not in seen_requested:
+        if reference not in seen:
             requested.append(reference)
-            seen_requested.add(reference)
+            seen.add(reference)
 
-    raw_text: dict[str, str] = {}
-    missing: set[str] = set()
-    discovered: set[str] = set()
-    chat_references: list[str] = []
-    reference_chains: dict[str, tuple[str, ...]] = {}
-    node_count = 0
-
-    def count_node(reference: str):
-        nonlocal node_count
-        node_count += 1
-        if node_count > limits.max_nodes:
-            raise FillingLimitError(
-                f"filling node limit exceeded while resolving {reference}"
-            )
-
-    def discover(reference: str, chain: tuple[str, ...] = ()):  # noqa: C901
-        if _explicit_filling(variables, reference) is not _MISSING:
-            return
-        if reference in missing or reference in discovered:
-            return
-        if reference in chain:
-            start = chain.index(reference)
-            cycle = chain[start:] + (reference,)
-            raise FillingCycleError(f"filling cycle: {' -> '.join(cycle)}")
-        if len(chain) + 1 > limits.max_depth:
-            raise FillingLimitError(
-                f"filling depth limit exceeded while resolving {reference}"
-            )
-        current_chain = chain + (reference,)
-        reference_chains.setdefault(reference, current_chain)
-
-        vendor, name = reference.split(".", 1)
-        if vendor == "chat":
-            if not allow_chat:
-                raise FillingAuthorityError(
-                    _with_chain(
-                        f"chat filling authority is required for {reference}",
-                        current_chain,
-                    )
-                )
-            count_node(reference)
-            if len(chat_references) >= limits.max_chat_calls:
-                raise FillingLimitError(
-                    f"chat filling call limit exceeded while resolving {reference}"
-                )
-            chat_references.append(reference)
-            discovered.add(reference)
-            return
-
-        try:
-            content = source.load_text(name)
-        except Exception:
-            raise FillingResolutionError(
-                _with_chain(f"could not resolve {reference}", current_chain)
-            ) from None
-        if content is None:
-            missing.add(reference)
-            return
-        if not isinstance(content, str):
-            raise FillingResolutionError(f"could not resolve {reference}")
-
-        count_node(reference)
-        raw_text[reference] = content
-        fields = _parse_fields(content, reference)
-        seen_dependencies: set[str] = set()
-        for field_name in fields:
-            dependency = _static_reference(field_name)
-            if dependency is None or dependency in seen_dependencies:
+    ordinary_variables = {
+        key: value for key, value in variables.items() if key not in {"text", "chat"}
+    }
+    resolved: dict[str, dict[str, Any]] = {}
+    state_token = _active_resolver.set(_ResolverState(allow_chat=allow_chat))
+    chain_token = _active_chain.set(())
+    try:
+        for reference in requested:
+            vendor, name = reference.split(".", 1)
+            namespace = resolved.setdefault(vendor, {})
+            explicit = _explicit_filling(variables, vendor, name)
+            if explicit is not _MISSING:
+                namespace[name] = explicit
                 continue
-            seen_dependencies.add(dependency)
-            discover(dependency, current_chain)
-        discovered.add(reference)
 
-    for reference in requested:
-        discover(reference)
-
-    chat_values: dict[str, str] = {}
-    semaphore = asyncio.Semaphore(limits.max_chat_concurrency)
-
-    async def resolve_chat(reference: str):
-        _, name = reference.split(".", 1)
-        async with semaphore:
             try:
-                value = await source.resolve_chat(name, variables)
+                namespace[name] = await aformatter.async_format(
+                    "{" + reference + "}",
+                    **filling_machine(ordinary_variables),
+                )
+            except _MissingFilling as error:
+                if error.reference == reference and len(error.chain) == 1:
+                    continue
+                raise FillingError(
+                    _with_chain(
+                        f"could not resolve {error.reference}",
+                        error.chain,
+                    )
+                ) from None
             except FillingError:
                 raise
             except Exception:
-                raise FillingResolutionError(
-                    _with_chain(
-                        f"could not resolve {reference}",
-                        reference_chains[reference],
-                    )
-                ) from None
-        if value is None:
-            return reference, _MISSING
-        if not isinstance(value, str):
-            raise FillingResolutionError(f"could not resolve {reference}")
-        return reference, value
+                raise FillingError(f"could not resolve {reference}") from None
+    finally:
+        _active_chain.reset(chain_token)
+        _active_resolver.reset(state_token)
 
-    if chat_references:
-        chat_results = await asyncio.gather(
-            *(resolve_chat(reference) for reference in chat_references)
-        )
-        for reference, value in chat_results:
-            if value is _MISSING:
-                missing.add(reference)
-            else:
-                chat_values[reference] = value
+    return resolved
 
-    text_values: dict[str, str] = {}
-    resolved_references: list[str] = []
-    resolved_seen: set[str] = set()
 
-    def mark_resolved(reference: str):
-        if reference not in resolved_seen:
-            resolved_references.append(reference)
-            resolved_seen.add(reference)
-
-    for reference in chat_references:
-        if reference in chat_values:
-            mark_resolved(reference)
-
-    def reference_value(reference: str):
-        explicit = _explicit_filling(variables, reference)
-        if explicit is not _MISSING:
-            return explicit
-        if reference in chat_values:
-            return chat_values[reference]
-        if reference in raw_text:
-            return render_text(reference)
+def _explicit_filling(
+    variables: Mapping[str, Any], vendor: str, name: str
+) -> Any:
+    namespace = variables.get(vendor, _MISSING)
+    if not isinstance(namespace, Mapping):
         return _MISSING
-
-    def render_text(reference: str) -> str:
-        if reference in text_values:
-            return text_values[reference]
-        template = raw_text[reference]
-        parts: list[str] = []
-        try:
-            parsed = list(_FORMATTER.parse(template))
-        except ValueError:
-            raise FillingResolutionError(f"could not resolve {reference}") from None
-        for literal_text, field_name, _, _ in parsed:
-            parts.append(literal_text)
-            if field_name is None:
-                continue
-            dependency = _static_reference(field_name)
-            value = (
-                reference_value(dependency)
-                if dependency is not None
-                else _lookup_mapping_path(variables, field_name)
-            )
-            if value is _MISSING:
-                if dependency is not None:
-                    failed_subject = dependency
-                    chain = reference_chains.get(dependency, (reference,))
-                else:
-                    failed_subject = f"variable {field_name}"
-                    chain = reference_chains.get(reference, (reference,))
-                raise FillingResolutionError(
-                    _with_chain(
-                        f"could not resolve {failed_subject}",
-                        chain,
-                    )
-                ) from None
-            parts.append(str(value))
-        value = "".join(parts)
-        text_values[reference] = value
-        mark_resolved(reference)
-        return value
-
-    for reference in requested:
-        if reference in raw_text:
-            render_text(reference)
-
-    result_context: dict[str, dict[str, Any]] = {}
-    missing_requested: list[str] = []
-    for reference in requested:
-        vendor, name = reference.split(".", 1)
-        namespace = result_context.setdefault(vendor, {})
-        value = reference_value(reference)
-        if value is _MISSING:
-            missing_requested.append(reference)
-        else:
-            namespace[name] = value
-
-    frozen_context = MappingProxyType(
-        {
-            vendor: MappingProxyType(dict(namespace))
-            for vendor, namespace in result_context.items()
-        }
-    )
-    return FillingResolution(
-        context=frozen_context,
-        resolved_references=tuple(resolved_references),
-        missing_references=tuple(missing_requested),
-        chat_calls=len(chat_references),
-    )
-
-
-def resolve_fillings(
-    references: Iterable[str],
-    **kwargs,
-) -> FillingResolution:
-    """Synchronous form of :func:`resolve_fillings_a`."""
-
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(resolve_fillings_a(references, **kwargs))
-    raise RuntimeError(
-        "Cannot call resolve_fillings() from an active event loop. "
-        "Use resolve_fillings_a() instead."
-    )
+    return namespace.get(name, _MISSING)
 
 
 def _with_chain(message: str, chain: tuple[str, ...]) -> str:

--- a/chatsnack/fillings.py
+++ b/chatsnack/fillings.py
@@ -275,9 +275,9 @@ async def resolve_fillings_a(
                 continue
 
             try:
-                namespace[name] = await aformatter.async_format(
+                namespace[name] = await aformatter.async_format_mapping(
                     "{" + reference + "}",
-                    **filling_machine(ordinary_variables),
+                    filling_machine(ordinary_variables),
                 )
             except _MissingFilling as error:
                 if error.reference == reference and len(error.chain) == 1:

--- a/chatsnack/fillings.py
+++ b/chatsnack/fillings.py
@@ -8,10 +8,10 @@ work and keep recursive expansion finite.
 
 from contextvars import ContextVar
 from dataclasses import dataclass
-import re
 from typing import Any, Awaitable, Callable, Dict, Iterable, Mapping, Optional
 
 from loguru import logger
+from snapclass.paths import safe_path_placeholder
 
 from .asynchelpers import aformatter
 
@@ -86,9 +86,6 @@ def filling_machine(additional: Optional[Dict] = None) -> dict:
     return fillings_dict
 
 
-_STATIC_FILLING_REFERENCE = re.compile(
-    r"^(?P<vendor>text|chat)\.(?P<name>[A-Za-z0-9_][A-Za-z0-9_-]*)$"
-)
 _MAX_DEPTH = 16
 _MAX_EXPANSIONS = 256
 _MAX_CHAT_CALLS = 16
@@ -225,6 +222,22 @@ def _missing_filling(reference: str) -> Exception:
     return _MissingFilling(reference, _active_chain.get())
 
 
+def _is_static_filling_reference(reference: Any) -> bool:
+    """Check for one formatter-addressable reference to a safely persisted asset."""
+
+    if not isinstance(reference, str) or "." not in reference:
+        return False
+    vendor, name = reference.split(".", 1)
+    if vendor not in {"text", "chat"} or not name:
+        return False
+    try:
+        safe_path_placeholder("name", name)
+        parsed = list(aformatter.parse("{" + reference + "}"))
+    except ValueError:
+        return False
+    return parsed == [("", reference, "", None)]
+
+
 async def resolve_fillings_a(
     references: Iterable[str],
     *,
@@ -251,9 +264,7 @@ async def resolve_fillings_a(
     requested: list[str] = []
     seen: set[str] = set()
     for reference in references:
-        if not isinstance(reference, str) or not _STATIC_FILLING_REFERENCE.fullmatch(
-            reference
-        ):
+        if not _is_static_filling_reference(reference):
             raise ValueError(
                 "filling references must be static text.Name or chat.Name values"
             )

--- a/chatsnack/fillings.py
+++ b/chatsnack/fillings.py
@@ -1,5 +1,19 @@
+"""Prompt fillings and the public, policy-aware filling resolver.
+
+The legacy formatter-facing catalog remains available through
+``filling_machine``.  ``resolve_fillings`` and ``resolve_fillings_a`` are the
+public boundary for tools that already know the finite set of static
+``text.Name`` and ``chat.Name`` references they need.
+"""
+
+import asyncio
+import re
+import string
 from contextvars import ContextVar
-from typing import Callable, Optional, Dict
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Protocol
+
 from loguru import logger
 
 
@@ -39,3 +53,398 @@ def filling_machine(additional: Optional[Dict] = None) -> dict:
             # don't overwrite if they had an argument with the same name
             fillings_dict[k] = _AsyncFillingMachine(v, additional)
     return fillings_dict
+
+
+_STATIC_FILLING_REFERENCE = re.compile(
+    r"^(?P<vendor>text|chat)\.(?P<name>[A-Za-z_][A-Za-z0-9_]*)$"
+)
+
+
+class FillingError(RuntimeError):
+    """Base class for public filling-resolution failures."""
+
+
+class FillingAuthorityError(FillingError):
+    """Raised before an unresolved chat filling can perform provider I/O."""
+
+
+class FillingLimitError(FillingError):
+    """Raised when a bounded filling graph exceeds an invocation limit."""
+
+
+class FillingCycleError(FillingError):
+    """Raised when text fillings form a recursive dependency cycle."""
+
+
+class FillingResolutionError(FillingError):
+    """Raised when an existing filling cannot be loaded or resolved."""
+
+
+@dataclass(frozen=True)
+class FillingLimits:
+    """Per-invocation filling limits with finite implementation ceilings."""
+
+    max_depth: int = 16
+    max_nodes: int = 256
+    max_chat_calls: int = 16
+    max_chat_concurrency: int = 4
+
+    _CEILINGS = {
+        "max_depth": 64,
+        "max_nodes": 4096,
+        "max_chat_calls": 256,
+        "max_chat_concurrency": 32,
+    }
+
+    def __post_init__(self):
+        for field_name, ceiling in self._CEILINGS.items():
+            value = getattr(self, field_name)
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise TypeError(f"{field_name} must be an integer")
+            if value < 1 or value > ceiling:
+                raise ValueError(
+                    f"{field_name} must be between 1 and {ceiling}"
+                )
+
+
+@dataclass(frozen=True)
+class FillingResolution:
+    """Frozen result metadata plus a JSON-like filling context."""
+
+    context: Mapping[str, Mapping[str, Any]]
+    resolved_references: tuple[str, ...]
+    missing_references: tuple[str, ...]
+    chat_calls: int
+
+
+class FillingSource(Protocol):
+    """Injectable source used by the resolver and its network-free tests."""
+
+    def load_text(self, name: str) -> Optional[str]:
+        """Return text content, or ``None`` when the name is absent."""
+
+    async def resolve_chat(
+        self,
+        name: str,
+        variables: Mapping[str, Any],
+    ) -> Optional[str]:
+        """Return a chat response, or ``None`` when the name is absent."""
+
+
+class ChatsnackFillingSource:
+    """Resolve persisted ``Text`` and ``Chat`` objects through public APIs."""
+
+    def __init__(self, *, stash=None):
+        self.stash = stash
+
+    def _objects(self, model):
+        return model.objects(self.stash) if self.stash is not None else model.objects
+
+    def load_text(self, name: str) -> Optional[str]:
+        from .chat import Text
+
+        prompt = self._objects(Text).get_or_none(name)
+        if prompt is None:
+            return None
+        if not isinstance(prompt.content, str):
+            raise TypeError("text filling content must be a string")
+        return prompt.content
+
+    async def resolve_chat(
+        self,
+        name: str,
+        variables: Mapping[str, Any],
+    ) -> Optional[str]:
+        from .chat import Chat
+
+        prompt = self._objects(Chat).get_or_none(name)
+        if prompt is None:
+            return None
+        response = await prompt.ask_a(**dict(variables))
+        if not isinstance(response, str):
+            raise TypeError("chat filling response must be a string")
+        return response
+
+
+_MISSING = object()
+_FORMATTER = string.Formatter()
+
+
+def _static_reference(field_name: str) -> Optional[str]:
+    match = _STATIC_FILLING_REFERENCE.fullmatch(field_name)
+    return match.group(0) if match is not None else None
+
+
+def _lookup_mapping_path(values: Mapping[str, Any], path: str):
+    current: Any = values
+    for part in path.split("."):
+        if not isinstance(current, Mapping) or part not in current:
+            return _MISSING
+        current = current[part]
+    return current
+
+
+def _explicit_filling(values: Mapping[str, Any], reference: str):
+    vendor, name = reference.split(".", 1)
+    namespace = values.get(vendor, _MISSING)
+    if not isinstance(namespace, Mapping) or name not in namespace:
+        return _MISSING
+    return namespace[name]
+
+
+def _parse_fields(template: str, reference: str) -> list[str]:
+    try:
+        return [
+            field_name
+            for _, field_name, _, _ in _FORMATTER.parse(template)
+            if field_name is not None
+        ]
+    except ValueError:
+        raise FillingResolutionError(f"could not resolve {reference}") from None
+
+
+async def resolve_fillings_a(
+    references: Iterable[str],
+    *,
+    variables: Optional[Mapping[str, Any]] = None,
+    allow_chat: bool = False,
+    limits: Optional[FillingLimits] = None,
+    source: Optional[FillingSource] = None,
+) -> FillingResolution:
+    """Resolve a finite sequence of static filling references.
+
+    Explicit values under ``variables["text"]`` or ``variables["chat"]`` win
+    without catalog access.  Unresolved chat references require
+    ``allow_chat=True`` before the source is called.  Text dependencies are
+    discovered transitively, while inserted results remain opaque.
+    """
+
+    variables = variables or {}
+    if not isinstance(variables, Mapping):
+        raise TypeError("variables must be a mapping")
+    limits = limits or FillingLimits()
+    source = source or ChatsnackFillingSource()
+
+    requested: list[str] = []
+    seen_requested: set[str] = set()
+    for reference in references:
+        if not isinstance(reference, str) or _static_reference(reference) is None:
+            raise ValueError(
+                "filling references must be static text.Name or chat.Name values"
+            )
+        if reference not in seen_requested:
+            requested.append(reference)
+            seen_requested.add(reference)
+
+    raw_text: dict[str, str] = {}
+    missing: set[str] = set()
+    discovered: set[str] = set()
+    chat_references: list[str] = []
+    reference_chains: dict[str, tuple[str, ...]] = {}
+    node_count = 0
+
+    def count_node(reference: str):
+        nonlocal node_count
+        node_count += 1
+        if node_count > limits.max_nodes:
+            raise FillingLimitError(
+                f"filling node limit exceeded while resolving {reference}"
+            )
+
+    def discover(reference: str, chain: tuple[str, ...] = ()):  # noqa: C901
+        if _explicit_filling(variables, reference) is not _MISSING:
+            return
+        if reference in missing or reference in discovered:
+            return
+        if reference in chain:
+            start = chain.index(reference)
+            cycle = chain[start:] + (reference,)
+            raise FillingCycleError(f"filling cycle: {' -> '.join(cycle)}")
+        if len(chain) + 1 > limits.max_depth:
+            raise FillingLimitError(
+                f"filling depth limit exceeded while resolving {reference}"
+            )
+        current_chain = chain + (reference,)
+        reference_chains.setdefault(reference, current_chain)
+
+        vendor, name = reference.split(".", 1)
+        if vendor == "chat":
+            if not allow_chat:
+                raise FillingAuthorityError(
+                    _with_chain(
+                        f"chat filling authority is required for {reference}",
+                        current_chain,
+                    )
+                )
+            count_node(reference)
+            if len(chat_references) >= limits.max_chat_calls:
+                raise FillingLimitError(
+                    f"chat filling call limit exceeded while resolving {reference}"
+                )
+            chat_references.append(reference)
+            discovered.add(reference)
+            return
+
+        try:
+            content = source.load_text(name)
+        except Exception:
+            raise FillingResolutionError(
+                _with_chain(f"could not resolve {reference}", current_chain)
+            ) from None
+        if content is None:
+            missing.add(reference)
+            return
+        if not isinstance(content, str):
+            raise FillingResolutionError(f"could not resolve {reference}")
+
+        count_node(reference)
+        raw_text[reference] = content
+        fields = _parse_fields(content, reference)
+        seen_dependencies: set[str] = set()
+        for field_name in fields:
+            dependency = _static_reference(field_name)
+            if dependency is None or dependency in seen_dependencies:
+                continue
+            seen_dependencies.add(dependency)
+            discover(dependency, current_chain)
+        discovered.add(reference)
+
+    for reference in requested:
+        discover(reference)
+
+    chat_values: dict[str, str] = {}
+    semaphore = asyncio.Semaphore(limits.max_chat_concurrency)
+
+    async def resolve_chat(reference: str):
+        _, name = reference.split(".", 1)
+        async with semaphore:
+            try:
+                value = await source.resolve_chat(name, variables)
+            except Exception:
+                raise FillingResolutionError(
+                    _with_chain(
+                        f"could not resolve {reference}",
+                        reference_chains[reference],
+                    )
+                ) from None
+        if value is None:
+            return reference, _MISSING
+        if not isinstance(value, str):
+            raise FillingResolutionError(f"could not resolve {reference}")
+        return reference, value
+
+    if chat_references:
+        chat_results = await asyncio.gather(
+            *(resolve_chat(reference) for reference in chat_references)
+        )
+        for reference, value in chat_results:
+            if value is _MISSING:
+                missing.add(reference)
+            else:
+                chat_values[reference] = value
+
+    text_values: dict[str, str] = {}
+    resolved_references: list[str] = []
+    resolved_seen: set[str] = set()
+
+    def mark_resolved(reference: str):
+        if reference not in resolved_seen:
+            resolved_references.append(reference)
+            resolved_seen.add(reference)
+
+    for reference in chat_references:
+        if reference in chat_values:
+            mark_resolved(reference)
+
+    def reference_value(reference: str):
+        explicit = _explicit_filling(variables, reference)
+        if explicit is not _MISSING:
+            return explicit
+        if reference in chat_values:
+            return chat_values[reference]
+        if reference in raw_text:
+            return render_text(reference)
+        return _MISSING
+
+    def render_text(reference: str) -> str:
+        if reference in text_values:
+            return text_values[reference]
+        template = raw_text[reference]
+        parts: list[str] = []
+        try:
+            parsed = list(_FORMATTER.parse(template))
+        except ValueError:
+            raise FillingResolutionError(f"could not resolve {reference}") from None
+        for literal_text, field_name, _, _ in parsed:
+            parts.append(literal_text)
+            if field_name is None:
+                continue
+            dependency = _static_reference(field_name)
+            value = (
+                reference_value(dependency)
+                if dependency is not None
+                else _lookup_mapping_path(variables, field_name)
+            )
+            if value is _MISSING:
+                failed_reference = dependency or reference
+                raise FillingResolutionError(
+                    _with_chain(
+                        f"could not resolve {failed_reference}",
+                        reference_chains.get(failed_reference, (reference,)),
+                    )
+                ) from None
+            parts.append(str(value))
+        value = "".join(parts)
+        text_values[reference] = value
+        mark_resolved(reference)
+        return value
+
+    for reference in requested:
+        if reference in raw_text:
+            render_text(reference)
+
+    result_context: dict[str, dict[str, Any]] = {}
+    missing_requested: list[str] = []
+    for reference in requested:
+        vendor, name = reference.split(".", 1)
+        namespace = result_context.setdefault(vendor, {})
+        value = reference_value(reference)
+        if value is _MISSING:
+            missing_requested.append(reference)
+        else:
+            namespace[name] = value
+
+    frozen_context = MappingProxyType(
+        {
+            vendor: MappingProxyType(dict(namespace))
+            for vendor, namespace in result_context.items()
+        }
+    )
+    return FillingResolution(
+        context=frozen_context,
+        resolved_references=tuple(resolved_references),
+        missing_references=tuple(missing_requested),
+        chat_calls=len(chat_references),
+    )
+
+
+def resolve_fillings(
+    references: Iterable[str],
+    **kwargs,
+) -> FillingResolution:
+    """Synchronous form of :func:`resolve_fillings_a`."""
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(resolve_fillings_a(references, **kwargs))
+    raise RuntimeError(
+        "Cannot call resolve_fillings() from an active event loop. "
+        "Use resolve_fillings_a() instead."
+    )
+
+
+def _with_chain(message: str, chain: tuple[str, ...]) -> str:
+    if len(chain) <= 1:
+        return message
+    return f"{message} (via {' -> '.join(chain)})"

--- a/chatsnack/fillings.py
+++ b/chatsnack/fillings.py
@@ -302,6 +302,8 @@ async def resolve_fillings_a(
 def _explicit_filling(
     variables: Mapping[str, Any], vendor: str, name: str
 ) -> Any:
+    """Return an opaque override only from the vendor's mapping namespace."""
+
     namespace = variables.get(vendor, _MISSING)
     if not isinstance(namespace, Mapping):
         return _MISSING
@@ -309,6 +311,8 @@ def _explicit_filling(
 
 
 def _with_chain(message: str, chain: tuple[str, ...]) -> str:
+    """Add transitive context while keeping direct-reference errors concise."""
+
     if len(chain) <= 1:
         return message
     return f"{message} (via {' -> '.join(chain)})"

--- a/chatsnack/fillings.py
+++ b/chatsnack/fillings.py
@@ -132,7 +132,11 @@ class FillingSource(Protocol):
 
 
 class ChatsnackFillingSource:
-    """Resolve persisted ``Text`` and ``Chat`` objects through public APIs."""
+    """Resolve persisted ``Text`` and self-contained ``Chat`` objects.
+
+    Nested saved-asset fillings inside a Chat are rejected before submission so
+    provider calls cannot escape the direct resolver's invocation limits.
+    """
 
     def __init__(self, *, stash=None):
         self.stash = stash
@@ -160,6 +164,16 @@ class ChatsnackFillingSource:
         prompt = self._objects(Chat).get_or_none(name)
         if prompt is None:
             return None
+        parent_reference = f"chat.{name}"
+        nested_reference = _first_static_reference_in_chat(
+            prompt,
+            parent_reference,
+        )
+        if nested_reference is not None:
+            raise FillingResolutionError(
+                f"nested filling {nested_reference} in {parent_reference} "
+                "is outside the bounded resolver graph"
+            )
         # Resolver override namespaces would replace the saved chat's built-in
         # filling machines if forwarded as query variables. Ordinary template
         # variables still belong to the nested chat call.
@@ -209,6 +223,29 @@ def _parse_fields(template: str, reference: str) -> list[str]:
         ]
     except ValueError:
         raise FillingResolutionError(f"could not resolve {reference}") from None
+
+
+def _first_static_reference_in_chat(prompt, parent_reference: str) -> Optional[str]:
+    """Find a nested saved-asset filling that would bypass resolver limits."""
+
+    try:
+        messages = prompt.get_messages()
+    except Exception:
+        raise FillingResolutionError(
+            f"could not resolve {parent_reference}"
+        ) from None
+    for message in messages:
+        if not isinstance(message, Mapping):
+            continue
+        for key in ("role", "content"):
+            value = message.get(key)
+            if not isinstance(value, str):
+                continue
+            for field_name in _parse_fields(value, parent_reference):
+                reference = _static_reference(field_name)
+                if reference is not None:
+                    return reference
+    return None
 
 
 async def resolve_fillings_a(
@@ -328,6 +365,8 @@ async def resolve_fillings_a(
         async with semaphore:
             try:
                 value = await source.resolve_chat(name, variables)
+            except FillingError:
+                raise
             except Exception:
                 raise FillingResolutionError(
                     _with_chain(
@@ -394,11 +433,16 @@ async def resolve_fillings_a(
                 else _lookup_mapping_path(variables, field_name)
             )
             if value is _MISSING:
-                failed_reference = dependency or reference
+                if dependency is not None:
+                    failed_subject = dependency
+                    chain = reference_chains.get(dependency, (reference,))
+                else:
+                    failed_subject = f"variable {field_name}"
+                    chain = reference_chains.get(reference, (reference,))
                 raise FillingResolutionError(
                     _with_chain(
-                        f"could not resolve {failed_reference}",
-                        reference_chains.get(failed_reference, (reference,)),
+                        f"could not resolve {failed_subject}",
+                        chain,
                     )
                 ) from None
             parts.append(str(value))

--- a/chatsnack/fillings.py
+++ b/chatsnack/fillings.py
@@ -22,13 +22,23 @@ active_filling_stash = ContextVar("chatsnack_active_filling_stash", default=None
 class _AsyncFillingMachine:
     """Expose one async catalog callback through formatter field access."""
 
-    def __init__(self, src, addl=None):
+    def __init__(self, vendor, src, addl=None):
+        self.vendor = vendor
         self.src = src
         self.addl = addl
 
     def __getitem__(self, key):
         async def completer_coro():
-            value = await self.src(key, self.addl)
+            reference = f"{self.vendor}.{key}"
+
+            async def expand():
+                return await self.src(key, self.addl)
+
+            value = await _bounded_filling_expansion(
+                reference,
+                expand,
+                is_chat=self.vendor == "chat",
+            )
             logger.trace(
                 "Filling machine: {key} filled with:\n{value}",
                 key=key,
@@ -60,7 +70,7 @@ def filling_machine(additional: Optional[Dict] = None) -> dict:
     fillings_dict = additional.copy() if additional is not None else {}
     for key, callback in snack_catalog.vendors.items():
         if key not in fillings_dict:
-            fillings_dict[key] = _AsyncFillingMachine(callback, additional)
+            fillings_dict[key] = _AsyncFillingMachine(key, callback, additional)
     return fillings_dict
 
 
@@ -102,13 +112,13 @@ _active_resolver = ContextVar("chatsnack_active_filling_resolver", default=None)
 _active_chain = ContextVar("chatsnack_active_filling_chain", default=())
 
 
-def filling_resolution_active() -> bool:
+def _filling_resolution_active() -> bool:
     """Return whether a public resolver currently owns filling expansion."""
 
     return _active_resolver.get() is not None
 
 
-async def bounded_filling_expansion(
+async def _bounded_filling_expansion(
     reference: str,
     expand: Callable[[], Awaitable[str]],
     *,
@@ -167,7 +177,11 @@ async def bounded_filling_expansion(
     token = _active_chain.set(current_chain)
     try:
         return await expand()
-    except (_MissingFilling, FillingError):
+    except _MissingFilling:
+        if is_chat:
+            state.chat_calls -= 1
+        raise
+    except FillingError:
         raise
     except Exception:
         raise FillingError(
@@ -177,7 +191,7 @@ async def bounded_filling_expansion(
         _active_chain.reset(token)
 
 
-def missing_filling(reference: str) -> Exception:
+def _missing_filling(reference: str) -> Exception:
     """Create the internal missing-asset signal for a resolver callback."""
 
     return _MissingFilling(reference, _active_chain.get())
@@ -194,8 +208,9 @@ async def resolve_fillings_a(
     ``references`` must contain static ``text.Name`` or ``chat.Name`` values.
     Explicit values in the matching ``variables`` namespace are returned as
     opaque data. Saved assets expand through the same callbacks used by
-    :meth:`Chat.ask_a`. Missing requested assets are omitted. Chat fillings,
-    including transitive ones, require explicit authority for this invocation.
+    :meth:`Chat.ask_a`. Missing requested assets are omitted after any required
+    Chat authority check. Chat fillings, including transitive ones, require
+    explicit authority for this invocation.
     """
 
     if variables is None:

--- a/chatsnack/fillings.py
+++ b/chatsnack/fillings.py
@@ -165,13 +165,13 @@ class ChatsnackFillingSource:
         if prompt is None:
             return None
         parent_reference = f"chat.{name}"
-        nested_reference = _first_static_reference_in_chat(
+        nested_vendor = _first_legacy_filling_vendor_in_chat(
             prompt,
             parent_reference,
         )
-        if nested_reference is not None:
+        if nested_vendor is not None:
             raise FillingResolutionError(
-                f"nested filling {nested_reference} in {parent_reference} "
+                f"nested {nested_vendor} filling in {parent_reference} "
                 "is outside the bounded resolver graph"
             )
         # Resolver override namespaces would replace the saved chat's built-in
@@ -225,8 +225,22 @@ def _parse_fields(template: str, reference: str) -> list[str]:
         raise FillingResolutionError(f"could not resolve {reference}") from None
 
 
-def _first_static_reference_in_chat(prompt, parent_reference: str) -> Optional[str]:
-    """Find a nested saved-asset filling that would bypass resolver limits."""
+def _legacy_filling_vendor(field_name: str) -> Optional[str]:
+    """Return the built-in vendor a legacy formatter field would dispatch."""
+
+    for vendor in ("text", "chat"):
+        if field_name.startswith(f"{vendor}.") or field_name.startswith(
+            f"{vendor}["
+        ):
+            return vendor
+    return None
+
+
+def _first_legacy_filling_vendor_in_chat(
+    prompt,
+    parent_reference: str,
+) -> Optional[str]:
+    """Find a nested legacy filling vendor that would bypass resolver limits."""
 
     try:
         messages = prompt.get_messages()
@@ -242,9 +256,9 @@ def _first_static_reference_in_chat(prompt, parent_reference: str) -> Optional[s
             if not isinstance(value, str):
                 continue
             for field_name in _parse_fields(value, parent_reference):
-                reference = _static_reference(field_name)
-                if reference is not None:
-                    return reference
+                vendor = _legacy_filling_vendor(field_name)
+                if vendor is not None:
+                    return vendor
     return None
 
 
@@ -267,6 +281,8 @@ async def resolve_fillings_a(
     variables = variables or {}
     if not isinstance(variables, Mapping):
         raise TypeError("variables must be a mapping")
+    if not isinstance(allow_chat, bool):
+        raise TypeError("allow_chat must be a bool")
     limits = limits or FillingLimits()
     source = source or ChatsnackFillingSource()
 

--- a/chatsnack/fillings.py
+++ b/chatsnack/fillings.py
@@ -188,20 +188,20 @@ async def _bounded_filling_expansion(
         )
 
     chat_call_reserved = False
-    if is_chat:
-        if not state.allow_chat:
-            raise FillingAuthorityError(
-                _with_chain(
-                    f"chat filling authority is required for {reference}",
-                    current_chain,
-                )
-            )
-        if not defer_chat_limit:
-            _reserve_chat_filling_call(reference)
-            chat_call_reserved = True
-
     token = _active_chain.set(current_chain)
     try:
+        if is_chat:
+            if not state.allow_chat:
+                raise FillingAuthorityError(
+                    _with_chain(
+                        f"chat filling authority is required for {reference}",
+                        current_chain,
+                    )
+                )
+            if not defer_chat_limit:
+                _reserve_chat_filling_call(reference)
+                chat_call_reserved = True
+
         return await expand()
     except _MissingFilling:
         if chat_call_reserved:

--- a/docs/guides/fillings.md
+++ b/docs/guides/fillings.md
@@ -61,3 +61,34 @@ print(snackfull.chat().yaml)
 ```
 
 This keeps the authoring surface small while still enabling multi-step prompt preparation.
+
+## Resolve fillings directly
+
+External assemblers such as Catsnack sometimes know the finite set of static
+`text.Name` and `chat.Name` references they need before building a prompt. They
+can resolve that set directly:
+
+```python
+from chatsnack import resolve_fillings
+
+resolved = resolve_fillings(["text.SnackExplosion"])
+print(resolved.context["text"]["SnackExplosion"])
+```
+
+Direct resolution follows these rules:
+
+- Explicit values in `variables["text"]` or `variables["chat"]` take priority
+  without loading a saved asset.
+- Saved text can refer to other text or chat fillings. Text cycles and excessive
+  nesting fail with a bounded resolver error.
+- Saved chat references require `allow_chat=True` before `chatsnack` makes a model
+  call. This also applies when saved text contains a chat reference.
+- Missing requested names appear in `missing_references`. A missing dependency
+  inside saved text stops that text from resolving.
+- Inserted values remain plain data. `chatsnack` does not scan them for more
+  filling references.
+- `FillingLimits` bounds nesting, resolved nodes, chat calls, and concurrent
+  chat calls.
+
+See the [Fillings API reference](../reference/api/fillings.md) for signatures,
+result metadata, limits, sources, and errors.

--- a/docs/guides/fillings.md
+++ b/docs/guides/fillings.md
@@ -83,12 +83,14 @@ Direct resolution follows these rules:
   `Chat.ask_a()`, including nested Text and Chat fillings.
 - Saved chat references require `allow_chat=True` before `chatsnack` makes a model
   call. This also applies when saved Text or Chat assets contain a chat filling.
-- Missing requested names are omitted. A missing transitive dependency stops the
-  requested filling from resolving.
+- Missing requested Text names are omitted. Chat authority is checked before
+  Chatsnack looks up a requested Chat; once authorized, a missing Chat is also
+  omitted. A missing transitive dependency stops the requested filling from
+  resolving.
 - Inserted values remain plain data. `chatsnack` does not scan them for more
   filling references.
-- Fixed resolver-only bounds cap recursive depth, filling expansions, and model
-  calls. They do not change ordinary Chat expansion.
+- Fixed resolver-only bounds cap recursive depth, filling expansions, and Chat
+  filling invocations. They do not change ordinary Chat expansion.
 
 See the [Fillings API reference](../reference/api/fillings.md) for the signature
 and errors.

--- a/docs/guides/fillings.md
+++ b/docs/guides/fillings.md
@@ -83,6 +83,9 @@ Direct resolution follows these rules:
   nesting fail with a bounded resolver error.
 - Saved chat references require `allow_chat=True` before `chatsnack` makes a model
   call. This also applies when saved text contains a chat reference.
+- Saved chats resolved by the default source must be self-contained. Nested
+  `text.*` or `chat.*` fillings are rejected before provider I/O so legacy
+  expansion cannot bypass the resolver's invocation limits.
 - Missing requested names appear in `missing_references`. A missing dependency
   inside saved text stops that text from resolving.
 - Inserted values remain plain data. `chatsnack` does not scan them for more

--- a/docs/guides/fillings.md
+++ b/docs/guides/fillings.md
@@ -69,30 +69,26 @@ External assemblers such as Catsnack sometimes know the finite set of static
 can resolve that set directly:
 
 ```python
-from chatsnack import resolve_fillings
+from chatsnack import resolve_fillings_a
 
-resolved = resolve_fillings(["text.SnackExplosion"])
-print(resolved.context["text"]["SnackExplosion"])
+resolved = await resolve_fillings_a(["text.SnackExplosion"])
+print(resolved["text"]["SnackExplosion"])
 ```
 
 Direct resolution follows these rules:
 
 - Explicit values in `variables["text"]` or `variables["chat"]` take priority
-  without loading a saved asset.
-- Saved text can refer to other text or chat fillings. Text cycles and excessive
-  nesting fail with a bounded resolver error.
+  for the requested names without loading a saved asset.
+- Saved assets expand through the same formatter and filling callbacks used by
+  `Chat.ask_a()`, including nested Text and Chat fillings.
 - Saved chat references require `allow_chat=True` before `chatsnack` makes a model
-  call. This must be a boolean, and also applies when saved text contains a chat
-  reference.
-- Saved chats resolved by the default source must be self-contained. Nested
-  `text.*` or `chat.*` fillings are rejected before provider I/O so legacy
-  expansion cannot bypass the resolver's invocation limits.
-- Missing requested names appear in `missing_references`. A missing dependency
-  inside saved text stops that text from resolving.
+  call. This also applies when saved Text or Chat assets contain a chat filling.
+- Missing requested names are omitted. A missing transitive dependency stops the
+  requested filling from resolving.
 - Inserted values remain plain data. `chatsnack` does not scan them for more
   filling references.
-- `FillingLimits` bounds nesting, resolved nodes, chat calls, and concurrent
-  chat calls.
+- Fixed resolver-only bounds cap recursive depth, filling expansions, and model
+  calls. They do not change ordinary Chat expansion.
 
-See the [Fillings API reference](../reference/api/fillings.md) for signatures,
-result metadata, limits, sources, and errors.
+See the [Fillings API reference](../reference/api/fillings.md) for the signature
+and errors.

--- a/docs/guides/fillings.md
+++ b/docs/guides/fillings.md
@@ -82,7 +82,8 @@ Direct resolution follows these rules:
 - Saved text can refer to other text or chat fillings. Text cycles and excessive
   nesting fail with a bounded resolver error.
 - Saved chat references require `allow_chat=True` before `chatsnack` makes a model
-  call. This also applies when saved text contains a chat reference.
+  call. This must be a boolean, and also applies when saved text contains a chat
+  reference.
 - Saved chats resolved by the default source must be self-contained. Nested
   `text.*` or `chat.*` fillings are rejected before provider I/O so legacy
   expansion cannot bypass the resolver's invocation limits.

--- a/docs/reference/api/fillings.md
+++ b/docs/reference/api/fillings.md
@@ -11,7 +11,8 @@ it and how resolution behaves.
 
 ## Errors
 
-All direct resolver errors inherit from `FillingError`.
+Resolution-time failures inherit from `FillingError`. Invalid arguments use
+the usual `TypeError` or `ValueError` validation exceptions.
 
 ### `FillingError`
 

--- a/docs/reference/api/fillings.md
+++ b/docs/reference/api/fillings.md
@@ -1,0 +1,58 @@
+# Fillings
+
+The direct filling resolver is an advanced public API for callers that already
+know the finite set of saved text and chat references they need. The
+[Fillings and Composition guide](../../guides/fillings.md) explains when to use
+it and how resolution behaves.
+
+## Resolve synchronously
+
+::: chatsnack.resolve_fillings
+
+## Resolve asynchronously
+
+::: chatsnack.resolve_fillings_a
+
+## Limits and results
+
+### `FillingLimits`
+
+::: chatsnack.FillingLimits
+
+### `FillingResolution`
+
+::: chatsnack.FillingResolution
+
+## Filling sources
+
+### `FillingSource`
+
+::: chatsnack.FillingSource
+
+### `ChatsnackFillingSource`
+
+::: chatsnack.ChatsnackFillingSource
+
+## Errors
+
+All direct resolver errors inherit from `FillingError`.
+
+### `FillingError`
+
+::: chatsnack.FillingError
+
+### `FillingAuthorityError`
+
+::: chatsnack.FillingAuthorityError
+
+### `FillingLimitError`
+
+::: chatsnack.FillingLimitError
+
+### `FillingCycleError`
+
+::: chatsnack.FillingCycleError
+
+### `FillingResolutionError`
+
+::: chatsnack.FillingResolutionError

--- a/docs/reference/api/fillings.md
+++ b/docs/reference/api/fillings.md
@@ -5,33 +5,9 @@ know the finite set of saved text and chat references they need. The
 [Fillings and Composition guide](../../guides/fillings.md) explains when to use
 it and how resolution behaves.
 
-## Resolve synchronously
-
-::: chatsnack.resolve_fillings
-
-## Resolve asynchronously
+## Resolve known references
 
 ::: chatsnack.resolve_fillings_a
-
-## Limits and results
-
-### `FillingLimits`
-
-::: chatsnack.FillingLimits
-
-### `FillingResolution`
-
-::: chatsnack.FillingResolution
-
-## Filling sources
-
-### `FillingSource`
-
-::: chatsnack.FillingSource
-
-### `ChatsnackFillingSource`
-
-::: chatsnack.ChatsnackFillingSource
 
 ## Errors
 
@@ -48,11 +24,3 @@ All direct resolver errors inherit from `FillingError`.
 ### `FillingLimitError`
 
 ::: chatsnack.FillingLimitError
-
-### `FillingCycleError`
-
-::: chatsnack.FillingCycleError
-
-### `FillingResolutionError`
-
-::: chatsnack.FillingResolutionError

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -6,6 +6,7 @@ The generated reference in this section stays focused on the stable public path 
 
 - [Chat](api/chat.md)
 - [Text](api/text.md)
+- [Fillings](api/fillings.md)
 - [Utensils](api/utensils.md)
 - [Packs](api/packs.md)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
       - reference/index.md
       - Chat: reference/api/chat.md
       - Text: reference/api/text.md
+      - Fillings: reference/api/fillings.md
       - Utensils: reference/api/utensils.md
       - Packs: reference/api/packs.md
   - Philosophy: philosophy.md

--- a/notebooks/ExperimentingWithChatsnack.ipynb
+++ b/notebooks/ExperimentingWithChatsnack.ipynb
@@ -573,6 +573,30 @@
     "        \"usage_reported\": response.usage_reported,\n",
     "    })\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Resolve Known Fillings\n",
+    "Assemblers that already found specific filling names can expand those names through Chatsnack's usual filling engine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from chatsnack import Text, resolve_fillings_a\n",
+    "\n",
+    "Text(name=\"ReadmeVoice\", content=\"Keep the README {tone}.\").save()\n",
+    "resolved = await resolve_fillings_a(\n",
+    "    [\"text.ReadmeVoice\"],\n",
+    "    variables={\"tone\": \"welcoming\"},\n",
+    ")\n",
+    "print(resolved[\"text\"][\"ReadmeVoice\"])\n"
+   ]
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chatsnack"
-version = "0.8.0"
+version = "0.8.1"
 description = "chatsnack is the easiest Python library for rapid development with OpenAI's ChatGPT API. It provides an intuitive interface for creating and managing chat-based prompts and responses, making it convenient to build complex, interactive conversations with AI."
 authors = ["Mattie Casper"]
 license = "MIT"

--- a/tests/test_filling_resolution.py
+++ b/tests/test_filling_resolution.py
@@ -105,6 +105,66 @@ def test_goal_authorized_chat_can_use_nested_text_and_chat_fillings(
     assert calls == ["Parent", "Child"]
 
 
+@pytest.mark.parametrize("variable_name", ["usermsg", "files", "images"])
+def test_chat_resolution_keeps_query_control_names_as_template_variables(
+    tmp_path,
+    monkeypatch,
+    variable_name,
+):
+    save_chat(tmp_path, "Reserved", f"reserved {{{variable_name}}}")
+    prompts = []
+
+    async def capture_prompt(self, prompt, **kwargs):
+        prompts.append(prompt)
+        return "resolved"
+
+    monkeypatch.setattr(Chat, "_cleaned_chat_completion", capture_prompt)
+
+    with use_filling_stash(tmp_path):
+        result = asyncio.run(
+            resolve_fillings_a(
+                ["chat.Reserved"],
+                variables={variable_name: "kept"},
+                allow_chat=True,
+            )
+        )
+
+    assert result == {"chat": {"Reserved": "resolved"}}
+    assert len(prompts) == 1
+    assert "reserved kept" in prompts[0]
+
+
+def test_chat_resolution_forwards_query_control_names_to_ask_override(
+    tmp_path,
+    monkeypatch,
+):
+    save_chat(tmp_path, "Reserved", "reserved {usermsg} {files} {images}")
+    calls = []
+
+    async def build_without_provider(self, **variables):
+        calls.append(variables)
+        return await self._build_final_prompt(variables)
+
+    monkeypatch.setattr(Chat, "ask_a", build_without_provider)
+    variables = {
+        "usermsg": "hello",
+        "files": "notes",
+        "images": "cover",
+    }
+
+    with use_filling_stash(tmp_path):
+        result = asyncio.run(
+            resolve_fillings_a(
+                ["chat.Reserved"],
+                variables=variables,
+                allow_chat=True,
+            )
+        )
+
+    assert "reserved hello notes cover" in result["chat"]["Reserved"]
+    assert calls == [variables]
+
+
 def test_explicit_values_win_without_loading_assets_or_chat_authority(monkeypatch):
     async def unexpected_call(name, additional):
         raise AssertionError(f"catalog called for {name}")

--- a/tests/test_filling_resolution.py
+++ b/tests/test_filling_resolution.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 import pytest
 from snapclass import Stash
 
+import chatsnack
 from chatsnack import Chat, Text
 from chatsnack.fillings import (
     FillingAuthorityError,
@@ -128,6 +129,26 @@ def test_explicit_values_win_without_loading_assets_or_chat_authority(monkeypatc
     }
 
 
+def test_replacement_chat_callback_obeys_resolver_authority(monkeypatch):
+    calls = []
+
+    async def replacement(name, additional):
+        calls.append(name)
+        return "generated"
+
+    monkeypatch.setitem(snack_catalog.vendors, "chat", replacement)
+
+    with pytest.raises(FillingAuthorityError):
+        asyncio.run(resolve_fillings_a(["chat.Dynamic"]))
+    assert calls == []
+
+    result = asyncio.run(
+        resolve_fillings_a(["chat.Dynamic"], allow_chat=True)
+    )
+    assert result == {"chat": {"Dynamic": "generated"}}
+    assert calls == ["Dynamic"]
+
+
 def test_namespace_overrides_only_apply_to_explicitly_requested_references(tmp_path):
     save_text(tmp_path, "Outer", "saved {text.Inner}")
     save_text(tmp_path, "Inner", "inner asset")
@@ -249,6 +270,27 @@ def test_fixed_chat_limit_stops_before_the_seventeenth_model_call(
     assert calls == [f"C{index}" for index in range(16)]
 
 
+def test_missing_chats_do_not_consume_the_model_call_budget(tmp_path, monkeypatch):
+    references = [f"chat.Missing{index}" for index in range(16)]
+    references.append("chat.Valid")
+    save_chat(tmp_path, "Valid", "valid")
+    calls = []
+
+    async def fake_provider(self, **variables):
+        calls.append(self.name)
+        return "resolved"
+
+    monkeypatch.setattr(Chat, "ask_a", fake_provider)
+
+    with use_filling_stash(tmp_path):
+        result = asyncio.run(
+            resolve_fillings_a(references, allow_chat=True)
+        )
+
+    assert result["chat"] == {"Valid": "resolved"}
+    assert calls == ["Valid"]
+
+
 def test_provider_failure_is_content_free(tmp_path, monkeypatch):
     save_chat(tmp_path, "Broken", "private prompt")
 
@@ -309,3 +351,30 @@ def test_normal_chat_prompt_expansion_keeps_its_existing_path(tmp_path):
     prompt = asyncio.run(chat._build_final_prompt({}))
 
     assert "Use clear instructions." in prompt
+
+
+def test_normal_chat_fillings_have_no_resolver_authority_or_call_cap(
+    tmp_path,
+    monkeypatch,
+):
+    save_chat(tmp_path, "Child", "child")
+    save_chat(tmp_path, "Parent", " ".join(["{chat.Child}"] * 17))
+    parent = Chat.objects(Stash(tmp_path)).get("Parent")
+    calls = []
+
+    async def fake_provider(self, **variables):
+        calls.append(self.name)
+        return "resolved"
+
+    monkeypatch.setattr(Chat, "ask_a", fake_provider)
+
+    prompt = asyncio.run(parent._build_final_prompt({}))
+
+    assert prompt.count("resolved") == 17
+    assert calls == ["Child"] * 17
+
+
+def test_resolver_policy_helpers_are_not_public_top_level_names():
+    assert not hasattr(chatsnack, "bounded_filling_expansion")
+    assert not hasattr(chatsnack, "filling_resolution_active")
+    assert not hasattr(chatsnack, "missing_filling")

--- a/tests/test_filling_resolution.py
+++ b/tests/test_filling_resolution.py
@@ -54,7 +54,11 @@ def test_goal_known_reference_uses_the_shared_formatter_catalog(monkeypatch):
 
 
 def test_goal_recursive_text_uses_main_expansion_and_keeps_values_opaque(tmp_path):
-    save_text(tmp_path, "Outer", "before {text.Inner} {topic} after")
+    save_text(
+        tmp_path,
+        "Outer",
+        "before {text.Inner} {topic} {self} {format_string} after",
+    )
     save_text(tmp_path, "Inner", "literal {payload}")
     save_text(tmp_path, "NotRescanned", "wrong")
 
@@ -65,13 +69,17 @@ def test_goal_recursive_text_uses_main_expansion_and_keeps_values_opaque(tmp_pat
                 variables={
                     "topic": "snacks",
                     "payload": "{text.NotRescanned}",
+                    "self": "reader",
+                    "format_string": "layout",
                 },
             )
         )
 
     assert result == {
         "text": {
-            "Outer": "before literal {text.NotRescanned} snacks after",
+            "Outer": (
+                "before literal {text.NotRescanned} snacks reader layout after"
+            ),
         }
     }
 
@@ -115,6 +123,8 @@ def test_goal_authorized_chat_can_use_nested_text_and_chat_fillings(
         "track_continuation",
         "_call_usage_ledger",
         "_submitted_runtime_out",
+        "self",
+        "format_string",
     ],
 )
 def test_chat_resolution_keeps_query_control_names_as_template_variables(

--- a/tests/test_filling_resolution.py
+++ b/tests/test_filling_resolution.py
@@ -619,13 +619,14 @@ def test_cancellation_propagates(tmp_path, monkeypatch):
             )
 
 
-def test_hyphenated_names_are_valid(tmp_path):
-    save_text(tmp_path, "snack-style", "playful")
+@pytest.mark.parametrize("name", ["snack-style", "123"])
+def test_supported_asset_names_are_valid(tmp_path, name):
+    save_text(tmp_path, name, "playful")
 
     with use_filling_stash(tmp_path):
-        result = asyncio.run(resolve_fillings_a(["text.snack-style"]))
+        result = asyncio.run(resolve_fillings_a([f"text.{name}"]))
 
-    assert result == {"text": {"snack-style": "playful"}}
+    assert result == {"text": {name: "playful"}}
 
 
 def test_adapter_attribute_names_still_route_through_catalog_policy(tmp_path):

--- a/tests/test_filling_resolution.py
+++ b/tests/test_filling_resolution.py
@@ -1,0 +1,259 @@
+import asyncio
+
+import pytest
+from snapclass import Stash
+
+from chatsnack import Text
+from chatsnack.fillings import (
+    ChatsnackFillingSource,
+    FillingAuthorityError,
+    FillingCycleError,
+    FillingLimits,
+    FillingLimitError,
+    FillingResolutionError,
+    resolve_fillings,
+    resolve_fillings_a,
+)
+
+
+class FakeFillingSource:
+    def __init__(self, *, texts=None, chats=None, delays=None):
+        self.texts = dict(texts or {})
+        self.chats = dict(chats or {})
+        self.delays = dict(delays or {})
+        self.chat_started = []
+        self.active_chat_calls = 0
+        self.peak_chat_calls = 0
+
+    def load_text(self, name):
+        return self.texts.get(name)
+
+    async def resolve_chat(self, name, variables):
+        if name not in self.chats:
+            return None
+        self.chat_started.append(name)
+        self.active_chat_calls += 1
+        self.peak_chat_calls = max(self.peak_chat_calls, self.active_chat_calls)
+        try:
+            await asyncio.sleep(self.delays.get(name, 0))
+            value = self.chats[name]
+            if isinstance(value, Exception):
+                raise value
+            return value
+        finally:
+            self.active_chat_calls -= 1
+
+
+def test_explicit_values_win_without_catalog_lookup_or_chat_authority():
+    source = FakeFillingSource(
+        texts={"Voice": "catalog text"},
+        chats={"Costly": "catalog chat"},
+    )
+
+    result = asyncio.run(
+        resolve_fillings_a(
+            ["text.Voice", "chat.Costly"],
+            variables={
+                "text": {"Voice": "explicit text"},
+                "chat": {"Costly": "explicit chat"},
+            },
+            source=source,
+        )
+    )
+
+    assert result.context == {
+        "text": {"Voice": "explicit text"},
+        "chat": {"Costly": "explicit chat"},
+    }
+    assert result.resolved_references == ()
+    assert result.missing_references == ()
+    assert source.chat_started == []
+
+
+def test_missing_catalog_names_stay_absent():
+    result = asyncio.run(
+        resolve_fillings_a(
+            ["text.Missing"],
+            source=FakeFillingSource(),
+        )
+    )
+
+    assert result.context == {"text": {}}
+    assert result.missing_references == ("text.Missing",)
+
+
+def test_recursive_text_is_expanded_but_inserted_results_are_opaque():
+    source = FakeFillingSource(
+        texts={
+            "Outer": "before {text.Inner} after",
+            "Inner": "literal {payload}",
+            "NotRescanned": "wrong",
+        }
+    )
+
+    result = asyncio.run(
+        resolve_fillings_a(
+            ["text.Outer"],
+            variables={"payload": "{text.NotRescanned}"},
+            source=source,
+        )
+    )
+
+    assert result.context == {
+        "text": {"Outer": "before literal {text.NotRescanned} after"}
+    }
+    assert result.resolved_references == ("text.Inner", "text.Outer")
+
+
+def test_transitive_chat_reference_is_denied_before_calling_source():
+    source = FakeFillingSource(
+        texts={"Outer": "answer: {chat.Costly}"},
+        chats={"Costly": "paid answer"},
+    )
+
+    with pytest.raises(FillingAuthorityError) as caught:
+        asyncio.run(resolve_fillings_a(["text.Outer"], source=source))
+
+    assert "text.Outer -> chat.Costly" in str(caught.value)
+    assert source.chat_started == []
+
+
+def test_allowed_chats_fan_out_with_stable_scheduling_and_bounded_concurrency():
+    source = FakeFillingSource(
+        chats={"First": "one", "Second": "two", "Third": "three"},
+        delays={"First": 0.03, "Second": 0.01, "Third": 0},
+    )
+
+    result = asyncio.run(
+        resolve_fillings_a(
+            ["chat.First", "chat.Second", "chat.Third"],
+            allow_chat=True,
+            limits=FillingLimits(max_chat_concurrency=2),
+            source=source,
+        )
+    )
+
+    assert source.chat_started == ["First", "Second", "Third"]
+    assert source.peak_chat_calls == 2
+    assert list(result.context["chat"]) == ["First", "Second", "Third"]
+    assert result.context["chat"] == {
+        "First": "one",
+        "Second": "two",
+        "Third": "three",
+    }
+
+
+def test_text_cycles_report_only_the_reference_chain():
+    source = FakeFillingSource(
+        texts={
+            "A": "secret-a {text.B}",
+            "B": "secret-b {text.A}",
+        }
+    )
+
+    with pytest.raises(FillingCycleError) as caught:
+        asyncio.run(resolve_fillings_a(["text.A"], source=source))
+
+    assert str(caught.value) == "filling cycle: text.A -> text.B -> text.A"
+    assert "secret" not in str(caught.value)
+
+
+def test_provider_failure_does_not_leak_prompt_or_response_content():
+    source = FakeFillingSource(
+        chats={"Broken": RuntimeError("provider leaked a secret response")}
+    )
+
+    with pytest.raises(FillingResolutionError) as caught:
+        asyncio.run(
+            resolve_fillings_a(
+                ["chat.Broken"],
+                allow_chat=True,
+                source=source,
+            )
+        )
+
+    assert str(caught.value) == "could not resolve chat.Broken"
+    assert "secret" not in str(caught.value)
+
+
+def test_sync_resolver_matches_async_contract():
+    result = resolve_fillings(
+        ["text.Voice"],
+        source=FakeFillingSource(texts={"Voice": "concise"}),
+    )
+
+    assert result.context == {"text": {"Voice": "concise"}}
+
+
+def test_sync_resolver_rejects_an_active_event_loop():
+    async def invoke_sync_resolver():
+        with pytest.raises(RuntimeError, match=r"Use resolve_fillings_a\(\)"):
+            resolve_fillings([], source=FakeFillingSource())
+
+    asyncio.run(invoke_sync_resolver())
+
+
+@pytest.mark.parametrize(
+    ("name", "maximum"),
+    [
+        ("max_depth", 64),
+        ("max_nodes", 4096),
+        ("max_chat_calls", 256),
+        ("max_chat_concurrency", 32),
+    ],
+)
+def test_filling_limits_have_finite_inclusive_ceilings(name, maximum):
+    FillingLimits(**{name: maximum})
+
+    with pytest.raises(ValueError, match=name):
+        FillingLimits(**{name: maximum + 1})
+
+
+def test_boolean_is_not_an_integer_filling_limit():
+    with pytest.raises(TypeError, match="max_chat_calls"):
+        FillingLimits(max_chat_calls=True)
+
+
+def test_node_limit_applies_to_the_transitive_text_graph():
+    source = FakeFillingSource(texts={"A": "{text.B}", "B": "done"})
+
+    with pytest.raises(FillingLimitError, match="node limit"):
+        resolve_fillings(
+            ["text.A"],
+            limits=FillingLimits(max_nodes=1),
+            source=source,
+        )
+
+
+def test_chat_call_limit_fails_before_any_chat_is_started():
+    source = FakeFillingSource(chats={"A": "one", "B": "two"})
+
+    with pytest.raises(FillingLimitError, match="call limit"):
+        resolve_fillings(
+            ["chat.A", "chat.B"],
+            allow_chat=True,
+            limits=FillingLimits(max_chat_calls=1),
+            source=source,
+        )
+
+    assert source.chat_started == []
+
+
+def test_missing_transitive_text_reports_its_dependency_chain():
+    source = FakeFillingSource(texts={"Outer": "{text.Missing}"})
+
+    with pytest.raises(FillingResolutionError) as caught:
+        resolve_fillings(["text.Outer"], source=source)
+
+    assert "text.Outer -> text.Missing" in str(caught.value)
+
+
+def test_default_source_resolves_a_persisted_text_through_public_storage(tmp_path):
+    Text(name="Voice", content="clear").save(tmp_path / "Voice.txt")
+
+    result = resolve_fillings(
+        ["text.Voice"],
+        source=ChatsnackFillingSource(stash=Stash(tmp_path)),
+    )
+
+    assert result.context["text"]["Voice"] == "clear"

--- a/tests/test_filling_resolution.py
+++ b/tests/test_filling_resolution.py
@@ -160,7 +160,11 @@ def test_chat_resolution_forwards_query_control_names_to_ask_override(
     tmp_path,
     monkeypatch,
 ):
-    save_chat(tmp_path, "Reserved", "reserved {usermsg} {files} {images}")
+    save_chat(
+        tmp_path,
+        "Reserved",
+        "reserved {usermsg} {files} {images} {self}",
+    )
     calls = []
 
     async def build_without_provider(self, **variables):
@@ -172,6 +176,7 @@ def test_chat_resolution_forwards_query_control_names_to_ask_override(
         "usermsg": "hello",
         "files": "notes",
         "images": "cover",
+        "self": "reader",
     }
 
     with use_filling_stash(tmp_path):
@@ -183,8 +188,10 @@ def test_chat_resolution_forwards_query_control_names_to_ask_override(
             )
         )
 
-    assert "reserved hello notes cover" in result["chat"]["Reserved"]
-    assert calls == [variables]
+    assert "reserved hello notes cover reader" in result["chat"]["Reserved"]
+    assert calls == [
+        {key: value for key, value in variables.items() if key != "self"}
+    ]
 
 
 @pytest.mark.parametrize("asset_shape", ["text_fields", "chat_messages"])
@@ -343,6 +350,18 @@ def test_resolver_still_tolerates_malformed_assistant_braces(
     assert result == {"chat": {"AssistantHistory": "resolved"}}
     assert len(prompts) == 1
     assert "unfinished {" in prompts[0]
+
+
+def test_normal_assistant_history_still_tolerates_filling_errors(monkeypatch):
+    async def fail(name, additional):
+        raise FillingError("custom filling failed")
+
+    monkeypatch.setitem(snack_catalog.vendors, "custom", fail)
+    chat = Chat().assistant("kept {custom.Value}")
+
+    prompt = asyncio.run(chat._build_final_prompt({}))
+
+    assert "kept {custom.Value}" in prompt
 
 
 def test_explicit_values_win_without_loading_assets_or_chat_authority(monkeypatch):
@@ -619,7 +638,19 @@ def test_cancellation_propagates(tmp_path, monkeypatch):
             )
 
 
-@pytest.mark.parametrize("name", ["snack-style", "123"])
+@pytest.mark.parametrize(
+    "name",
+    [
+        "SnackStyle",
+        "snack-style",
+        "123",
+        "-snack",
+        "café",
+        "snack style",
+        ".hidden",
+        "snack.style",
+    ],
+)
 def test_supported_asset_names_are_valid(tmp_path, name):
     save_text(tmp_path, name, "playful")
 
@@ -642,7 +673,17 @@ def test_adapter_attribute_names_still_route_through_catalog_policy(tmp_path):
 
 @pytest.mark.parametrize(
     "reference",
-    ["text../secret", "text.Snack/Secret", "text.Snack.Secret", "other.Name"],
+    [
+        "text.",
+        "text..",
+        "text...",
+        "text../secret",
+        "text.Snack/Secret",
+        r"text.Snack\Secret",
+        "text.Snack:raw",
+        "text.Snack!r",
+        "other.Name",
+    ],
 )
 def test_references_reject_non_static_or_traversal_shapes(reference):
     with pytest.raises(ValueError, match="static text.Name or chat.Name"):

--- a/tests/test_filling_resolution.py
+++ b/tests/test_filling_resolution.py
@@ -82,6 +82,33 @@ def test_missing_catalog_names_stay_absent():
     assert result.missing_references == ("text.Missing",)
 
 
+def test_hyphenated_text_and_chat_asset_names_are_valid_references():
+    source = FakeFillingSource(
+        texts={"snack-style": "playful"},
+        chats={"snack-picker": "popcorn"},
+    )
+
+    result = resolve_fillings(
+        ["text.snack-style", "chat.snack-picker"],
+        allow_chat=True,
+        source=source,
+    )
+
+    assert result.context == {
+        "text": {"snack-style": "playful"},
+        "chat": {"snack-picker": "popcorn"},
+    }
+
+
+@pytest.mark.parametrize(
+    "reference",
+    ["text../secret", "text.Snack/Secret", "text.Snack.Secret"],
+)
+def test_asset_references_reject_traversal_characters(reference):
+    with pytest.raises(ValueError, match="static text.Name or chat.Name"):
+        resolve_fillings([reference], source=FakeFillingSource())
+
+
 def test_recursive_text_is_expanded_but_inserted_results_are_opaque():
     source = FakeFillingSource(
         texts={
@@ -257,3 +284,38 @@ def test_default_source_resolves_a_persisted_text_through_public_storage(tmp_pat
     )
 
     assert result.context["text"]["Voice"] == "clear"
+
+
+def test_default_chat_source_keeps_reserved_namespaces_out_of_query_variables(
+    monkeypatch,
+):
+    captured = {}
+
+    class FakePrompt:
+        async def ask_a(self, **variables):
+            captured.update(variables)
+            return "popcorn"
+
+    class FakeObjects:
+        def get_or_none(self, name):
+            assert name == "SnackPicker"
+            return FakePrompt()
+
+    source = ChatsnackFillingSource()
+    monkeypatch.setattr(source, "_objects", lambda model: FakeObjects())
+
+    result = asyncio.run(
+        resolve_fillings_a(
+            ["chat.SnackPicker"],
+            variables={
+                "topic": "movie night",
+                "text": {"Voice": "playful"},
+                "chat": {"Other": "pretzels"},
+            },
+            allow_chat=True,
+            source=source,
+        )
+    )
+
+    assert result.context["chat"]["SnackPicker"] == "popcorn"
+    assert captured == {"topic": "movie night"}

--- a/tests/test_filling_resolution.py
+++ b/tests/test_filling_resolution.py
@@ -275,6 +275,19 @@ def test_missing_transitive_text_reports_its_dependency_chain():
     assert "text.Outer -> text.Missing" in str(caught.value)
 
 
+def test_missing_variable_reports_its_name_and_text_dependency_chain():
+    source = FakeFillingSource(
+        texts={"Outer": "{text.Inner}", "Inner": "{payload}"}
+    )
+
+    with pytest.raises(FillingResolutionError) as caught:
+        resolve_fillings(["text.Outer"], source=source)
+
+    assert str(caught.value) == (
+        "could not resolve variable payload (via text.Outer -> text.Inner)"
+    )
+
+
 def test_default_source_resolves_a_persisted_text_through_public_storage(tmp_path):
     Text(name="Voice", content="clear").save(tmp_path / "Voice.txt")
 
@@ -292,6 +305,9 @@ def test_default_chat_source_keeps_reserved_namespaces_out_of_query_variables(
     captured = {}
 
     class FakePrompt:
+        def get_messages(self):
+            return []
+
         async def ask_a(self, **variables):
             captured.update(variables)
             return "popcorn"
@@ -319,3 +335,45 @@ def test_default_chat_source_keeps_reserved_namespaces_out_of_query_variables(
 
     assert result.context["chat"]["SnackPicker"] == "popcorn"
     assert captured == {"topic": "movie night"}
+
+
+@pytest.mark.parametrize("nested_reference", ["text.Child", "chat.Child"])
+def test_default_chat_source_rejects_nested_fillings_before_provider_io(
+    monkeypatch,
+    nested_reference,
+):
+    provider_calls = []
+
+    class FakePrompt:
+        def get_messages(self):
+            return [
+                {
+                    "role": "system",
+                    "content": f"Nested value: {{{nested_reference}}}",
+                }
+            ]
+
+        async def ask_a(self, **variables):
+            provider_calls.append(variables)
+            return "should not run"
+
+    class FakeObjects:
+        def get_or_none(self, name):
+            assert name == "Parent"
+            return FakePrompt()
+
+    source = ChatsnackFillingSource()
+    monkeypatch.setattr(source, "_objects", lambda model: FakeObjects())
+
+    with pytest.raises(
+        FillingResolutionError,
+        match=rf"nested filling {nested_reference}.*chat.Parent",
+    ):
+        resolve_fillings(
+            ["chat.Parent"],
+            allow_chat=True,
+            limits=FillingLimits(max_chat_calls=1),
+            source=source,
+        )
+
+    assert provider_calls == []

--- a/tests/test_filling_resolution.py
+++ b/tests/test_filling_resolution.py
@@ -228,6 +228,62 @@ def test_resolver_cancels_sibling_expansions_before_returning_an_error(
     asyncio.run(exercise())
 
 
+def test_resolver_propagates_missing_fillings_from_assistant_messages(
+    tmp_path,
+    monkeypatch,
+):
+    Chat(name="AssistantHistory").assistant("{text.Missing}").save(
+        tmp_path / "AssistantHistory.yml"
+    )
+    provider_calls = []
+
+    async def unexpected_provider(self, prompt, **kwargs):
+        provider_calls.append(prompt)
+        return "unexpected"
+
+    monkeypatch.setattr(Chat, "_cleaned_chat_completion", unexpected_provider)
+
+    with use_filling_stash(tmp_path):
+        with pytest.raises(FillingError) as caught:
+            asyncio.run(
+                resolve_fillings_a(
+                    ["chat.AssistantHistory"],
+                    allow_chat=True,
+                )
+            )
+
+    assert "chat.AssistantHistory -> text.Missing" in str(caught.value)
+    assert provider_calls == []
+
+
+def test_resolver_still_tolerates_malformed_assistant_braces(
+    tmp_path,
+    monkeypatch,
+):
+    Chat(name="AssistantHistory").assistant("unfinished {").save(
+        tmp_path / "AssistantHistory.yml"
+    )
+    prompts = []
+
+    async def capture_prompt(self, prompt, **kwargs):
+        prompts.append(prompt)
+        return "resolved"
+
+    monkeypatch.setattr(Chat, "_cleaned_chat_completion", capture_prompt)
+
+    with use_filling_stash(tmp_path):
+        result = asyncio.run(
+            resolve_fillings_a(
+                ["chat.AssistantHistory"],
+                allow_chat=True,
+            )
+        )
+
+    assert result == {"chat": {"AssistantHistory": "resolved"}}
+    assert len(prompts) == 1
+    assert "unfinished {" in prompts[0]
+
+
 def test_explicit_values_win_without_loading_assets_or_chat_authority(monkeypatch):
     async def unexpected_call(name, additional):
         raise AssertionError(f"catalog called for {name}")
@@ -412,6 +468,35 @@ def test_missing_chats_do_not_consume_the_model_call_budget(tmp_path, monkeypatc
 
     assert result["chat"] == {"Valid": "resolved"}
     assert calls == ["Valid"]
+
+
+def test_missing_chat_after_full_model_call_budget_is_still_omitted(
+    tmp_path,
+    monkeypatch,
+):
+    references = []
+    for index in range(16):
+        name = f"Valid{index}"
+        references.append(f"chat.{name}")
+        save_chat(tmp_path, name, name)
+    references.append("chat.Missing")
+    calls = []
+
+    async def fake_provider(self, **variables):
+        calls.append(self.name)
+        return self.name
+
+    monkeypatch.setattr(Chat, "ask_a", fake_provider)
+
+    with use_filling_stash(tmp_path):
+        result = asyncio.run(
+            resolve_fillings_a(references, allow_chat=True)
+        )
+
+    assert result["chat"] == {
+        f"Valid{index}": f"Valid{index}" for index in range(16)
+    }
+    assert calls == [f"Valid{index}" for index in range(16)]
 
 
 def test_provider_failure_is_content_free(tmp_path, monkeypatch):

--- a/tests/test_filling_resolution.py
+++ b/tests/test_filling_resolution.py
@@ -510,6 +510,31 @@ def test_fixed_chat_limit_stops_before_the_seventeenth_model_call(
     assert calls == [f"C{index}" for index in range(16)]
 
 
+def test_replacement_chat_limit_reports_the_complete_transitive_chain(
+    tmp_path,
+    monkeypatch,
+):
+    save_text(tmp_path, "Root", "{chat.Overflow}")
+    calls = []
+
+    async def replacement(name, additional):
+        calls.append(name)
+        return name
+
+    monkeypatch.setitem(snack_catalog.vendors, "chat", replacement)
+    references = [f"chat.C{index}" for index in range(16)] + ["text.Root"]
+
+    with use_filling_stash(tmp_path):
+        with pytest.raises(FillingLimitError) as caught:
+            asyncio.run(resolve_fillings_a(references, allow_chat=True))
+
+    assert str(caught.value) == (
+        "chat filling call limit exceeded while resolving chat.Overflow "
+        "(via text.Root -> chat.Overflow)"
+    )
+    assert calls == [f"C{index}" for index in range(16)]
+
+
 def test_missing_chats_do_not_consume_the_model_call_budget(tmp_path, monkeypatch):
     references = [f"chat.Missing{index}" for index in range(16)]
     references.append("chat.Valid")

--- a/tests/test_filling_resolution.py
+++ b/tests/test_filling_resolution.py
@@ -105,7 +105,18 @@ def test_goal_authorized_chat_can_use_nested_text_and_chat_fillings(
     assert calls == ["Parent", "Child"]
 
 
-@pytest.mark.parametrize("variable_name", ["usermsg", "files", "images"])
+@pytest.mark.parametrize(
+    "variable_name",
+    [
+        "usermsg",
+        "files",
+        "images",
+        "__user",
+        "track_continuation",
+        "_call_usage_ledger",
+        "_submitted_runtime_out",
+    ],
+)
 def test_chat_resolution_keeps_query_control_names_as_template_variables(
     tmp_path,
     monkeypatch,
@@ -163,6 +174,58 @@ def test_chat_resolution_forwards_query_control_names_to_ask_override(
 
     assert "reserved hello notes cover" in result["chat"]["Reserved"]
     assert calls == [variables]
+
+
+@pytest.mark.parametrize("asset_shape", ["text_fields", "chat_messages"])
+def test_resolver_cancels_sibling_expansions_before_returning_an_error(
+    tmp_path,
+    monkeypatch,
+    asset_shape,
+):
+    if asset_shape == "text_fields":
+        save_text(tmp_path, "Parallel", "{chat.Failing} {chat.Slow}")
+        reference = "text.Parallel"
+    else:
+        Chat(name="Parallel").system("{chat.Failing}").user(
+            "{chat.Slow}"
+        ).save(tmp_path / "Parallel.yml")
+        reference = "chat.Parallel"
+    save_chat(tmp_path, "Failing", "unused")
+    save_chat(tmp_path, "Slow", "unused")
+    normal_ask_a = Chat.ask_a
+
+    async def exercise():
+        slow_started = asyncio.Event()
+        slow_cancelled = asyncio.Event()
+
+        async def controlled_ask(self, **variables):
+            if self.name == "Slow":
+                slow_started.set()
+                try:
+                    await asyncio.Future()
+                except asyncio.CancelledError:
+                    slow_cancelled.set()
+                    raise
+            if self.name == "Failing":
+                await slow_started.wait()
+                raise RuntimeError("failed")
+            return await normal_ask_a(self, **variables)
+
+        monkeypatch.setattr(Chat, "ask_a", controlled_ask)
+
+        with use_filling_stash(tmp_path):
+            with pytest.raises(FillingError):
+                await asyncio.wait_for(
+                    resolve_fillings_a(
+                        [reference],
+                        allow_chat=True,
+                    ),
+                    timeout=2,
+                )
+
+        assert slow_cancelled.is_set()
+
+    asyncio.run(exercise())
 
 
 def test_explicit_values_win_without_loading_assets_or_chat_authority(monkeypatch):

--- a/tests/test_filling_resolution.py
+++ b/tests/test_filling_resolution.py
@@ -6,6 +6,7 @@ from snapclass import Stash
 
 import chatsnack
 from chatsnack import Chat, Text
+from chatsnack.asynchelpers import aformatter
 from chatsnack.fillings import (
     FillingAuthorityError,
     FillingError,
@@ -234,6 +235,56 @@ def test_resolver_cancels_sibling_expansions_before_returning_an_error(
                 )
 
         assert slow_cancelled.is_set()
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.parametrize("formatting_scope", ["fields", "messages"])
+def test_normal_formatting_failure_does_not_cancel_siblings(formatting_scope):
+    async def exercise():
+        started = asyncio.Event()
+        release = asyncio.Event()
+        cancelled = asyncio.Event()
+        finished = asyncio.Event()
+
+        async def fail():
+            await started.wait()
+            raise RuntimeError("formatting failed")
+
+        async def wait():
+            started.set()
+            try:
+                await release.wait()
+                return "finished"
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+            finally:
+                finished.set()
+
+        class Field:
+            def __init__(self, value):
+                self.value = value
+
+        variables = {
+            "failing": Field(fail),
+            "slow": Field(wait),
+        }
+        if formatting_scope == "fields":
+            formatting = aformatter.async_format(
+                "{failing.value} {slow.value}",
+                **variables,
+            )
+        else:
+            chat = Chat().system("{failing.value}").user("{slow.value}")
+            formatting = chat._build_final_prompt(variables)
+
+        with pytest.raises(RuntimeError, match="^formatting failed$"):
+            await formatting
+
+        release.set()
+        await asyncio.wait_for(finished.wait(), timeout=1)
+        assert not cancelled.is_set()
 
     asyncio.run(exercise())
 

--- a/tests/test_filling_resolution.py
+++ b/tests/test_filling_resolution.py
@@ -145,6 +145,20 @@ def test_transitive_chat_reference_is_denied_before_calling_source():
     assert source.chat_started == []
 
 
+@pytest.mark.parametrize("allow_chat", ["false", 1, None])
+def test_chat_authority_requires_a_boolean(allow_chat):
+    source = FakeFillingSource(chats={"Costly": "paid answer"})
+
+    with pytest.raises(TypeError, match="allow_chat must be a bool"):
+        resolve_fillings(
+            ["chat.Costly"],
+            allow_chat=allow_chat,
+            source=source,
+        )
+
+    assert source.chat_started == []
+
+
 def test_allowed_chats_fan_out_with_stable_scheduling_and_bounded_concurrency():
     source = FakeFillingSource(
         chats={"First": "one", "Second": "two", "Third": "three"},
@@ -337,10 +351,21 @@ def test_default_chat_source_keeps_reserved_namespaces_out_of_query_variables(
     assert captured == {"topic": "movie night"}
 
 
-@pytest.mark.parametrize("nested_reference", ["text.Child", "chat.Child"])
+@pytest.mark.parametrize(
+    ("nested_field", "vendor"),
+    [
+        ("text.Child", "text"),
+        ("chat.Child", "chat"),
+        ("chat.123", "chat"),
+        ("chat.Child.foo", "chat"),
+        ("chat[Child]", "chat"),
+        ("text[Child]", "text"),
+    ],
+)
 def test_default_chat_source_rejects_nested_fillings_before_provider_io(
     monkeypatch,
-    nested_reference,
+    nested_field,
+    vendor,
 ):
     provider_calls = []
 
@@ -349,7 +374,7 @@ def test_default_chat_source_rejects_nested_fillings_before_provider_io(
             return [
                 {
                     "role": "system",
-                    "content": f"Nested value: {{{nested_reference}}}",
+                    "content": f"Nested value: {{{nested_field}}}",
                 }
             ]
 
@@ -367,7 +392,7 @@ def test_default_chat_source_rejects_nested_fillings_before_provider_io(
 
     with pytest.raises(
         FillingResolutionError,
-        match=rf"nested filling {nested_reference}.*chat.Parent",
+        match=rf"nested {vendor} filling.*chat.Parent",
     ):
         resolve_fillings(
             ["chat.Parent"],

--- a/tests/test_filling_resolution.py
+++ b/tests/test_filling_resolution.py
@@ -542,6 +542,17 @@ def test_hyphenated_names_are_valid(tmp_path):
     assert result == {"text": {"snack-style": "playful"}}
 
 
+def test_adapter_attribute_names_still_route_through_catalog_policy(tmp_path):
+    save_text(tmp_path, "vendor", "saved value")
+
+    with use_filling_stash(tmp_path):
+        result = asyncio.run(resolve_fillings_a(["text.vendor"]))
+        with pytest.raises(FillingAuthorityError):
+            asyncio.run(resolve_fillings_a(["chat.vendor"]))
+
+    assert result == {"text": {"vendor": "saved value"}}
+
+
 @pytest.mark.parametrize(
     "reference",
     ["text../secret", "text.Snack/Secret", "text.Snack.Secret", "other.Name"],

--- a/tests/test_filling_resolution.py
+++ b/tests/test_filling_resolution.py
@@ -1,404 +1,311 @@
 import asyncio
+from contextlib import contextmanager
 
 import pytest
 from snapclass import Stash
 
-from chatsnack import Text
+from chatsnack import Chat, Text
 from chatsnack.fillings import (
-    ChatsnackFillingSource,
     FillingAuthorityError,
-    FillingCycleError,
-    FillingLimits,
+    FillingError,
     FillingLimitError,
-    FillingResolutionError,
-    resolve_fillings,
+    active_filling_stash,
     resolve_fillings_a,
+    snack_catalog,
 )
 
 
-class FakeFillingSource:
-    def __init__(self, *, texts=None, chats=None, delays=None):
-        self.texts = dict(texts or {})
-        self.chats = dict(chats or {})
-        self.delays = dict(delays or {})
-        self.chat_started = []
-        self.active_chat_calls = 0
-        self.peak_chat_calls = 0
-
-    def load_text(self, name):
-        return self.texts.get(name)
-
-    async def resolve_chat(self, name, variables):
-        if name not in self.chats:
-            return None
-        self.chat_started.append(name)
-        self.active_chat_calls += 1
-        self.peak_chat_calls = max(self.peak_chat_calls, self.active_chat_calls)
-        try:
-            await asyncio.sleep(self.delays.get(name, 0))
-            value = self.chats[name]
-            if isinstance(value, Exception):
-                raise value
-            return value
-        finally:
-            self.active_chat_calls -= 1
+@contextmanager
+def use_filling_stash(path):
+    token = active_filling_stash.set(Stash(path))
+    try:
+        yield
+    finally:
+        active_filling_stash.reset(token)
 
 
-def test_explicit_values_win_without_catalog_lookup_or_chat_authority():
-    source = FakeFillingSource(
-        texts={"Voice": "catalog text"},
-        chats={"Costly": "catalog chat"},
-    )
+def save_text(path, name, content):
+    Text(name=name, content=content).save(path / f"{name}.txt")
+
+
+def save_chat(path, name, content):
+    Chat(name=name).system(content).save(path / f"{name}.yml")
+
+
+def test_goal_known_reference_uses_the_shared_formatter_catalog(monkeypatch):
+    calls = []
+
+    async def expand(name, additional):
+        calls.append((name, additional))
+        return f"{additional['tone']} {name}"
+
+    monkeypatch.setitem(snack_catalog.vendors, "text", expand)
 
     result = asyncio.run(
         resolve_fillings_a(
-            ["text.Voice", "chat.Costly"],
-            variables={
-                "text": {"Voice": "explicit text"},
-                "chat": {"Costly": "explicit chat"},
-            },
-            source=source,
+            ["text.Voice"],
+            variables={"tone": "bright"},
         )
     )
 
-    assert result.context == {
-        "text": {"Voice": "explicit text"},
-        "chat": {"Costly": "explicit chat"},
-    }
-    assert result.resolved_references == ()
-    assert result.missing_references == ()
-    assert source.chat_started == []
+    assert result == {"text": {"Voice": "bright Voice"}}
+    assert calls == [("Voice", {"tone": "bright"})]
 
 
-def test_missing_catalog_names_stay_absent():
-    result = asyncio.run(
-        resolve_fillings_a(
-            ["text.Missing"],
-            source=FakeFillingSource(),
+def test_goal_recursive_text_uses_main_expansion_and_keeps_values_opaque(tmp_path):
+    save_text(tmp_path, "Outer", "before {text.Inner} {topic} after")
+    save_text(tmp_path, "Inner", "literal {payload}")
+    save_text(tmp_path, "NotRescanned", "wrong")
+
+    with use_filling_stash(tmp_path):
+        result = asyncio.run(
+            resolve_fillings_a(
+                ["text.Outer"],
+                variables={
+                    "topic": "snacks",
+                    "payload": "{text.NotRescanned}",
+                },
+            )
         )
-    )
 
-    assert result.context == {"text": {}}
-    assert result.missing_references == ("text.Missing",)
-
-
-def test_hyphenated_text_and_chat_asset_names_are_valid_references():
-    source = FakeFillingSource(
-        texts={"snack-style": "playful"},
-        chats={"snack-picker": "popcorn"},
-    )
-
-    result = resolve_fillings(
-        ["text.snack-style", "chat.snack-picker"],
-        allow_chat=True,
-        source=source,
-    )
-
-    assert result.context == {
-        "text": {"snack-style": "playful"},
-        "chat": {"snack-picker": "popcorn"},
-    }
-
-
-@pytest.mark.parametrize(
-    "reference",
-    ["text../secret", "text.Snack/Secret", "text.Snack.Secret"],
-)
-def test_asset_references_reject_traversal_characters(reference):
-    with pytest.raises(ValueError, match="static text.Name or chat.Name"):
-        resolve_fillings([reference], source=FakeFillingSource())
-
-
-def test_recursive_text_is_expanded_but_inserted_results_are_opaque():
-    source = FakeFillingSource(
-        texts={
-            "Outer": "before {text.Inner} after",
-            "Inner": "literal {payload}",
-            "NotRescanned": "wrong",
+    assert result == {
+        "text": {
+            "Outer": "before literal {text.NotRescanned} snacks after",
         }
-    )
+    }
+
+
+def test_goal_authorized_chat_can_use_nested_text_and_chat_fillings(
+    tmp_path,
+    monkeypatch,
+):
+    save_text(tmp_path, "Voice", "Use a {tone} voice.")
+    save_chat(tmp_path, "Child", "child answer")
+    save_chat(tmp_path, "Parent", "{text.Voice} {chat.Child}")
+    calls = []
+
+    async def build_without_provider(self, **variables):
+        calls.append(self.name)
+        return await self._build_final_prompt(variables)
+
+    monkeypatch.setattr(Chat, "ask_a", build_without_provider)
+
+    with use_filling_stash(tmp_path):
+        result = asyncio.run(
+            resolve_fillings_a(
+                ["chat.Parent"],
+                variables={"tone": "playful"},
+                allow_chat=True,
+            )
+        )
+
+    assert "Use a playful voice." in result["chat"]["Parent"]
+    assert "child answer" in result["chat"]["Parent"]
+    assert calls == ["Parent", "Child"]
+
+
+def test_explicit_values_win_without_loading_assets_or_chat_authority(monkeypatch):
+    async def unexpected_call(name, additional):
+        raise AssertionError(f"catalog called for {name}")
+
+    monkeypatch.setitem(snack_catalog.vendors, "text", unexpected_call)
+    monkeypatch.setitem(snack_catalog.vendors, "chat", unexpected_call)
+    explicit = "literal {chat.Costly}"
 
     result = asyncio.run(
         resolve_fillings_a(
-            ["text.Outer"],
-            variables={"payload": "{text.NotRescanned}"},
-            source=source,
+            ["text.Voice", "chat.Answer"],
+            variables={
+                "text": {"Voice": explicit},
+                "chat": {"Answer": 42},
+            },
         )
     )
 
-    assert result.context == {
-        "text": {"Outer": "before literal {text.NotRescanned} after"}
+    assert result == {
+        "text": {"Voice": explicit},
+        "chat": {"Answer": 42},
     }
-    assert result.resolved_references == ("text.Inner", "text.Outer")
 
 
-def test_transitive_chat_reference_is_denied_before_calling_source():
-    source = FakeFillingSource(
-        texts={"Outer": "answer: {chat.Costly}"},
-        chats={"Costly": "paid answer"},
+def test_namespace_overrides_only_apply_to_explicitly_requested_references(tmp_path):
+    save_text(tmp_path, "Outer", "saved {text.Inner}")
+    save_text(tmp_path, "Inner", "inner asset")
+
+    with use_filling_stash(tmp_path):
+        result = asyncio.run(
+            resolve_fillings_a(
+                ["text.Outer"],
+                variables={"text": {"Inner": "override"}},
+            )
+        )
+
+    assert result == {"text": {"Outer": "saved inner asset"}}
+
+
+def test_missing_requested_asset_is_omitted(tmp_path):
+    with use_filling_stash(tmp_path):
+        result = asyncio.run(resolve_fillings_a(["text.Missing"]))
+
+    assert result == {"text": {}}
+
+
+def test_missing_transitive_asset_reports_only_its_reference_chain(tmp_path):
+    save_text(tmp_path, "Outer", "secret {text.Missing}")
+
+    with use_filling_stash(tmp_path):
+        with pytest.raises(FillingError) as caught:
+            asyncio.run(resolve_fillings_a(["text.Outer"]))
+
+    assert str(caught.value) == (
+        "could not resolve text.Missing (via text.Outer -> text.Missing)"
     )
+    assert "secret" not in str(caught.value)
 
-    with pytest.raises(FillingAuthorityError) as caught:
-        asyncio.run(resolve_fillings_a(["text.Outer"], source=source))
+
+def test_transitive_chat_is_denied_before_loading_or_calling_it(tmp_path, monkeypatch):
+    save_text(tmp_path, "Outer", "answer: {chat.Costly}")
+    calls = []
+
+    async def unexpected_provider(self, **variables):
+        calls.append(self.name)
+        return "paid answer"
+
+    monkeypatch.setattr(Chat, "ask_a", unexpected_provider)
+
+    with use_filling_stash(tmp_path):
+        with pytest.raises(FillingAuthorityError) as caught:
+            asyncio.run(resolve_fillings_a(["text.Outer"]))
 
     assert "text.Outer -> chat.Costly" in str(caught.value)
-    assert source.chat_started == []
+    assert calls == []
 
 
 @pytest.mark.parametrize("allow_chat", ["false", 1, None])
 def test_chat_authority_requires_a_boolean(allow_chat):
-    source = FakeFillingSource(chats={"Costly": "paid answer"})
-
     with pytest.raises(TypeError, match="allow_chat must be a bool"):
-        resolve_fillings(
-            ["chat.Costly"],
-            allow_chat=allow_chat,
-            source=source,
+        asyncio.run(
+            resolve_fillings_a(
+                ["chat.Costly"],
+                allow_chat=allow_chat,
+            )
         )
 
-    assert source.chat_started == []
 
+def test_text_cycle_reports_only_the_reference_chain(tmp_path):
+    save_text(tmp_path, "A", "secret-a {text.B}")
+    save_text(tmp_path, "B", "secret-b {text.A}")
 
-def test_allowed_chats_fan_out_with_stable_scheduling_and_bounded_concurrency():
-    source = FakeFillingSource(
-        chats={"First": "one", "Second": "two", "Third": "three"},
-        delays={"First": 0.03, "Second": 0.01, "Third": 0},
-    )
-
-    result = asyncio.run(
-        resolve_fillings_a(
-            ["chat.First", "chat.Second", "chat.Third"],
-            allow_chat=True,
-            limits=FillingLimits(max_chat_concurrency=2),
-            source=source,
-        )
-    )
-
-    assert source.chat_started == ["First", "Second", "Third"]
-    assert source.peak_chat_calls == 2
-    assert list(result.context["chat"]) == ["First", "Second", "Third"]
-    assert result.context["chat"] == {
-        "First": "one",
-        "Second": "two",
-        "Third": "three",
-    }
-
-
-def test_text_cycles_report_only_the_reference_chain():
-    source = FakeFillingSource(
-        texts={
-            "A": "secret-a {text.B}",
-            "B": "secret-b {text.A}",
-        }
-    )
-
-    with pytest.raises(FillingCycleError) as caught:
-        asyncio.run(resolve_fillings_a(["text.A"], source=source))
+    with use_filling_stash(tmp_path):
+        with pytest.raises(FillingError) as caught:
+            asyncio.run(resolve_fillings_a(["text.A"]))
 
     assert str(caught.value) == "filling cycle: text.A -> text.B -> text.A"
     assert "secret" not in str(caught.value)
 
 
-def test_provider_failure_does_not_leak_prompt_or_response_content():
-    source = FakeFillingSource(
-        chats={"Broken": RuntimeError("provider leaked a secret response")}
-    )
+def test_fixed_depth_limit_bounds_recursive_text(tmp_path):
+    for index in range(17):
+        content = "done" if index == 16 else f"{{text.N{index + 1}}}"
+        save_text(tmp_path, f"N{index}", content)
 
-    with pytest.raises(FillingResolutionError) as caught:
-        asyncio.run(
-            resolve_fillings_a(
-                ["chat.Broken"],
-                allow_chat=True,
-                source=source,
+    with use_filling_stash(tmp_path):
+        with pytest.raises(FillingLimitError, match="depth limit"):
+            asyncio.run(resolve_fillings_a(["text.N0"]))
+
+
+def test_fixed_expansion_limit_bounds_formatter_fanout(tmp_path):
+    save_text(tmp_path, "Root", "{text.Leaf}" * 256)
+    save_text(tmp_path, "Leaf", "x")
+
+    with use_filling_stash(tmp_path):
+        with pytest.raises(FillingLimitError, match="expansion limit"):
+            asyncio.run(resolve_fillings_a(["text.Root"]))
+
+
+def test_fixed_chat_limit_stops_before_the_seventeenth_model_call(
+    tmp_path,
+    monkeypatch,
+):
+    references = []
+    calls = []
+    for index in range(17):
+        name = f"C{index}"
+        references.append(f"chat.{name}")
+        save_chat(tmp_path, name, name)
+
+    async def fake_provider(self, **variables):
+        calls.append(self.name)
+        return self.name
+
+    monkeypatch.setattr(Chat, "ask_a", fake_provider)
+
+    with use_filling_stash(tmp_path):
+        with pytest.raises(FillingLimitError, match="call limit"):
+            asyncio.run(
+                resolve_fillings_a(references, allow_chat=True)
             )
-        )
+
+    assert calls == [f"C{index}" for index in range(16)]
+
+
+def test_provider_failure_is_content_free(tmp_path, monkeypatch):
+    save_chat(tmp_path, "Broken", "private prompt")
+
+    async def fail(self, **variables):
+        raise RuntimeError("provider leaked a secret response")
+
+    monkeypatch.setattr(Chat, "ask_a", fail)
+
+    with use_filling_stash(tmp_path):
+        with pytest.raises(FillingError) as caught:
+            asyncio.run(
+                resolve_fillings_a(["chat.Broken"], allow_chat=True)
+            )
 
     assert str(caught.value) == "could not resolve chat.Broken"
     assert "secret" not in str(caught.value)
+    assert "private" not in str(caught.value)
 
 
-def test_sync_resolver_matches_async_contract():
-    result = resolve_fillings(
-        ["text.Voice"],
-        source=FakeFillingSource(texts={"Voice": "concise"}),
-    )
+def test_cancellation_propagates(tmp_path, monkeypatch):
+    save_chat(tmp_path, "Cancelled", "unused")
 
-    assert result.context == {"text": {"Voice": "concise"}}
+    async def cancel(self, **variables):
+        raise asyncio.CancelledError
 
+    monkeypatch.setattr(Chat, "ask_a", cancel)
 
-def test_sync_resolver_rejects_an_active_event_loop():
-    async def invoke_sync_resolver():
-        with pytest.raises(RuntimeError, match=r"Use resolve_fillings_a\(\)"):
-            resolve_fillings([], source=FakeFillingSource())
-
-    asyncio.run(invoke_sync_resolver())
+    with use_filling_stash(tmp_path):
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(
+                resolve_fillings_a(["chat.Cancelled"], allow_chat=True)
+            )
 
 
-@pytest.mark.parametrize(
-    ("name", "maximum"),
-    [
-        ("max_depth", 64),
-        ("max_nodes", 4096),
-        ("max_chat_calls", 256),
-        ("max_chat_concurrency", 32),
-    ],
-)
-def test_filling_limits_have_finite_inclusive_ceilings(name, maximum):
-    FillingLimits(**{name: maximum})
+def test_hyphenated_names_are_valid(tmp_path):
+    save_text(tmp_path, "snack-style", "playful")
 
-    with pytest.raises(ValueError, match=name):
-        FillingLimits(**{name: maximum + 1})
+    with use_filling_stash(tmp_path):
+        result = asyncio.run(resolve_fillings_a(["text.snack-style"]))
 
-
-def test_boolean_is_not_an_integer_filling_limit():
-    with pytest.raises(TypeError, match="max_chat_calls"):
-        FillingLimits(max_chat_calls=True)
-
-
-def test_node_limit_applies_to_the_transitive_text_graph():
-    source = FakeFillingSource(texts={"A": "{text.B}", "B": "done"})
-
-    with pytest.raises(FillingLimitError, match="node limit"):
-        resolve_fillings(
-            ["text.A"],
-            limits=FillingLimits(max_nodes=1),
-            source=source,
-        )
-
-
-def test_chat_call_limit_fails_before_any_chat_is_started():
-    source = FakeFillingSource(chats={"A": "one", "B": "two"})
-
-    with pytest.raises(FillingLimitError, match="call limit"):
-        resolve_fillings(
-            ["chat.A", "chat.B"],
-            allow_chat=True,
-            limits=FillingLimits(max_chat_calls=1),
-            source=source,
-        )
-
-    assert source.chat_started == []
-
-
-def test_missing_transitive_text_reports_its_dependency_chain():
-    source = FakeFillingSource(texts={"Outer": "{text.Missing}"})
-
-    with pytest.raises(FillingResolutionError) as caught:
-        resolve_fillings(["text.Outer"], source=source)
-
-    assert "text.Outer -> text.Missing" in str(caught.value)
-
-
-def test_missing_variable_reports_its_name_and_text_dependency_chain():
-    source = FakeFillingSource(
-        texts={"Outer": "{text.Inner}", "Inner": "{payload}"}
-    )
-
-    with pytest.raises(FillingResolutionError) as caught:
-        resolve_fillings(["text.Outer"], source=source)
-
-    assert str(caught.value) == (
-        "could not resolve variable payload (via text.Outer -> text.Inner)"
-    )
-
-
-def test_default_source_resolves_a_persisted_text_through_public_storage(tmp_path):
-    Text(name="Voice", content="clear").save(tmp_path / "Voice.txt")
-
-    result = resolve_fillings(
-        ["text.Voice"],
-        source=ChatsnackFillingSource(stash=Stash(tmp_path)),
-    )
-
-    assert result.context["text"]["Voice"] == "clear"
-
-
-def test_default_chat_source_keeps_reserved_namespaces_out_of_query_variables(
-    monkeypatch,
-):
-    captured = {}
-
-    class FakePrompt:
-        def get_messages(self):
-            return []
-
-        async def ask_a(self, **variables):
-            captured.update(variables)
-            return "popcorn"
-
-    class FakeObjects:
-        def get_or_none(self, name):
-            assert name == "SnackPicker"
-            return FakePrompt()
-
-    source = ChatsnackFillingSource()
-    monkeypatch.setattr(source, "_objects", lambda model: FakeObjects())
-
-    result = asyncio.run(
-        resolve_fillings_a(
-            ["chat.SnackPicker"],
-            variables={
-                "topic": "movie night",
-                "text": {"Voice": "playful"},
-                "chat": {"Other": "pretzels"},
-            },
-            allow_chat=True,
-            source=source,
-        )
-    )
-
-    assert result.context["chat"]["SnackPicker"] == "popcorn"
-    assert captured == {"topic": "movie night"}
+    assert result == {"text": {"snack-style": "playful"}}
 
 
 @pytest.mark.parametrize(
-    ("nested_field", "vendor"),
-    [
-        ("text.Child", "text"),
-        ("chat.Child", "chat"),
-        ("chat.123", "chat"),
-        ("chat.Child.foo", "chat"),
-        ("chat[Child]", "chat"),
-        ("text[Child]", "text"),
-    ],
+    "reference",
+    ["text../secret", "text.Snack/Secret", "text.Snack.Secret", "other.Name"],
 )
-def test_default_chat_source_rejects_nested_fillings_before_provider_io(
-    monkeypatch,
-    nested_field,
-    vendor,
-):
-    provider_calls = []
+def test_references_reject_non_static_or_traversal_shapes(reference):
+    with pytest.raises(ValueError, match="static text.Name or chat.Name"):
+        asyncio.run(resolve_fillings_a([reference]))
 
-    class FakePrompt:
-        def get_messages(self):
-            return [
-                {
-                    "role": "system",
-                    "content": f"Nested value: {{{nested_field}}}",
-                }
-            ]
 
-        async def ask_a(self, **variables):
-            provider_calls.append(variables)
-            return "should not run"
+def test_normal_chat_prompt_expansion_keeps_its_existing_path(tmp_path):
+    save_text(tmp_path, "Voice", "clear")
+    save_chat(tmp_path, "Prompt", "Use {text.Voice} instructions.")
+    chat = Chat.objects(Stash(tmp_path)).get("Prompt")
 
-    class FakeObjects:
-        def get_or_none(self, name):
-            assert name == "Parent"
-            return FakePrompt()
+    prompt = asyncio.run(chat._build_final_prompt({}))
 
-    source = ChatsnackFillingSource()
-    monkeypatch.setattr(source, "_objects", lambda model: FakeObjects())
-
-    with pytest.raises(
-        FillingResolutionError,
-        match=rf"nested {vendor} filling.*chat.Parent",
-    ):
-        resolve_fillings(
-            ["chat.Parent"],
-            allow_chat=True,
-            limits=FillingLimits(max_chat_calls=1),
-            source=source,
-        )
-
-    assert provider_calls == []
+    assert "Use clear instructions." in prompt


### PR DESCRIPTION
## Summary

- add a narrow async API for resolving a known set of `text.Name` and `chat.Name` references
- expand saved Text and Chat assets through the same formatter and filling callbacks used by `Chat.ask_a()`
- keep Catsnack-style assemblers in charge of syntax discovery, then return a plain nested mapping for one deterministic render
- document the companion workflow and prepare version 0.8.1

## Scope and safety

- ordinary Chat prompt construction remains outside resolver authority and limits
- ordinary formatting retains its existing sibling-task failure behavior; resolver formatting cancels and drains sibling work before returning an error
- explicit requested values win without loading saved assets and remain opaque
- unresolved Chat fillings, including transitive and replacement-catalog callbacks, require `allow_chat=True` before model work
- fixed resolver-only bounds cap depth at 16, filling expansions at 256, and Chat filling invocations at 16
- missing Text assets are omitted; Chat authority is checked before lookup, and authorized missing Chats are omitted without consuming the Chat-filling budget
- transitive failures report content-free reference chains and cancellation propagates unchanged

## Why this shape

The resolver formats synthetic single-reference strings instead of parsing an external document. This lets Catsnack preserve ordinary braces, JSON, Jinja, and GitHub expressions while Chatsnack remains responsible only for its existing filling semantics. The earlier parallel parser, renderer, source protocol, configurable limits, sync wrapper, and result metadata have been removed.

## Verification

- `python -m pytest -q` — 741 passed, 116 skipped
- focused resolver tests — 59 passed
- focused legacy filling/query regressions — 65 passed, 23 skipped
- `python -m mkdocs build --strict` — passed
- Catsnack Python suite against built Catsnack + Chatsnack 0.8.1 wheels — 38 passed
- Catsnack focused adapter/real integration — 10 passed
- Catsnack Rust workspace — all unit, goal, steer, conformance, property, and doc tests passed

## Release note

Chatsnack 0.8.1 is prepared by this PR and is not published here. Catsnack's hosted real-resolver gate remains pending that publication; local cross-project verification is complete.


